### PR TITLE
Prepare documentation for Private Beta

### DIFF
--- a/packages/aws-cdk-docs/src/_includes.txt
+++ b/packages/aws-cdk-docs/src/_includes.txt
@@ -37,3 +37,13 @@
 .. |npm-package| replace:: aws-cdk-tools
 .. |nuget-package| replace:: aws-cdk
 .. |maven-id| replace:: aws-cdk
+
+.. Construct levels
+
+.. |l1| replace:: CloudFormation Resource
+.. |l2| replace:: AWS Construct Library
+.. |l3| replace:: Purpose-built Library
+
+.. So back-to-back entities have a space between them
+
+.. |space| unicode:: 0x20

--- a/packages/aws-cdk-docs/src/cloudformation.rst
+++ b/packages/aws-cdk-docs/src/cloudformation.rst
@@ -8,26 +8,36 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
-.. _cloudformation:
+.. _advanced_topics:
 
-###################
-Using CloudFormation Resource Constructs
-###################
+###############
+Advanced Topics
+###############
 
-CloudFormation Resource constructs are found in the :py:mod:`_aws-cdk_resources` package. They map directly onto |cfn|
+This section includes information about |cdk| features that most developers do not use.
+
+.. _creating_l1_constructs:
+
+Creating |l1| Constructs
+========================
+
+|l1| constructs are found in the :py:mod:`aws-cdk-resources` package. They map directly onto |cfn|
 resources.
 
 .. important::
 
   In general, you shouldn't need to use this type of Constructs, unless you have
   special requirements or there is no Construct Library for the AWS resource you
-  need yet. Prefer using other packages with higher-level constructs instead. See
+  need yet. You should use other packages with higher-level constructs instead. See
   :ref:`l1_vs_l2` for a comparison between the construct types.
+
+The remainder of this section is for those who need to create a stack using a |l1| construct,
+or want to create a |l2| construct from |l1| constructs.
 
 .. _construct_attributes:
 
 Construct Attributes
-====================
+--------------------
 
 To reference the runtime attributes of constructs,
 use one of the properties available on the construct object.
@@ -56,7 +66,7 @@ named attribute instead of *ref*.
 .. _resource_options:
 
 Resource Options
-================
+----------------
 
 The :py:attr:`aws-cdk.Resource.options` object includes |CFN| options, such as
 :code:`condition`, :code:`updatePolicy`, :code:`createPolicy` and
@@ -65,7 +75,7 @@ The :py:attr:`aws-cdk.Resource.options` object includes |CFN| options, such as
 .. _parameters:
 
 Parameters
-==========
+----------
 
 .. NEEDS SOME INTRO TEXT
 
@@ -79,7 +89,7 @@ Parameters
 .. _outputs:
 
 Outputs
-=======
+-------
 
 .. NEEDS SOME INTRO TEXT
 
@@ -96,7 +106,7 @@ Outputs
 .. _conditions:
 
 Conditions
-==========
+----------
 
 .. NEEDS SOME INTRO TEXT
 
@@ -113,7 +123,7 @@ Conditions
 .. _intrinsic_functions:
 
 Intrinsic Functions
-===================
+-------------------
 
 .. NEEDS SOME INTRO TEXT
 
@@ -125,7 +135,7 @@ Intrinsic Functions
 .. _pseudo_parameters:
 
 Pseudo Parameters
-=================
+-----------------
 
 .. NEEDS SOME INTRO TEXT
 
@@ -133,3 +143,7 @@ Pseudo Parameters
 
     import { AwsRegion } from '@aws-cdk/core';
     new AwsRegion()
+
+.. Add a new topic in "Advanced Topics" about integrating
+   cdk synch > mytemplate
+   into a CI/CD pipeline

--- a/packages/aws-cdk-docs/src/conf.py
+++ b/packages/aws-cdk-docs/src/conf.py
@@ -32,7 +32,7 @@ import os, codecs
 service_name_long = u'AWS Cloud Development Kit'
 service_docs_home = u'http://aws.amazon.com/documentation/CDK/'
 
-project = u'AWS Cloud Development Kit User Guide'
+project = u'User Guide'
 project_desc = u'AWS Cloud Development Kit User Guide'
 project_basename = u'CDK/ug'
 
@@ -48,6 +48,11 @@ forum_id = u'0'
 docset_path_slug = u'CDK'
 version_path_slug = u'latest'
 guide_path_slug = u'ug'
+
+# Add beta banner
+guide_banner = """
+This documentation is for the beta release of the AWS Cloud Development Kit (CDK).
+"""
 
 build_html = True
 build_pdf = True

--- a/packages/aws-cdk-docs/src/creating-constructs.rst
+++ b/packages/aws-cdk-docs/src/creating-constructs.rst
@@ -26,7 +26,7 @@ combine into other constructs and an application stack to create an |cdk|
 application.
 
 The lowest-level |cdk| construct is a Resource Construct, which represents a
