### PR TITLE
Refactor the custom resource provider as proposed in #9

### DIFF
--- a/packages/aws-cdk-custom-resources/lib/provider.ts
+++ b/packages/aws-cdk-custom-resources/lib/provider.ts
@@ -1,65 +1,47 @@
-import { Stack, Token } from "aws-cdk";
+import { Construct, PolicyStatement, Token } from "aws-cdk";
 import { Lambda, LambdaProps } from 'aws-cdk-lambda';
 
 /**
  * Base class for Custom Resource providers, that details how the custom resource is created
  */
-export abstract class CustomResourceImplementation {
+export interface CustomResourceImplementation {
     /**
      * Return the provider ID for the provider in the given stack
      *
      * Returns either a Lambda ARN or an SNS topic ARN.
      */
-    public abstract providerArn(stack: Stack): Token;
+    providerArn(): Token;
 }
 
 /**
  * Properties to pass to a Lambda-backed custom resource provider
  */
 export interface LambdaBackedCustomResourceProps {
-    /**
-     * A unique identifier to identify this lambda
-     *
-     * The identifier should be unique across all custom resource providers.
-     * We recommend generating a UUID per provider.
-     */
-    uuid: string;
 
     /**
      * Properties to instantiate the Lambda
      */
-    lambdaProperties: LambdaProps;
+    lambdaProperties: LambdaPropsWithPermissions;
 }
 
+export interface LambdaPropsWithPermissions extends LambdaProps {
+    permissions?: PolicyStatement[];
+}
 /**
  * Custom Resource implementation that is backed by a Lambda function
  */
-export class LambdaBackedCustomResource extends CustomResourceImplementation {
-    constructor(private readonly props: LambdaBackedCustomResourceProps) {
-        super();
-    }
+export class LambdaBackedCustomResource implements CustomResourceImplementation {
 
-    public providerArn(stack: Stack): Token {
-        const providerLambda = this.ensureLambda(stack);
-        return providerLambda.functionArn;
-    }
+    private readonly lambda: Lambda;
 
-    /**
-     * Add a fresh Lambda to the stack, or return the existing one if it already exists
-     */
-    private ensureLambda(stack: Stack): Lambda {
-        const name = slugify(this.props.uuid);
-        const existing = stack.tryFindChild(name);
-        if (existing) {
-            // Just assume this is true
-            return existing as Lambda;
+    constructor(parent: Construct, name: string, private readonly props: LambdaBackedCustomResourceProps) {
+        this.lambda = new Lambda(parent, name, this.props.lambdaProperties);
+        if (this.props.lambdaProperties.permissions && this.props.lambdaProperties.permissions.length > 0) {
+            this.props.lambdaProperties.permissions.forEach(permission => this.lambda.addToRolePolicy(permission));
         }
-
-        const newFunction = new Lambda(stack, name, this.props.lambdaProperties);
-        return newFunction;
     }
-}
 
-function slugify(x: string): string {
-    return x.replace(/[^a-zA-Z0-9]/g, '');
+    public providerArn(): Token {
+        return this.lambda.functionArn;
+    }
 }

--- a/packages/aws-cdk-custom-resources/package.json
+++ b/packages/aws-cdk-custom-resources/package.json
@@ -42,6 +42,7 @@
     "aws-cdk": "^0.6.0",
     "aws-cdk-iam": "^0.6.0",
     "aws-cdk-lambda": "^0.6.0",
-    "aws-cdk-resources": "^0.6.0"
+    "aws-cdk-resources": "^0.6.0",
+    "@types/uuid": "^3.2.1"
   }
 }

--- a/packages/aws-cdk-custom-resources/test/test.resource.ts
+++ b/packages/aws-cdk-custom-resources/test/test.resource.ts
@@ -7,13 +7,15 @@ import { CustomResource, LambdaBackedCustomResource } from '../lib';
 // tslint:disable:object-literal-key-quotes
 
 export = {
-    'custom resource is added twice, lambda is added once'(test: Test) {
+    'custom resource is instantiated twice, lambda is added once'(test: Test) {
         // GIVEN
         const stack = new Stack();
 
         // WHEN
-        new TestCustomResource(stack, 'Custom1');
-        new TestCustomResource(stack, 'Custom2');
+        const resourceProvider = new TestCustomResource(stack, 'Why');
+
+        resourceProvider.resourceInstance("Custom1");
+        resourceProvider.resourceInstance("Custom2");
 
         // THEN
         expect(stack).toMatch({
@@ -89,8 +91,7 @@ export = {
 class TestCustomResource extends CustomResource {
     constructor(parent: Construct, name: string) {
         super(parent, name, {
-            provider: new LambdaBackedCustomResource({
-                uuid: 'TestCustomResourceProvider',
+            provider: new LambdaBackedCustomResource(parent, 'TestCustomResourceProvider', {
                 lambdaProperties: {
                     code: new LambdaInlineCode('def hello(): pass'),
                     runtime: LambdaRuntime.Python27,


### PR DESCRIPTION
This change makes it such that each custom resource is split into 2 parts

The "resource provider" and instances of the custom resource, that refer to a given provider.

This also for the Lambda backed provider adds the ability to add custom permissions :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
