### PR TITLE
Add `cdk docs` command to open (local) docsite

### DIFF
--- a/packages/aws-cdk-docs/.gitignore
+++ b/packages/aws-cdk-docs/.gitignore
@@ -1,2 +1,4 @@
+*.js
+*.d.ts
 dist
 python-deps

--- a/packages/aws-cdk-docs/lib/index.ts
+++ b/packages/aws-cdk-docs/lib/index.ts
@@ -1,0 +1,3 @@
+import * as path from 'path';
+
+export const documentationIndexPath = path.join(path.dirname(__dirname), 'dist', 'docs', 'index.html');

--- a/packages/aws-cdk-docs/package.json
+++ b/packages/aws-cdk-docs/package.json
@@ -4,7 +4,6 @@
   "description": "AWS CDK Documentation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git://github.com/awslabs/aws-cdk"
@@ -13,7 +12,9 @@
     "ignore": true
   },
   "scripts": {
-    "prepare": "/bin/bash ./build-docs.sh"
+    "prepare": "tslint -p . && tsc && /bin/bash ./build-docs.sh",
+    "watch": "tsc -w",
+    "lint": "tsc && tslint -p . --force"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/aws-cdk-docs/tsconfig.json
+++ b/packages/aws-cdk-docs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target":"ES2018",
+        "module": "commonjs",
+        "lib": ["es2016", "es2017.object", "es2017.string"],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization":false
+    }
+}
+

--- a/packages/aws-cdk-toolkit/package.json
+++ b/packages/aws-cdk-toolkit/package.json
@@ -31,6 +31,7 @@
     "aws-cdk": "^0.6.0",
     "aws-cdk-cloudformation-diff": "^0.6.0",
     "aws-cdk-cx-api": "^0.6.0",
+    "aws-cdk-docs": "^0.6.0",
     "aws-cdk-resources": "^0.6.0",
     "aws-cdk-util": "^0.6.0",
     "aws-sdk": "^2.135.0",


### PR DESCRIPTION
Opens the docsite in a browser of your choice (by default uses `open`,
but can be configured using `--browser` or by specifying the `browser`
key in your `cdk.json` files.

Closes #22 