### PR TITLE
Update dotnet namespace names for consistency with other dotnet AWS products.

### DIFF
--- a/create-missing-libraries.sh
+++ b/create-missing-libraries.sh
@@ -58,7 +58,7 @@ EOM
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.${PB}",
-      "dotnet": "${S/AWS::/Aws.Cdk.}"
+      "dotnet": "${S/AWS::/Amazon.Cdk.}"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/apigateway/package.json
+++ b/packages/@aws-cdk/apigateway/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.apigateway",
-      "dotnet": "Aws.Cdk.ApiGateway"
+      "dotnet": "Amazon.Cdk.ApiGateway"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/applicationautoscaling/package.json
+++ b/packages/@aws-cdk/applicationautoscaling/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.applicationautoscaling",
-      "dotnet": "Aws.Cdk.ApplicationAutoScaling"
+      "dotnet": "Amazon.Cdk.ApplicationAutoScaling"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/appsync/package.json
+++ b/packages/@aws-cdk/appsync/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.appsync",
-      "dotnet": "Aws.Cdk.AppSync"
+      "dotnet": "Amazon.Cdk.AppSync"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/athena/package.json
+++ b/packages/@aws-cdk/athena/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.athena",
-      "dotnet": "Aws.Cdk.Athena"
+      "dotnet": "Amazon.Cdk.Athena"
     }
   },
   "cdk-build": {

--- a/packages/@aws-cdk/autoscaling/package.json
+++ b/packages/@aws-cdk/autoscaling/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.autoscaling",
-      "dotnet": "Aws.Cdk.AutoScaling"
+      "dotnet": "Amazon.Cdk.AutoScaling"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/autoscalingplans/package.json
+++ b/packages/@aws-cdk/autoscalingplans/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.autoscalingplans",
-      "dotnet": "Aws.Cdk.AutoScalingPlans"
+      "dotnet": "Amazon.Cdk.AutoScalingPlans"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/batch/package.json
+++ b/packages/@aws-cdk/batch/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.batch",
-      "dotnet": "Aws.Cdk.Batch"
+      "dotnet": "Amazon.Cdk.Batch"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/budgets/package.json
+++ b/packages/@aws-cdk/budgets/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.budgets",
-      "dotnet": "Aws.Cdk.Budgets"
+      "dotnet": "Amazon.Cdk.Budgets"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/certificatemanager/package.json
+++ b/packages/@aws-cdk/certificatemanager/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.certificatemanager",
-      "dotnet": "Aws.Cdk.CertificateManager"
+      "dotnet": "Amazon.Cdk.CertificateManager"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cloud9/package.json
+++ b/packages/@aws-cdk/cloud9/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cloud9",
-      "dotnet": "Aws.Cdk.Cloud9"
+      "dotnet": "Amazon.Cdk.Cloud9"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cloudformation/package.json
+++ b/packages/@aws-cdk/cloudformation/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cloudformation",
-      "dotnet": "Aws.Cdk.CloudFormation"
+      "dotnet": "Amazon.Cdk.CloudFormation"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cloudfront/package.json
+++ b/packages/@aws-cdk/cloudfront/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cloudfront",
-      "dotnet": "Aws.Cdk.CloudFront"
+      "dotnet": "Amazon.Cdk.CloudFront"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cloudtrail/package.json
+++ b/packages/@aws-cdk/cloudtrail/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cloudtrail",
-      "dotnet": "Aws.Cdk.CloudTrail"
+      "dotnet": "Amazon.Cdk.CloudTrail"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cloudwatch/package.json
+++ b/packages/@aws-cdk/cloudwatch/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cloudwatch",
-      "dotnet": "Aws.Cdk.CloudWatch"
+      "dotnet": "Amazon.Cdk.CloudWatch"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/codebuild/package.json
+++ b/packages/@aws-cdk/codebuild/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.codebuild",
-      "dotnet": "Aws.Cdk.CodeBuild"
+      "dotnet": "Amazon.Cdk.CodeBuild"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/codecommit/package.json
+++ b/packages/@aws-cdk/codecommit/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.codecommit",
-      "dotnet": "Aws.Cdk.CodeCommit"
+      "dotnet": "Amazon.Cdk.CodeCommit"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/codedeploy/package.json
+++ b/packages/@aws-cdk/codedeploy/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.codedeploy",
-      "dotnet": "Aws.Cdk.CodeDeploy"
+      "dotnet": "Amazon.Cdk.CodeDeploy"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/codepipeline/package.json
+++ b/packages/@aws-cdk/codepipeline/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.codepipeline",
-      "dotnet": "Aws.Cdk.CodePipeline"
+      "dotnet": "Amazon.Cdk.CodePipeline"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cognito/package.json
+++ b/packages/@aws-cdk/cognito/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cognito",
-      "dotnet": "Aws.Cdk.Cognito"
+      "dotnet": "Amazon.Cdk.Cognito"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/config/package.json
+++ b/packages/@aws-cdk/config/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.config",
-      "dotnet": "Aws.Cdk.Config"
+      "dotnet": "Amazon.Cdk.Config"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/core/package.json
+++ b/packages/@aws-cdk/core/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk",
-      "dotnet": "Aws.Cdk"
+      "dotnet": "Amazon.Cdk"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/custom-resources/package.json
+++ b/packages/@aws-cdk/custom-resources/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.customresources",
-      "dotnet": "Aws.Cdk.CustomResources"
+      "dotnet": "Amazon.Cdk.CustomResources"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/cx-api/package.json
+++ b/packages/@aws-cdk/cx-api/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.cxapi",
-      "dotnet": "Aws.Cdk.CxApi"
+      "dotnet": "Amazon.Cdk.CxApi"
     }
   },
   "scripts": {

--- a/packages/@aws-cdk/datapipeline/package.json
+++ b/packages/@aws-cdk/datapipeline/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.datapipeline",
-      "dotnet": "Aws.Cdk.DataPipeline"
+      "dotnet": "Amazon.Cdk.DataPipeline"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/dax/package.json
+++ b/packages/@aws-cdk/dax/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.dax",
-      "dotnet": "Aws.Cdk.DAX"
+      "dotnet": "Amazon.Cdk.DAX"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/directoryservice/package.json
+++ b/packages/@aws-cdk/directoryservice/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.directoryservice",
-      "dotnet": "Aws.Cdk.DirectoryService"
+      "dotnet": "Amazon.Cdk.DirectoryService"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/dms/package.json
+++ b/packages/@aws-cdk/dms/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.dms",
-      "dotnet": "Aws.Cdk.DMS"
+      "dotnet": "Amazon.Cdk.DMS"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/dynamodb/package.json
+++ b/packages/@aws-cdk/dynamodb/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.dynamodb",
-      "dotnet": "Aws.Cdk.DynamoDb"
+      "dotnet": "Amazon.Cdk.DynamoDb"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/ec2/package.json
+++ b/packages/@aws-cdk/ec2/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.ec2",
-      "dotnet": "Aws.Cdk.Ec2"
+      "dotnet": "Amazon.Cdk.Ec2"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/ecr/package.json
+++ b/packages/@aws-cdk/ecr/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.ecr",
-      "dotnet": "Aws.Cdk.ECR"
+      "dotnet": "Amazon.Cdk.ECR"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/ecs/package.json
+++ b/packages/@aws-cdk/ecs/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.ecs",
-      "dotnet": "Aws.Cdk.ECS"
+      "dotnet": "Amazon.Cdk.ECS"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/efs/package.json
+++ b/packages/@aws-cdk/efs/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.efs",
-      "dotnet": "Aws.Cdk.EFS"
+      "dotnet": "Amazon.Cdk.EFS"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/eks/package.json
+++ b/packages/@aws-cdk/eks/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.eks",
-      "dotnet": "Aws.Cdk.EKS"
+      "dotnet": "Amazon.Cdk.EKS"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/elasticache/package.json
+++ b/packages/@aws-cdk/elasticache/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.elasticache",
-      "dotnet": "Aws.Cdk.ElastiCache"
+      "dotnet": "Amazon.Cdk.ElastiCache"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/elasticbeanstalk/package.json
+++ b/packages/@aws-cdk/elasticbeanstalk/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.elasticbeanstalk",
-      "dotnet": "Aws.Cdk.ElasticBeanstalk"
+      "dotnet": "Amazon.Cdk.ElasticBeanstalk"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/elasticloadbalancing/package.json
+++ b/packages/@aws-cdk/elasticloadbalancing/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.elasticloadbalancing",
-      "dotnet": "Aws.Cdk.ElasticLoadBalancing"
+      "dotnet": "Amazon.Cdk.ElasticLoadBalancing"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/elasticloadbalancingv2/package.json
+++ b/packages/@aws-cdk/elasticloadbalancingv2/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.elasticloadbalancingv2",
-      "dotnet": "Aws.Cdk.ElasticLoadBalancingV2"
+      "dotnet": "Amazon.Cdk.ElasticLoadBalancingV2"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/elasticsearch/package.json
+++ b/packages/@aws-cdk/elasticsearch/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.elasticsearch",
-      "dotnet": "Aws.Cdk.Elasticsearch"
+      "dotnet": "Amazon.Cdk.Elasticsearch"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/emr/package.json
+++ b/packages/@aws-cdk/emr/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.emr",
-      "dotnet": "Aws.Cdk.EMR"
+      "dotnet": "Amazon.Cdk.EMR"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/events/package.json
+++ b/packages/@aws-cdk/events/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.events",
-      "dotnet": "Aws.Cdk.Events"
+      "dotnet": "Amazon.Cdk.Events"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/gamelift/package.json
+++ b/packages/@aws-cdk/gamelift/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.gamelift",
-      "dotnet": "Aws.Cdk.GameLift"
+      "dotnet": "Amazon.Cdk.GameLift"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/glue/package.json
+++ b/packages/@aws-cdk/glue/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.glue",
-      "dotnet": "Aws.Cdk.Glue"
+      "dotnet": "Amazon.Cdk.Glue"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/guardduty/package.json
+++ b/packages/@aws-cdk/guardduty/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.guardduty",
-      "dotnet": "Aws.Cdk.GuardDuty"
+      "dotnet": "Amazon.Cdk.GuardDuty"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/iam/package.json
+++ b/packages/@aws-cdk/iam/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.iam",
-      "dotnet": "Aws.Cdk.Iam"
+      "dotnet": "Amazon.Cdk.Iam"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/inspector/package.json
+++ b/packages/@aws-cdk/inspector/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.inspector",
-      "dotnet": "Aws.Cdk.Inspector"
+      "dotnet": "Amazon.Cdk.Inspector"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/iot/package.json
+++ b/packages/@aws-cdk/iot/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.iot",
-      "dotnet": "Aws.Cdk.IoT"
+      "dotnet": "Amazon.Cdk.IoT"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/kinesis/package.json
+++ b/packages/@aws-cdk/kinesis/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.kinesis",
-      "dotnet": "Aws.Cdk.Kinesis"
+      "dotnet": "Amazon.Cdk.Kinesis"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/kinesisanalytics/package.json
+++ b/packages/@aws-cdk/kinesisanalytics/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.kinesisanalytics",
-      "dotnet": "Aws.Cdk.KinesisAnalytics"
+      "dotnet": "Amazon.Cdk.KinesisAnalytics"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/kinesisfirehose/package.json
+++ b/packages/@aws-cdk/kinesisfirehose/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.kinesisfirehose",
-      "dotnet": "Aws.Cdk.KinesisFirehose"
+      "dotnet": "Amazon.Cdk.KinesisFirehose"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/kms/package.json
+++ b/packages/@aws-cdk/kms/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.kms",
-      "dotnet": "Aws.Cdk.Kms"
+      "dotnet": "Amazon.Cdk.Kms"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/lambda/package.json
+++ b/packages/@aws-cdk/lambda/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.lambda",
-      "dotnet": "Aws.Cdk.Lambda"
+      "dotnet": "Amazon.Cdk.Lambda"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/logs/package.json
+++ b/packages/@aws-cdk/logs/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.logs",
-      "dotnet": "Aws.Cdk.Logs"
+      "dotnet": "Amazon.Cdk.Logs"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/neptune/package.json
+++ b/packages/@aws-cdk/neptune/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.neptune",
-      "dotnet": "Aws.Cdk.Neptune"
+      "dotnet": "Amazon.Cdk.Neptune"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/opsworks/package.json
+++ b/packages/@aws-cdk/opsworks/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.opsworks",
-      "dotnet": "Aws.Cdk.OpsWorks"
+      "dotnet": "Amazon.Cdk.OpsWorks"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/quickstarts/package.json
+++ b/packages/@aws-cdk/quickstarts/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.quickstarts",
-      "dotnet": "Aws.Cdk.QuickStarts"
+      "dotnet": "Amazon.Cdk.QuickStarts"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/rds/package.json
+++ b/packages/@aws-cdk/rds/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.rds",
-      "dotnet": "Aws.Cdk.Rds"
+      "dotnet": "Amazon.Cdk.Rds"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/redshift/package.json
+++ b/packages/@aws-cdk/redshift/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.redshift",
-      "dotnet": "Aws.Cdk.Redshift"
+      "dotnet": "Amazon.Cdk.Redshift"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/route53/package.json
+++ b/packages/@aws-cdk/route53/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.route53",
-      "dotnet": "Aws.Cdk.Route53"
+      "dotnet": "Amazon.Cdk.Route53"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/rtv/package.json
+++ b/packages/@aws-cdk/rtv/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.rtv",
-      "dotnet": "Aws.Cdk.Rtv"
+      "dotnet": "Amazon.Cdk.Rtv"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/s3/package.json
+++ b/packages/@aws-cdk/s3/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.s3",
-      "dotnet": "Aws.Cdk.S3"
+      "dotnet": "Amazon.Cdk.S3"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/sdb/package.json
+++ b/packages/@aws-cdk/sdb/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.sdb",
-      "dotnet": "Aws.Cdk.SDB"
+      "dotnet": "Amazon.Cdk.SDB"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/serverless/package.json
+++ b/packages/@aws-cdk/serverless/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.serverless",
-      "dotnet": "Aws.Cdk.Serverless"
+      "dotnet": "Amazon.Cdk.Serverless"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/servicecatalog/package.json
+++ b/packages/@aws-cdk/servicecatalog/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.servicecatalog",
-      "dotnet": "Aws.Cdk.ServiceCatalog"
+      "dotnet": "Amazon.Cdk.ServiceCatalog"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/servicediscovery/package.json
+++ b/packages/@aws-cdk/servicediscovery/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.servicediscovery",
-      "dotnet": "Aws.Cdk.ServiceDiscovery"
+      "dotnet": "Amazon.Cdk.ServiceDiscovery"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/ses/package.json
+++ b/packages/@aws-cdk/ses/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.ses",
-      "dotnet": "Aws.Cdk.SES"
+      "dotnet": "Amazon.Cdk.SES"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/sns/package.json
+++ b/packages/@aws-cdk/sns/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.sns",
-      "dotnet": "Aws.Cdk.Sns"
+      "dotnet": "Amazon.Cdk.Sns"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/sqs/package.json
+++ b/packages/@aws-cdk/sqs/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.sqs",
-      "dotnet": "Aws.Cdk.Sqs"
+      "dotnet": "Amazon.Cdk.Sqs"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/ssm/package.json
+++ b/packages/@aws-cdk/ssm/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.ssm",
-      "dotnet": "Aws.Cdk.SSM"
+      "dotnet": "Amazon.Cdk.SSM"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/stepfunctions/package.json
+++ b/packages/@aws-cdk/stepfunctions/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.stepfunctions",
-      "dotnet": "Aws.Cdk.StepFunctions"
+      "dotnet": "Amazon.Cdk.StepFunctions"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/waf/package.json
+++ b/packages/@aws-cdk/waf/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.waf",
-      "dotnet": "Aws.Cdk.WAF"
+      "dotnet": "Amazon.Cdk.WAF"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/wafregional/package.json
+++ b/packages/@aws-cdk/wafregional/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.wafregional",
-      "dotnet": "Aws.Cdk.WAFRegional"
+      "dotnet": "Amazon.Cdk.WAFRegional"
     }
   },
   "repository": {

--- a/packages/@aws-cdk/workspaces/package.json
+++ b/packages/@aws-cdk/workspaces/package.json
@@ -8,7 +8,7 @@
     "outdir": "dist",
     "names": {
       "java": "com.amazonaws.cdk.workspaces",
-      "dotnet": "Aws.Cdk.WorkSpaces"
+      "dotnet": "Amazon.Cdk.WorkSpaces"
     }
   },
   "repository": {

--- a/tools/pkglint/lib/rules.ts
+++ b/tools/pkglint/lib/rules.ts
@@ -176,7 +176,7 @@ export class JSIIDotNetNamespaceIsRequired extends ValidationRule {
             return;
         }
 
-        const prefix = 'Aws.Cdk';
+        const prefix = 'Amazon.Cdk';
 
         if (!java.startsWith(prefix)) {
             pkg.report({ message: `.NET namespace must start with '${prefix}'` });


### PR DESCRIPTION
.NET naming guidelines are to only capitalize the first letter of acronyms, but existing .NET products from AWS start `AWS` or `AWSSDK`.