### PR TITLE
Remove --pinentry-mode option from gpg invokation

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -48,7 +48,6 @@ while [[ "${1:-}" != "" ]]; do
         --homedir $tmpdir \
         --local-user aws-cdk@amazon.com \
         --batch --yes --no-tty \
-        --pinentry-mode loopback \
         --passphrase-fd 0 \
         --output $1.sig \
         --detach-sign $1


### PR DESCRIPTION
It is not supported by the version of `gnupg` (`1.4.16`) that is built into the latest superchain image (prior image used `gnupg >= 2.1`).

The `--pinentry-mode` option is used to allow the `gpg-agent` process to request the passphrase from the process that invoked it, which is required when using `gnupg >= 2.1` and passing a private key's passphrase using the `--passphrase-fd` option (since the fd is owned by the invoker process).