### PR TITLE
typescript/app init template: add "npm run cdk"

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.template.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.template.json
@@ -8,11 +8,13 @@
     },
     "scripts": {
         "prepare": "tsc && chmod a+x bin/%name%.js",
-        "watch": "tsc -w"
+        "watch": "tsc -w",
+        "cdk": "cdk"
     },
     "devDependencies": {
         "@types/node": "^8.9.4",
-        "typescript": "^2.8.3"
+        "typescript": "^2.8.3",
+        "aws-cdk": "^%cdk-version%"
     },
     "dependencies": {
         "@aws-cdk/core": "^%cdk-version%",


### PR DESCRIPTION
Take a dep on aws-cdk and add a script that allows running the toolkit via "npm run cdk".

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
