### PR TITLE
Have cdk diff output render 'number' value changes

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/format.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format.ts
@@ -143,7 +143,7 @@ export function formatDifferences(stream: NodeJS.WriteStream, templateDiff: Temp
      * @param linePrefix a prefix (indent-like) to be used on every line.
      */
     function formatObjectDiff(oldObject: any, newObject: any, linePrefix: string) {
-        if ((typeof oldObject !== typeof newObject) || Array.isArray(oldObject) || typeof oldObject === 'string') {
+        if ((typeof oldObject !== typeof newObject) || Array.isArray(oldObject) || typeof oldObject === 'string' || typeof oldObject === 'number') {
             if (oldObject !== undefined && newObject !== undefined) {
                 print('%s   ├─ %s Old value: %s', linePrefix, REMOVAL, formatValue(oldObject, colors.red));
                 print('%s   └─ %s New value: %s', linePrefix, ADDITION, formatValue(newObject, colors.green));


### PR DESCRIPTION
Number value changes did not benefit from the old/new value rendering in the output
of `cdk diff` because 'number' value types were handled with the non-'string'
types.

Fixes #133