### PR TITLE
Remove "+BUILD" component from maven package versions

### DIFF
--- a/examples/cdk-examples-java/pom.xml.t.js
+++ b/examples/cdk-examples-java/pom.xml.t.js
@@ -2,7 +2,7 @@ const path = require('path');
 const version = require('./package.json').version;
 
 const mavenFromNpm = name => ({
-    version: require(`${name}/package.json`).version,
+    version: require(`${name}/package.json`).version.replace(/\+.+$/, ''), // remove "+build" component from version when building in ci
     repo: path.join(path.dirname(require.resolve(name)), 'maven-repo'),
 });
 

--- a/packages/aws-cdk-java/pom.xml.t.js
+++ b/packages/aws-cdk-java/pom.xml.t.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const version = require('./package.json').version;
+const version = require('./package.json').version.replace(/\+.+$/, ''); // omit "+build" postfix
 
 const jsiiRuntime = {
     version: require('jsii-java-runtime/package.json').version,


### PR DESCRIPTION
When building in CI, the +BUILD component should be
omitted from the locally-published version string.

Since `cdk-examples-java` consumes aws-cdk from
this repository, the build component should be
removed at the consumption side as well.