### PR TITLE
fix(aws-cdk-toolkit): ignore template ts files

### DIFF
--- a/packages/aws-cdk-toolkit/.npmignore
+++ b/packages/aws-cdk-toolkit/.npmignore
@@ -1,5 +1,6 @@
 # Don't include original .ts files when doing `npm pack`
 *.ts
+!*.template.ts
 !*.d.ts
 coverage
 .nyc_output


### PR DESCRIPTION
The .npmignore was ignoring the bin/template.ts file used
by the cdk init script. As such, it meant that cdk init
did not work on a packaged CDK.

Fixes #72

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
