### PR TITLE
Correct dependency cycle

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ export PATH=node_modules/.bin:$PATH
 
 echo "============================================================================================="
 echo "boostrapping..."
-lerna bootstrap --loglevel=debug
+lerna bootstrap --reject-cycles --loglevel=debug
 
 echo "============================================================================================="
 echo "testing..."

--- a/bundle-beta.sh
+++ b/bundle-beta.sh
@@ -30,14 +30,14 @@ rsync -aL ${root}/local-npm/*.tgz repo/npm # jsii modules
 mkdir -p repo/maven
 cp ${root}/packages/aws-cdk-java/target/*.jar repo/maven
 
-# Deploy the docs website to docs/
-rsync -a ${root}/packages/aws-cdk-docs/dist/docs/ ./docs
-
 # Bootstrap a production-ready node_modules closure with all npm modules (jsii and CDK)
 npm install --global-style --production --no-save repo/npm/*.tgz
 
 # Symlink 'bin' to the root
 ln -s node_modules/.bin bin
+
+# Symlink the docs website to docs
+ln -s node_modules/aws-cdk-docs/dist/docs docs
 
 # Create an archive under ./dist
 version="$(cat ${root}/lerna.json | grep version | cut -d '"' -f4)"

--- a/packages/aws-cdk-toolkit/package.json
+++ b/packages/aws-cdk-toolkit/package.json
@@ -31,7 +31,6 @@
     "aws-cdk": "^0.6.0",
     "aws-cdk-cloudformation-diff": "^0.6.0",
     "aws-cdk-cx-api": "^0.6.0",
-    "aws-cdk-docs": "^0.6.0",
     "aws-cdk-resources": "^0.6.0",
     "aws-cdk-util": "^0.6.0",
     "aws-sdk": "^2.135.0",


### PR DESCRIPTION
Applies the short-term strategy described in #31 by taking an un-modelled dependency on aws-cdk-docs and displaying an error message with instructions to install aws-cdk-docs if it cannot be resolved when cdk docs is invoked.