-single AWS service resource, such as an SNS topic or an SQS queue.
+single AWS service resource, such as an |SNS| topic or an |SQS| queue.
 
 The next level of constructs, which we call a Construct Library Construct,
 typicall wraps one or more Resource Constructs and adds higher-level
@@ -73,7 +73,7 @@ To create a new Construct Library construct as a pull request to the |cdk|:
    git checkout my-branch
 
 * Create a new folder, *aws-cdk-RESOURCE*, in *packages/*,
-  where *RESOURCE* is the name of a |cfn| resource.
+  where *RESOURCE* is the name of a |CFN| resource.
 
 * Code goes in *lib/*; tests in *test/*.
 

--- a/packages/aws-cdk-docs/src/examples.rst
+++ b/packages/aws-cdk-docs/src/examples.rst
@@ -10,9 +10,9 @@
 
 .. _cdk_examples:
 
-########
-Examples
-########
+##############
+|cdk| Examples
+##############
 
 This topic contains some usage examples to help you get started understanding
 the |cdk|.
@@ -113,11 +113,11 @@ the |cdk|.
 
 .. _dynamodb_example:
 
-Creating a |ddb| Table
-===========================
+Creating a |DDB| Table
+======================
 
 The following example creates a
-|dynamodb| table with the partition key **Alias**
+|DDB| table with the partition key **Alias**
 and sort key **Timestamp**.
 
 .. code-block:: js
@@ -148,7 +148,7 @@ and sort key **Timestamp**.
 
 .. _creating_rds_example:
 
-Creating an |rds| Database
+Creating an |RDS| Database
 ==========================
 
 The following example creates the Aurora database **MyAuroraDatabase**.
@@ -191,11 +191,11 @@ The following example creates the Aurora database **MyAuroraDatabase**.
 
 .. _creating_s3_example:
 
-Creating an |s3| Bucket
+Creating an |S3| Bucket
 =======================
 
-The following example creates the |s3| bucket **MyS3Bucket** with server-side KMS
-encryption provided by |s3|.
+The following example creates the |S3| bucket **MyS3Bucket** with server-side KMS
+encryption provided by |S3|.
 
 .. code-block:: js
 
@@ -246,7 +246,7 @@ Creating a CloudFormation Template
 ==================================
 
 Use the |cx-synth-bold| command to create an |CFN| template from the stack in your app.
-You should see output similar to the following for your |dynamodb| table.
+You should see output similar to the following for your |DDB| table.
 
 .. code-block:: yaml
 

--- a/packages/aws-cdk-docs/src/getting-started.rst
+++ b/packages/aws-cdk-docs/src/getting-started.rst
@@ -12,146 +12,31 @@
 
 .. _getting_started:
 
-###############
-Getting Started
-###############
+##############################
+Getting Started With the |cdk|
+##############################
 
-This topic provides information for those getting started with the |cdk-long| (|cdk|),
-including information about how to install and set up the |cdk|.
+This topic provides information for those getting started with the |cdk-long| (|cdk|).
 
-.. _requirements:
-
-Requirements
-============
-
-To run the |cdk|, you must have the following software installed on your system:
-
-* `Node.js <https://nodejs.org/en/download/>`_ version 8.x or later
-
-.. _installation:
-
-Installing the |CDK|
-====================
-
-These instructions describe how to install the following |cdk| components on your system:
-
-* The |cdk| shared libraries
-* The |cdk| Toolkit - the ``cdk`` command-line interface
-
-By default these are installed in:
-
-* ~/.cdk on Linux or MacOS
-* %USERPROFILE% on Windows
-
-The various installers also add the *bin* directory within the installation directory to your
-**PATH** environment variable.
-
-.. _javascript_installation:
-
-Installing the AWS CDK for JavaScript/TypeScript Development
-------------------------------------------------------------
-
-To install the |cdk| for TypeScript/JavaScript development,
-use the following command.
-
-.. code-block:: sh
-
-   npm install -g aws-cdk-tools
-
-To update the |cdk| after you have installed it,
-use the following command.
-
-.. code-block:: sh
-
-   npm update -g aws-cdk-tools
-
-.. _java_installation:
-
-Installing the AWS CDK for Java Development
--------------------------------------------
-
-To use the public beta release of the |cdk| for Java development,
-declare the following in your *pom.xml* file.
-
-.. code-block:: xml
-
-   <dependencies>
-    <dependency>
-      <groupId>aws-cdk</groupId>
-      <artifactId>aws-cdk</artifactId>
-      <version>0.6</version>
-    </dependency>
-   </dependencies>
-
-.. _dotnet_installation:
-
-Installing the AWS CDK for .NET Development
--------------------------------------------
-
-To install the |cdk| for .NET development,
-use the following command.
-
-.. code-block:: sh
-
-   nuget install aws-cdk
-
-To update the |cdk| after you have installed it,
-use the following command.
-
-.. code-block:: sh
-
-   nuget update aws-cdk
-
-.. _verifying_installation:
-
-Verifying your CDK Installation
-===============================
-
-To verify the |cdk| is installed on your system, open a terminal/PowerShell console and run:
-
-.. code-block:: sh
-
-   cdk --version
-
-This displays the current version of the |cdk|, which is |cdk-version|.
-
-.. _credentials_and_region:
-
-AWS Credentials and Region
-==========================
-
-Use the `AWS Command Line Interface <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html>`_
-``aws configure`` command to specify your default credentials and region.
-
-You can also set environment variables for your default credentials and region.
-Environment variables take precedence over settings in the credentials or config file.
-
-* *AWS_ACCESS_KEY_ID* specifies your access key
-* *AWS_SECRET_ACCESS_KEY* specifies your secret access key
-* *AWS_DEFAULT_REGION* specifies your default region
-
-See the `Environment Variables <https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html>`_
-topic in the CLI User Guide for details.
-
-.. _hello-stack:
+.. _hello_cdk:
 
 Hello, CDK!
 ===========
 
-Enough about installing, let's see some code!
-
-Let's use the |cdk| to create an |CFN| template that
-creates an |SQS| queue, |SNS| topic, a subscription between the topic and the queue,
+Let's use the |cdk| to create an |CFN| an |SQS| queue, an |SNS| topic, a subscription between the topic and the queue,
 and an |IAM| policy document that enables the
 topic to send messages to the queue.
+
+.. _hello_cdk_typescript
 
 .. _create_dirs:
 
 Create Your Project Structure
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use **cdk init** to create a skeleton for your CDK project.
-Currently only TypeScript is supported.
+Use **cdk init --lang** *LANGUAGE* to create a skeleton for your |cdk| project
+in one of the supported programming languages.
+For the examples in this section we'll use TypeScript.
 
 .. code-block:: sh
 
@@ -159,52 +44,11 @@ Currently only TypeScript is supported.
    cd hello-cdk
    cdk init --language=typescript
 
-**cdk init** creates a skeleton |cdk| program for you to work with
+The **cdk init** command creates a skeleton |cdk| program for you to work with
 and displays some useful commands to help you get started.
 
 Replace the contents of the file *index.ts* with the following code to create a class that
 extends **Stack**, and include some construction logic.
-
-.. code-block:: js
-
-    import { App, Stack, StackProps } from "@aws-cdk/core";
-    import { Topic } from '@aws-cdk/sns';
-    import { Queue } from '@aws-cdk/sqs';
-
-    class HelloStack extends Stack {
-        constructor(parent: App, name: string, props?: StackProps) {
-            super(parent, name, props);
-
-            const topic = new Topic(this, 'MyTopic');
-            const queue = new Queue(this, 'MyQueue');
-
-            topic.subscribeQueue('TopicToQueue', queue);
-        }
-    }
-
-    const app = new App(process.argv);
-    new HelloStack(app, 'hello-cdk');
-    process.stdout.write(app.run());
-
-.. _compile:
-
-Compiling the App
------------------
-
-Use the following command to compile the TypeScript app *index.ts* into the JavaScript code *index.js*.
-You must compile your app from TypeScript to JavaScript every time you change it.
-
-.. code-block:: sh
-
-   npm run prepare
-
-You can have **npm** watch for source changes and automatically re-compile
-those changes using the **watch** option.
-Do not run the command in the background (Linux or MacOS).
-
-.. code-block:: sh
-
-   npm run watch
 
 .. note:: You can use an IDE, such as
    `Microsoft Visual Code <https://code.visualstudio.com/>`_,
@@ -214,12 +58,74 @@ Do not run the command in the background (Linux or MacOS).
    `Atom TypeScript <https://atom.io/packages/atom-typescript>`_ plugin,
    to get auto-completion in your Typescript code.
 
+.. code-block:: js
+
+    // You'll need this statement in every app
+    import { App, Stack, StackProps } from '@aws-cdk/core';
+
+    // The SNS resources, such as Topic, are defined in aws-cdk-sns
+    import { Topic } from '@aws-cdk/sns';
+
+    // The SQS resources, such as Queue, are defined in aws-cdk-sqs
+    import { Queue } from '@aws-cdk/sqs';
+
+    class HelloStack extends Stack {
+        // Instantiate HelloStack with a reference to its parent,
+	// as it might need some context;
+	// a name; and some optional properties.
+	// You'll almost always use these same two lines.
+        constructor(parent: App, name: string, props?: StackProps) {
+            super(parent, name, props);
+
+	    // Create an SNS topic
+            const topic = new Topic(this, 'MyTopic');
+
+	    // Create an SQS queue
+	    const queue = new Queue(this, 'MyQueue', {
+	      // By default you only get 30 seconds to delete a read message after you've read it;
+	      // otherwise it becomes available to other consumers.
+	      // This extends that duration to 5 minutes.
+              visibilityTimeoutSec: 300
+            });
+
+	    // Subscribe the topic to the queue
+            topic.subscribeQueue('TopicToQueue', queue);
+        }
+    }
+
+    // Create a new App and associate the HelloStack stack with it.
+    const app = new App(process.argv);
+    new HelloStack(app, 'hello-cdk');
+
+    // Boilerplate to produce the CloudFormation template
+    process.stdout.write(app.run());
+
+.. _compile:
+
+Compiling the App
+-----------------
+
+Use one of the commands in the following table to compile your app.
+You must compile your app every time you change it.
+
+.. list-table::
+  :widths: 1 2
+  :header-rows: 1
+
+  * - Language
+    - Compilation Command
+
+  * - TypeScript
+    - `npm run prepare`
+      (use `npm run watch` in a separate command window to watch for source changes and automatically recompile)
+
 .. _create_cloud_formation:
 
 Synthesizing a CloudFormation Template
 --------------------------------------
 
-Use the **cdk synth** command to synthesize a CloudFormation template for a stack in your app.
+Use the **cdk synth** command to synthesize a |CFN| template for a stack in your app.
+You do not need to synthesize your |CFN| template to deploy it.
 
 .. code-block:: console
 
@@ -244,6 +150,8 @@ You should see output similar to the following:
                     Ref: MyTopic86869434
         MyQueueE6CA6235:
             Type: 'AWS::SQS::Queue'
+	    Properties:
+                VisibilityTimeout: 300
         MyQueuePolicy6BBEDDAC:
             Type: 'AWS::SQS::QueuePolicy'
             Properties:
@@ -276,19 +184,34 @@ the :py:class:`_aws-cdk_sns.Topic` resulted in:
 
 .. _deploy_your_stack:
 
-Deploying your Stack
+Deploying Your Stack
 ---------------------
 
-Use **cdk deploy** to deploy the stack. As *cdk deploy* executes you
+Use **cdk deploy** to deploy the stack. As **cdk deploy** executes you
 should see information messages, such as feedback from CloudFormation logs.
 
 .. code-block:: sh
 
    cdk deploy
 
+.. note:: You must specify your default credentials and region to use the **cdk deploy** command.
+
+   Use the `AWS Command Line Interface <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html>`_
+   ``aws configure`` command to specify your default credentials and region.
+
+   You can also set environment variables for your default credentials and region.
+   Environment variables take precedence over settings in the credentials or config file.
+
+   * *AWS_ACCESS_KEY_ID* specifies your access key
+   * *AWS_SECRET_ACCESS_KEY* specifies your secret access key
+   * *AWS_DEFAULT_REGION* specifies your default region
+
+   See `Environment Variables <https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html>`_
+   in the CLI User Guide for details.
+
 .. _making_changes:
 
-Making changes
+Making Changes
 --------------
 
 Let's change the visibility timeout of the queue from 300 to 500.
@@ -299,7 +222,8 @@ Let's change the visibility timeout of the queue from 300 to 500.
         visibilityTimeoutSec: 500
     });
 
-Run the following command to see the difference between the *deployed* stack and your CDK project:
+Run the following command to see the difference between the *deployed* stack and your |cdk| project
+(if you haven't deployed the stack, you won't see any output):
 
 .. code-block:: sh
 

--- a/packages/aws-cdk-docs/src/glossary.rst
+++ b/packages/aws-cdk-docs/src/glossary.rst
@@ -1,0 +1,64 @@
+.. Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+   International License (the "License"). You may not use this file except in compliance with the
+   License. A copy of the License is located at http://creativecommons.org/licenses/by-nc-sa/4.0/.
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+   either express or implied. See the License for the specific language governing permissions and
+   limitations under the License.
+
+.. _glossary:
+
+##############
+|cdk| Glossary
+##############
+
+The |cdk| uses the following terms.
+Some are based on AWS CloudFormation `concepts <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-concepts.html>`_.
+
+app
+   An executable program that the |cdk| uses to synthesize artifacts
+   that can contain multiple stacks and be deployed into multiple AWS environments.
+   Apps extend the :py:class:`aws-cdk.App` class.
+
+applet
+   A reusable |cdk| construct that can be instantiated and deployed through a
+   YAML-format file.
+
+|cdk-long| (|cdk|)
+   An AWS toolkit that enables infrastructure as code (IaC), exposing AWS
+   resources and high-level constructs for use in popular DevOps programming
+   languages.
+
+construct
+   The building block of an |cdk| app or library. In code, they are instances of
+   the :py:class:`aws-cdk.Construct` class or a class that extends the
+   :py:class:`aws-cdk.Construct` class.
+
+environment
+   An AWS deployment target for |cdk| stacks, defined by a specific AWS account and region.
+
+|l1|
+   The lowest-level construct, which maps directly to an |CFN| resource,
+   as described in the
+   `AWS Resource Types Reference <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html>`_.
+   These constructs are available in the :py:mod:`aws-cdk-resources` package
+   as the |CFN| name with a **Resource** suffix within the AWS service namespace,
+   such as **sqs.QueueResource**, which represents an |SQS| queue.
+
+|l2|
+   A construct that provides high-level APIs for AWS services.
+   Their names imply the underlying AWS service.
+   For example, |S3| resources are available through the **aws-cdk-s3**
+   Construct Library.
+
+|l3|
+   A construct that abstracts common architectural
+   patterns on AWS. These are not supplied with the standard |cdk| distribution,
+   but are shared within your organization or on GitHub.
+
+stack
+   An |cdk| construct that can be deployed into an environment.
+   Stacks extend the :py:class:`aws-cdk.Stack` class.
+

--- a/packages/aws-cdk-docs/src/guidelines.rst
+++ b/packages/aws-cdk-docs/src/guidelines.rst
@@ -10,12 +10,74 @@
 
 .. _guidelines:
 
-##########
-Guidelines
-##########
+##########################
+Developing |cdk| Libraries
+##########################
 
-This topic describes helpful tips for using the |cdk|. These apply when you are
-writing Constructs.
+This topic provides information to help you develop a |l2| for the |cdk|.
+
+.. _creating_l2_constructs:
+
+Creating Construct Library constructs
+=====================================
+
+To submit a new |l2| to the CDK, the process
+starts with a pull request to the |cdk|:
+
+* Fork the |cdk| project to your own GitHub account.
+* Clone the repository to your computer:
+
+.. code-block:: sh
+
+   mkdir ~/cdk
+   cd ~/cdk
+   git clone ...
+
+* Create a new branch to hold your code
+
+.. code-block:: sh
+
+   git checkout my-branch
+
+* Create a new folder, *aws-cdk-RESOURCE*, in *packages/*,
+  where *RESOURCE* is the name of a |CFN| resource.
+
+* Code goes in *lib/*; tests in *test/*.
+
+* Create an *index.ts* file that only imports the other *NAME.ts* files,
+  where *NAME* indicates the functionality within the file.
+
+* Create *NAME.ts* for each set of related classes,
+  such as the construct itself and its props interface.
+
+In *NAME.ts*:
+
+* Create a class.
+
+* Create the related props interface.
+
+* Instantiate the resource.
+
+* Add enhancements as methods.
+
+* Set props to reasonable default values
+  (think clicking through the console and accepting those defaults).
+
+* Don't forget to implement **validate()**.
+
+Finally for the package:
+
+* Add a test, *test.NAME.ts*, for each construct.
+
+* Create an integration test, *integ.everything.ts*.
+
+* Commit your changes and push them back to GitHub.
+
+* Once everything looks good, navigate to the |cdk| project on the GitHub
+  website, select your branch, and next to the **Branch** menu select **New pull
+  request**.
+
+See the **aws-cdk-dynamodb** package for examples.
 
 .. _general_guidelines:
 
@@ -28,7 +90,7 @@ Although not a guideline,
 don't forget that if you change the name of a deployed construct,
 but do not rename the construct as described in the
 *Changing Logical IDs* section of the :ref:`concepts` topic,
-|cfn| deletes the old construct, including any resources created by the construct,
+|CFN| deletes the old construct, including any resources created by the construct,
 when you deploy the new construct.
 
 **Use TypeScript unless you are a single-language shop.**

--- a/packages/aws-cdk-docs/src/index.rst
+++ b/packages/aws-cdk-docs/src/index.rst
@@ -10,22 +10,25 @@
 
 .. _top:
 
-####################################
-AWS Cloud Development Kit User Guide
-####################################
+##########
+User Guide
+##########
 
 .. toctree::
-   welcome
-   getting-started
-   concepts
-   l1-vs-l2
-   cloudformation
-   writing-cdk-apps
-   creating-constructs
-   examples
-   tools
-   guidelines
-   reference
+   Welcome <welcome>
+   Getting Started <getting-started>
+   Developing Apps <writing-cdk-apps>
+   Developing Libraries <guidelines>
+   Examples <examples>
+   Concepts <concepts>
+   Tools <tools>
+   Advanced Topics <cloudformation>
+   Glossary <glossary>
+   Reference <reference>
+
+.. Incorporated into concepts: l1-vs-l2
+.. Incorporated into guidelines: creating-constructs
+.. Skipping: validating-downloads as that info should go in the "Start Here" doc
 
 .. installing on various systems:
    C++: NuGet

--- a/packages/aws-cdk-docs/src/l1-vs-l2.rst
+++ b/packages/aws-cdk-docs/src/l1-vs-l2.rst
@@ -8,23 +8,23 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
-.. _l1_vs_l2:
+.. _the_cdk_construct_library:
 
-#####################
-The Construct Library
-#####################
+###########################
+The |cdk| Construct Library
+###########################
 
-The |cdk| standard library comes with two different types of Constructs:
+The |cdk| standard library comes with two different levels of constructs:
 
-AWS CloudFormation Resource Constructs
+|l1| Constructs
 
-  CloudFormation Resource constructs are low-level constructs that provide a direct, one-to-one,
-  mapping to an |cfn| resource,
-  as listed in the |cfn| topic `AWS Resource Types Reference <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html>`_.
+  These constructs are low-level constructs that provide a direct, one-to-one,
+  mapping to an |CFN| resource,
+  as listed in the |CFN| topic `AWS Resource Types Reference <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html>`_.
 
-  All Resource constructs are found in the :py:mod:`_aws-cdk_resources` package.
+  All |l1| constructs are found in the :py:mod:`_aws-cdk_resources` package.
 
-AWS Construct Library Constructs
+|l2| Constructs
 
   These constructs have been handwritten by AWS engineers and come with
   convenient defaults and additional knowledge about the inner workings of the
@@ -32,30 +32,32 @@ AWS Construct Library Constructs
   intent without worrying about the details too much, and the correct resources
   will automatically be defined for you.
 
-  Construt Library constructs are those that are found in all of the other
-  **aws-cdk-** packages. See the :ref:`reference` section for a list of all
-  available Construct Library packages and constructs.
+  |l2| constructs are found in the :py:mod:`aws-cdk-RESOURCE` package,
+  where RESOURCE is the short name for the associated service,
+  such as SQS for the |l2| constructs for the |SQS| service.
+  See the :ref:`reference` section for descriptions of the |cdk|
+  packages and constructs.
 
-Prefer using Construct Library constructs whenever possible, as they will provide the
+Use |l2| constructs whenever possible, as they provide the
 best developer experience.
 
-Sometimes there are use cases where you need to directly define |cfn| resources,
+Sometimes there are use cases where you need to directly define |CFN| resources,
 such as when migrating from an existing template, or when there is no Construct
-Library for the AWS resources you need yet. In those case you can use Resource
-constructs to define CloudFormation entities such as Resources, Parameters, Outputs, and
+Library for the AWS resources you need yet. In those case you can use |l1|
+constructs to define |CFN| entities such as Resources, Parameters, Outputs, and
 Conditions.
 
-Of course, it's always possible to define your own higher-level constructs in
-addition to the ones already provided, simply by defining a new class that
-describes your construct. For more information, see :doc:`creating-constructs`.
+You can define your own higher-level constructs in
+addition to the ones already provided, by creating a new class that
+pdescribes your construct.
 
 .. _aws_constructs_versus_cfn_resources:
 
-Construct Library constructs vs CloudFormation Resource constructs
-==================================================================
+|l2| Constructs vs |l1| Constructs
+==================================
 
-To illustrate the advantages that Construct Library constructs have over
-CloudFormation Resource constructs, let's look at an example.
+To illustrate the advantages that |l2| constructs have over
+|l1| constructs, let's look at an example.
 
 The :py:mod:`_aws-cdk_sns` Construct Library includes the `Topic` construct that
 you can use to define an |SNS| topic:
@@ -65,7 +67,7 @@ you can use to define an |SNS| topic:
     import { Topic } from '@aws-cdk/sns';
     const topic = new Topic(this, 'MyTopic');
 
-Library constructs encapsulate the
+|l2| constructs encapsulate the
 details of working with these AWS resources. For example, to subscribe a queue to a topic,
 call the :py:meth:`_aws-cdk_sns.Topic.subscribeQueue` method with a queue object as the second argument:
 
@@ -114,22 +116,22 @@ Notice how much cleaner the first version is. There is more focus on intent,
 rather than mechanism.
 
 This example shows one of the many benefits
-of using the Library constructs instead of the Resource constructs.
+of using the |l2| constructs instead of the |l1| constructs.
 
 .. _purpose_built_constructs:
 
-Purpose-built constructs
-========================
+|l3| Constructs
+===============
 
-At an even higher-level than Construct Library constructs, *Purpose-built
-constructs* are constructs that aggregate multiple other constructs together
+At an even higher-level than |l2| constructs, |l3|
+constructs aggregate multiple, other constructs together
 into common architectural patterns, such as a *queue processor* or an *HTTP
 service*.
 
-By leveraging these common patterns, you will be able to assemble your
-application even faster than by using Construct Library constructs directly.
+By leveraging these common patterns, you can assemble your
+application even faster than by using |l2| constructs directly.
 
-Because these constructs will depend on your application's specific goals and
-requirements, they are not included with the standard CDK Construct
+The |l3| constructs
+are not included with the standard CDK Construct
 Library. Instead, we encourage you to develop and share them inside your
 organization or on GitHub.

--- a/packages/aws-cdk-docs/src/tools.rst
+++ b/packages/aws-cdk-docs/src/tools.rst
@@ -10,9 +10,9 @@
 
 .. _tools:
 
-#####
-Tools
-#####
+###########
+|cdk| Tools
+###########
 
 cdk
 ===
@@ -46,6 +46,7 @@ Below are the actions you can take on your CDK app:
    Usage: cdk -a <cloud-executable> COMMAND
 
    Commands:
+     docs                        Opens the documentation in a browser
      list                        Lists all stacks in the cloud executable (alias:
                                  ls)
      synth [STACKS..]            Synthesizes and prints the cloud formation
@@ -59,20 +60,24 @@ Below are the actions you can take on your CDK app:
      diff [STACK]                Compares the specified stack with the deployed
                                  stack or a local template file
      metadata [STACK]            Returns all metadata associated with this stack
-     init [TEMPLATE]             Create a new, empty CDK project from a template
+     init [TEMPLATE]             Create a new, empty CDK project from a template.
+                                 Invoked without TEMPLATE, the app template will be
+                                 used.
 
    Options:
      --help         Show help                                             [boolean]
-     --version      Show version number                                   [boolean]
      --app, -a      REQUIRED: Command-line of cloud executable (e.g. "node
-                    bin/my-app.js")                                        [string]
+                   bin/my-app.js")                                        [string]
      --context, -c  Add contextual string parameter.                        [array]
+     --plugin, -p   Name or path of a node package that extend the CDK features.
+                   Can be specified multiple times                         [array]
      --rename       Rename stack name if different then the one defined in the
-                    cloud executable                                       [string]
+                   cloud executable                                       [string]
      --trace        Print trace for stack warnings                        [boolean]
      --strict       Do not construct stacks with warnings                 [boolean]
      --json, -j     Use JSON output instead of YAML                       [boolean]
      --verbose, -v  Show debug logs                                       [boolean]
+     --version      Show version number                                   [boolean]
 
    If your app has a single stack, there is no need to specify the stack name
 

--- a/packages/aws-cdk-docs/src/welcome.rst
+++ b/packages/aws-cdk-docs/src/welcome.rst
@@ -8,8 +8,6 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
-.. Synched with release 1.0.200180 on 3/15/2018
-
 .. _welcome:
 
 #######
@@ -18,99 +16,83 @@ Welcome
 
 Welcome to the |cdk-long| (|cdk|) User Guide.
 
-The |cdk| is a software development framework which allows
-developers to model model AWS infrastructure components as code.
+The |cdk| is a software development framework for defining cloud infrastructure in code.
 
-Modern web services rely more and more on infrastructure to achieve their goals.
-As the complexity of these applications increases, there is a growing need for
-modeling techniques and tools to enable sharing and reusing higher-level
-infrastructure building blocks. Previously, achieving even seemingly trivial tasks on
-AWS, such as deploying a service on an EC2 fleet, require deep understanding of
-the low-level building blocks.
+The |cdk| consists of a core software package,
+language bindings, and command-line interface tools.
+The |cdk| also provides reusable component libraries, which we call *constructs*.
+Constructs are abstractions of cloud infrastructure logic that create AWS resources and are packaged for reuse.
+They expose a rich programmatic interface and can be composed together to form |cdk| apps that generate |CFN| templates.
 
-The |cdk| takes a code-first approach to cloud architectures and allows developers
-to use familiar object-oriented idioms to describe their architecture
-**constructs**.
+Here's a short example of creating an |SNS| topic, an |SQS| queue,
+and subscribing the topic to the queue.
+We'll explain the code in more detail,
+including how to see your |CFN| template before you deploy it,
+in :doc:`getting-started`.
+
+.. code-block:: js
+
+    import { App, Stack, StackProps } from '@aws-cdk/core';
+    import { Topic } from '@aws-cdk/sns';
+    import { Queue } from '@aws-cdk/sqs';
+
+    class HelloStack extends Stack {
+        constructor(parent: App, name: string, props?: StackProps) {
+            super(parent, name, props);
+
+            const topic = new Topic(this, 'MyTopic');
+
+	    const queue = new Queue(this, 'MyQueue', {
+              visibilityTimeoutSec: 300
+            });
+
+            topic.subscribeQueue('TopicToQueue', queue);
+        }
+    }
+
+    const app = new App(process.argv);
+    new HelloStack(app, 'hello-cdk');
+
+    process.stdout.write(app.run());
+
+The process of creating your AWS resources using the |cdk| is straightforward:
+
+1. Install the |cdk| on your development machine
+2. Run the **cdk init** command to create the skeleton of your program
+   in one of the supported programming lanuages
+3. Use your favorite development environment to define your AWS application infrastructure
+   using the |l2|
+4. Compile your code, if necessary
+5. (Optional) Run the |cdk| toolkit **cdk synth** command to see what your |CFN| temlate looks like
+6. Run the |cdk| toolkit **cdk deploy** command to deploy the resulting |CFN| template
+   and create the AWS resources in your AWS account
+7. Repeats steps 3-6 until you are satisfied with your resources
 
 .. note:: There is no charge for using the |cdk|, however you may incur AWS charges for creating or using AWS
 	  `chargeable resources <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#chargeable-resources>`_,
-	  such as running Amazon EC2 instances or using Amazon S3 storage.
+	  such as running |EC2| instances or using |S3| storage.
 	  Use the
 	  `AWS Simple Monthly Calculator <http://calculator.s3.amazonaws.com/index.html>`_
           to estimate charges for the use of various AWS resources.
-
-.. _terminology:
-
-Terminology
-===========
-
-The |cdk| uses the following terms.
-
-|cdk-long| (|cdk|)
-   An AWS toolkit that enables infrastructure as code (IaC), exposing AWS
-   resources and high level constructs for use in popular DevOps programming
-   languages.
-
-construct
-   The building block of an |cdk| app or library. In code, they are instances of
-   the :py:class:`_aws-cdk_core.Construct` class or a class that extends the
-   :py:class:`_aws-cdk_core.Construct` class.
-
-app
-   An executable program that the |cdk| uses to synthesize artifacts
-   that can contain multiple stacks and be deployed into multiple AWS environments.
-   Apps extend the :py:class:`_aws-cdk_core.App` class.
-
-environment
-   An AWS deployment target for |cdk| stacks, defined by a specific AWS account and region.
-
-stack
-   An |cdk| construct that can be deployed into an environment.
-   Stacks extend the :py:class:`_aws-cdk_core.Stack` class.
-
-applet
-   A reusable |cdk| construct that can be instantiated and deployed through a
-   YAML-format file.
-
-CloudFormation Resource construct
-   The lowest-level construct, which map directly to an |CFN| resource,
-   as described in the
-   `AWS Resource Types Reference <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html>`_.
-   These constructs are available in the :py:mod:`_aws-cdk_resources` package
-   as the |CFN| name with a **Resource** suffix within the AWS service namespace,
-   such as **sqs.QueueResource** representing an |SQS| queue.
-
-Construct Library construct
-   A construct that provides high level APIs for a AWS services.
-   Their names imply the underlying AWS service.
-   For example, |s3| resources are available through the **aws-cdk-s3**
-   Construct Library.
-
-Purpose-built construct
-   Purpose-built construct, designed to abstract away common architectural
-   patterns on AWS. These are not supplied with the standard CDK distribution,
-   but are shared within your organization or on GitHub.
 
 .. _aws_cdk_additional_resources:
 
 Additional Documentation and Resources
 ======================================
 
-In addition to this guide, there are a number of other resources available for |cdk| users:
+In addition to this guide, the following are other resources available to |cdk| users:
 
 * `AWS Developer blog <https://aws.amazon.com/blogs/developer/>`_
-* GitHub
-
-  * documentation source (link TBD)
-  * documentation issues (link TBD)
-  * toolkit source (link TBD)
-  * toolkit issues (link TBD)
-
-* License (link TBD)
-* FAQ (link TBD)
+* `GitHub repository <https://github.com/awslabs/aws-cdk>`_
+  * `Documentation source <https://github.com/awslabs/aws-cdk/tree/master/packages/aws-cdk-docs/src>`_
+  * `Issues <https://github.com/awslabs/aws-cdk/issues>`_
 * :doc:`getting-started`
-* Installing the |cdk| (video) (link TBD)
 * `TypeScriptLang.org <https://www.typescriptlang.org/>`_
+
+.. TBD:
+   * License (link)
+   * FAQ (link)
+   * Installing the |cdk| (video) (link)
 
 .. _about-aws:
 
@@ -124,7 +106,7 @@ application synchronization (messaging and queuing).
 AWS uses a pay-as-you-go service model. You are charged only for the services that you |mdash| or
 your applications |mdash| use. Also, to make AWS useful as a platform for prototyping and
 experimentation, AWS offers a free usage tier, in which services are free below a certain level of
-usage. For more information about AWS costs and the free usage tier go to
+usage. For more information about AWS costs and the free usage tier, see
 `Test-Driving AWS in the Free Usage Tier <http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-free-tier.html>`_.
 
 To obtain an AWS account, go to `aws.amazon.com <https://aws.amazon.com>`_ and click :guilabel:`Create a Free Account`.

--- a/packages/aws-cdk-docs/src/writing-cdk-apps.rst
+++ b/packages/aws-cdk-docs/src/writing-cdk-apps.rst
@@ -8,18 +8,19 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
-.. _using_l2_constructs:
+.. _developing_cdk_apps:
 
-#################
-Writing CDK Apps
-#################
+#####################
+Developing |cdk| Apps
+#####################
 
 *CDK Apps* are the applications you write using the CDK libraries. After writing
 and compiling them, you'll use the |toolkit| to synthesize or deploy the
 stacks they describe.
 
 To write your CDK app, you can create your own constructs, as described in
-:doc:`cloudformation`, or use constructs created by others.
+:doc:`cloudformation`, or use higher-level constructs.
+See the :doc:`concepts` section for an overview of which constructs you should use or create.
 
 .. _incorporating_external_constructs:
 
@@ -77,10 +78,7 @@ to it to make it more reusable, and sharing it among your projects, or even
 sharing it with other people.
 
 Writing a CDK app means breaking down your desired infrastructure into logical
-constructs, and reusing them wherever it makes sense. For more information on
-writing constructs, see :ref:`creating_constructs`, :ref:`guidelines` and of
-course the :ref:`cdk_examples`.
-
+constructs, and reusing them wherever it makes sense.
 
 .. _runtime_discovery:
 


### PR DESCRIPTION
Make sure all examples in the documentation are valid (they compile and
produce the expected result), uniformize the terminology and style used
throughout the documentation, and re-organize some sections to optimize
reader experience.