### PR TITLE
Make the 'version' field of serverless S3Location optional

### DIFF
--- a/packages/aws-cdk-resources/cloudformation-specs/000_sam.spec.json
+++ b/packages/aws-cdk-resources/cloudformation-specs/000_sam.spec.json
@@ -194,7 +194,7 @@
                 },
                 "Version": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
-                    "Required": true,
+                    "Required": false,
                     "PrimitiveType": "Integer",
                     "UpdateType": "Immutable"
                 }

--- a/packages/aws-cdk-resources/test/test.specifics.ts
+++ b/packages/aws-cdk-resources/test/test.specifics.ts
@@ -1,0 +1,22 @@
+// Tests some properties of the generated code
+import { Stack } from 'aws-cdk';
+import { Test } from 'nodeunit';
+import { serverless } from '../lib';
+
+export = {
+    'codeuri version field should be optional'(test: Test) {
+        const stack = new Stack();
+        new serverless.FunctionResource(stack, 'Fucntion', {
+            codeUri: {
+                bucket: 'a',
+                key: 'b'
+                // 'version' shouldn't have to go here
+                // https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3-location-object
+            },
+            handler: 'index',
+            runtime: 'asdf'
+        });
+
+        test.done();
+    }
+};


### PR DESCRIPTION
The hand-written docs disagree with our copy of the model.

This fixes #66.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
