### PR TITLE
Add support for Node8.10 Lambda runtime

### DIFF
--- a/packages/@aws-cdk/lambda/lib/code.ts
+++ b/packages/@aws-cdk/lambda/lib/code.ts
@@ -38,16 +38,8 @@ export class LambdaInlineCode extends LambdaCode {
     }
 
     public toJSON(runtime: LambdaRuntime): lambda.FunctionResource.CodeProperty {
-        const allowed = [
-            LambdaRuntime.NodeJS,
-            LambdaRuntime.NodeJS43,
-            LambdaRuntime.NodeJS610,
-            LambdaRuntime.Python27,
-            LambdaRuntime.Python36
-        ];
-
-        if (!allowed.find(a => a === runtime)) {
-            throw new Error(`Inline source only allowed for: ${allowed.join(', ')}`);
+        if (!runtime.supportsInlineCode) {
+            throw new Error(`Inline source not supported for: ${runtime.name}`);
         }
 
         return {

--- a/packages/@aws-cdk/lambda/lib/inline.ts
+++ b/packages/@aws-cdk/lambda/lib/inline.ts
@@ -1,7 +1,7 @@
 import { Construct } from '@aws-cdk/core';
 import { LambdaInlineCode } from './code';
 import { Lambda } from './lambda';
-import { LambdaRuntime } from './runtime';
+import { InlinableJavascriptLambdaRuntime, LambdaRuntime } from './runtime';
 
 /**
  * Defines the handler code for an inline JavaScript lambda function.
@@ -28,15 +28,6 @@ export interface IJavaScriptLambdaHandler {
      * to the caller. Signature is `callback(err, response)`.
      */
     fn(event: any, context: any, callback: any): void;
-}
-
-/**
- * The set of runtime that support inline javascript code.
- */
-export enum InlineJavaScriptLambdaRuntime {
-    NodeJS = LambdaRuntime.NodeJS,
-    NodeJS43 = LambdaRuntime.NodeJS43,
-    NodeJS610 = LambdaRuntime.NodeJS610,
 }
 
 export interface InlineJavaScriptLambdaProps {
@@ -75,9 +66,9 @@ export interface InlineJavaScriptLambdaProps {
      * For valid values, see the Runtime property in the AWS Lambda Developer
      * Guide.
      *
-     * @default NodeJS610
+     * @default NodeJS810
      */
-    runtime?: InlineJavaScriptLambdaRuntime;
+    runtime?: InlinableJavascriptLambdaRuntime;
 
     /**
      * A name for the function. If you don't specify a name, AWS CloudFormation
@@ -117,7 +108,7 @@ export interface InlineJavaScriptLambdaProps {
 export class InlineJavaScriptLambda extends Lambda {
     constructor(parent: Construct, name: string, props: InlineJavaScriptLambdaProps) {
         const code = new LambdaInlineCode(renderCode(props.handler));
-        const runtime = (props.runtime || InlineJavaScriptLambdaRuntime.NodeJS610) as any;
+        const runtime: InlinableJavascriptLambdaRuntime = props.runtime || LambdaRuntime.NodeJS610;
         const handler = 'index.handler';
         const timeout = props.timeout || 30;
         super(parent, name, {

--- a/packages/@aws-cdk/lambda/lib/lambda.ts
+++ b/packages/@aws-cdk/lambda/lib/lambda.ts
@@ -140,7 +140,7 @@ export class Lambda extends LambdaRef {
             code: props.code.toJSON(props.runtime),
             handler: props.handler,
             timeout: props.timeout,
-            runtime: props.runtime,
+            runtime: props.runtime.name,
             role: this.role.roleArn,
             environment: new Token(() => this.renderEnvironment()),
             memorySize: props.memorySize,

--- a/packages/@aws-cdk/lambda/lib/runtime.ts
+++ b/packages/@aws-cdk/lambda/lib/runtime.ts
@@ -1,15 +1,57 @@
+export interface LambdaRuntimeProps {
+    /**
+     * Whether the ``ZipFile`` (aka inline code) property can be used with this runtime.
+     * @default false
+     */
+    readonly supportsInlineCode?: boolean;
+}
+
 /**
  * Lambda function runtime environment.
  */
-export enum LambdaRuntime {
-    NodeJS = 'nodejs',
-    NodeJS43 = 'nodejs4.3',
-    NodeJS43Edge = 'nodejs4.3-edge',
-    NodeJS610 = 'nodejs6.10',
-    Java8 = 'java8',
-    Python27 = 'python2.7',
-    Python36 = 'python3.6',
-    DotNetCore1 = 'dotnetcore1.0',
-    DotNetCore2 = 'dotnetcore2.0',
-    Go1x = 'go1.x'
+export class LambdaRuntime {
+    public static readonly NodeJS = new LambdaRuntime('nodejs', { supportsInlineCode: true }) as InlinableJavascriptLambdaRuntime;
+    // Using ``as InlinableLambdaRuntime`` because that calss cannot be defined just yet
+    public static readonly NodeJS43 = new LambdaRuntime('nodejs4.3', { supportsInlineCode: true }) as InlinableJavascriptLambdaRuntime;
+    public static readonly NodeJS43Edge = new LambdaRuntime('nodejs4.3-edge');
+    // Using ``as InlinableLambdaRuntime`` because that calss cannot be defined just yet
+    public static readonly NodeJS610 = new LambdaRuntime('nodejs6.10', { supportsInlineCode: true }) as InlinableJavascriptLambdaRuntime;
+    public static readonly NodeJS810 = new LambdaRuntime('nodejs8.10');
+    public static readonly Java8 = new LambdaRuntime('java8');
+    // Using ``as InlinableLambdaRuntime`` because that calss cannot be defined just yet
+    public static readonly Python27 = new LambdaRuntime('python2.7', { supportsInlineCode: true }) as InlinableLambdaRuntime;
+    // Using ``as InlinableLambdaRuntime`` because that calss cannot be defined just yet
+    public static readonly Python36 = new LambdaRuntime('python3.6', { supportsInlineCode: true }) as InlinableLambdaRuntime;
+    public static readonly DotNetCore1 = new LambdaRuntime('dotnetcore1.0');
+    public static readonly DotNetCore2 = new LambdaRuntime('dotnetcore2.0');
+    public static readonly Go1x = new LambdaRuntime('go1.x');
+
+    /** The name of this runtime, as expected by the Lambda resource. */
+    public readonly name: string;
+    /** Whether the ``ZipFile`` (aka inline code) property can be used with this runtime. */
+    public readonly supportsInlineCode: boolean;
+
+    constructor(name: string, props: LambdaRuntimeProps = {}) {
+        this.name = name;
+        this.supportsInlineCode = !!props.supportsInlineCode;
+    }
+
+    public toString(): string {
+        return this.name;
+    }
 }
+
+/**
+ * A ``LambdaRuntime`` that can be used in conjunction with the ``ZipFile``
+ * property of the ``AWS::Lambda::Function`` resource.
+ */
+export interface InlinableLambdaRuntime {
+    readonly name: string;
+    readonly supportsInlineCode: true;
+}
+
+/**
+ * A ``LambdaRuntime`` that can be used for inlining JavaScript.
+ */
+// tslint:disable-next-line:no-empty-interface this is a marker to allow type-safe declarations
+export interface InlinableJavascriptLambdaRuntime extends InlinableLambdaRuntime {}


### PR DESCRIPTION
Also make it the defaul for the `InlineJavaScriptLambda`.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
