### PR TITLE
fix: Convert buff array to string when printing stdout on error

### DIFF
--- a/packages/aws-cdk/bin/cdk.ts
+++ b/packages/aws-cdk/bin/cdk.ts
@@ -563,8 +563,9 @@ async function initCommandLine() {
             proc.on('error', fail);
 
             proc.on('exit', code => {
+                const stdout = Buffer.concat(buf).toString();
+
                 if (code === 0) {
-                    const stdout = Buffer.concat(buf).toString();
                     let parsed = null;
                     try {
                         parsed = JSON.parse(stdout);
@@ -575,7 +576,7 @@ async function initCommandLine() {
                     }
                     return ok(parsed);
                 } else {
-                    error(buf.toString());
+                    error(stdout);
                     return fail(new Error('Subprocess exited with error ' + code.toString()));
                 }
             });


### PR DESCRIPTION
When child exists with a non-zero, we need to concat and convert
buffer array to string before we emit it as part of the error
message.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
