### PR TITLE
Fix conditional post-build actions

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -12,9 +12,8 @@ phases:
       - /bin/bash ./build.sh
   post_build:
     commands:
-      - if [[ ! -f ".BUILD_COMPLETED" ]]; then exit 1; fi
-      - /bin/bash ./pack.sh
-      - /bin/bash ./bundle-beta.sh
+      - "[ -f .BUILD_COMPLETED ] && /bin/bash ./pack.sh"
+      - "[ -f .BUILD_COMPLETED ] && /bin/bash ./bundle-beta.sh"
 artifacts:
   files:
     - "**/*"


### PR DESCRIPTION
A few things didn't work:

1. Each action needs to be conditional, since codebuild will continue
   even if the first action failed.

2. This error happened:

    /codebuild/output/tmp/script.sh: [[: not found

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
