### PR TITLE
Pass -y to `zip` so symlinks are correctly represented in the zip file.

### DIFF
--- a/bundle-beta.sh
+++ b/bundle-beta.sh
@@ -45,6 +45,5 @@ dist=${root}/dist
 output=${dist}/aws-cdk-${version}.zip
 rm -fr ${dist}
 mkdir -p ${dist}
-zip -r ${output} .
+zip -y -r ${output} .
 echo ${output}
-


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
