### PR TITLE
Remove unnecessary artifact type from sign script call site

### DIFF
--- a/bundle-beta.sh
+++ b/bundle-beta.sh
@@ -49,5 +49,5 @@ zip -y -r ${output} .
 echo ${output}
 
 # Sign the bundle
-/bin/bash $root/sign.sh Archive $output
+/bin/bash $root/sign.sh $output
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
