### PR TITLE
Also support AWS_DEFAULT_REGION environment variable

### DIFF
--- a/packages/aws-cdk/lib/api/util/sdk.ts
+++ b/packages/aws-cdk/lib/api/util/sdk.ts
@@ -72,8 +72,15 @@ export class SDK {
     }
 
     public defaultRegion() {
-        debug('Obtaining default region from AWS configuration');
-        return config.region;
+        if (process.env.AWS_DEFAULT_REGION) {
+            debug('Obtaining default region from environment');
+            return process.env.AWS_DEFAULT_REGION;
+        }
+        if (config.region) {
+            debug('Obtaining default region from AWS configuration');
+            return config.region;
+        }
+        return undefined;
     }
 
     public async defaultAccount() {


### PR DESCRIPTION
We use the account from the environment variables, but only look
for the region in ~/.aws/config directory, which is inconsistent.
This is the official environment variable to use for regions.

Also, for some reason on my machine, the config setting from the
environment variable is not even used, which makes running integ
tests fail. This fixes that.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
