### PR TITLE
Add script to sign arbitrary files using the key stored in Secrets Manager

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -8,7 +8,6 @@ if [[ "${2:-}" == "" ]]; then
     exit 1
 fi
 
-
 tmpdir=$(mktemp -d)
 trap "shred $tmpdir/* && rm -rf $tmpdir" EXIT
 
@@ -16,11 +15,16 @@ SECRET=CDK/$1/SigningKey
 
 # Use secrets manager to obtain the key and passphrase into a JSON file
 echo "Retrieving key $SECRET..." >&2
-aws --region us-east-1 secretsmanager get-secret-value --secret-id "$SECRET" --output text --query SecretString > $tmpdir/secret.txt
-passphrase=$(python -c "import json; print(json.load(file('$tmpdir/secret.txt'))['Passphrase'])")
+aws secretsmanager get-secret-value --secret-id "$SECRET" --output text --query SecretString > $tmpdir/secret.txt
+
+value-from-secret() {
+    node -e "console.log(JSON.parse(require('fs').readFileSync('$tmpdir/secret.txt', { encoding: 'utf-8' })).$1)"
+}
+
+passphrase=$(value-from-secret Passphrase)
 
 echo "Importing key..." >&2
-gpg --homedir $tmpdir --import <(python -c "import json; print(json.load(file('$tmpdir/secret.txt'))['PrivateKey'])")
+gpg --homedir $tmpdir --import <(value-from-secret PrivateKey)
 
 while [[ "${2:-}" != "" ]]; do
     echo "Signing $2..." >&2


### PR DESCRIPTION
This adds a script that loads a secret PGP key from secrets manager and signs arbitrary artifacts with it, creating detached (FILE.sig) signatures.

Not integrated with the `buildspec.yaml` yet. We should do that when we're builder superzips.