### PR TITLE
feat(@aws-cdk/lambda): Implement IEventRuleTarget for Lambda

### DIFF
--- a/packages/@aws-cdk/lambda/package.json
+++ b/packages/@aws-cdk/lambda/package.json
@@ -44,6 +44,7 @@
     "@aws-cdk/core": "^0.7.2",
     "@aws-cdk/iam": "^0.7.2",
     "@aws-cdk/resources": "^0.7.2",
-    "@aws-cdk/s3": "^0.7.2"
+    "@aws-cdk/s3": "^0.7.2",
+    "@aws-cdk/events": "^0.7.2"
   }
 }


### PR DESCRIPTION
Lambdas can now be used as CloudWatch event targets.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
