### PR TITLE
Improve error message when no environment is found

### DIFF
--- a/packages/aws-cdk/bin/cdk.ts
+++ b/packages/aws-cdk/bin/cdk.ts
@@ -405,7 +405,7 @@ async function initCommandLine() {
             if (stackIds.length !== 1) { highlight(stack.name); }
             if (!stack.environment) {
                 // tslint:disable-next-line:max-line-length
-                throw new Error(`Stack ${stack.name} does not define an environment, and AWS credentails could not be obtained from standard locations.`);
+                throw new Error(`Stack ${stack.name} does not define an environment, and AWS credentials could not be obtained from standard locations or no region was configured.`);
             }
             const toolkitInfo = await loadToolkitInfo(stack.environment, aws, toolkitStackName);
             const deployName = renames.finalName(stack.name);


### PR DESCRIPTION
No environment can be inferred if we are unable to determine any of:
1. The account ID (no AWS credentials can be obtained via standard ways)
2. The region to be used

The error message covered 1 but not 2. New message covers both and corrects
a typo, but still is not as actionale as we'd like it to be.

See #131 