### PR TITLE
Consider environment variables the AWS CLI considers

### DIFF
--- a/packages/aws-cdk/lib/api/util/sdk-load-aws-config.ts
+++ b/packages/aws-cdk/lib/api/util/sdk-load-aws-config.ts
@@ -31,3 +31,15 @@ if (fs.existsSync(sharedCredentialsFile)) {
     // Ensures that region is loaded from ~/.aws/config (https://github.com/aws/aws-sdk-js/pull/1391)
     process.env.AWS_SDK_LOAD_CONFIG = '1';
 }
+
+/*
+ * Set environment variables so JS AWS SDK behaves as close as possible to AWS CLI.
+ * @see https://github.com/aws/aws-sdk-js/issues/373
+ * @see https://github.com/awslabs/aws-cdk/issues/131
+ */
+if (process.env.AWS_DEFAULT_PROFILE && !process.env.AWS_PROFILE) {
+    process.env.AWS_PROFILE = process.env.AWS_DEFAULT_PROFILE;
+}
+if (process.env.AWS_DEFAULT_REGION && !process.env.AWS_REGION) {
+    process.env.AWS_REGION = process.env.AWS_DEFAULT_REGION;
+}


### PR DESCRIPTION
The AWS CLI considers `AWS_DEFAULT_PROFILE` and `AWS_DEFAULT_REGION`
when creating default clients, however the AWS SDK for JS only considers
`AWS_PROFILE` and `AWS_REGION`. This aims to align the behavior of both
ways by automatically setting `AWS_PROFILE` and `AWS_REGION` from the
matching `AWS_DEFAULT_` variable (unless the variables were already set)

See #131