### PR TITLE
Missing .npmignore in @aws-cdk/cloudwatch

### DIFF
--- a/packages/@aws-cdk/cloudwatch/.npmignore
+++ b/packages/@aws-cdk/cloudwatch/.npmignore
@@ -1,0 +1,6 @@
+# Don't include original .ts files when doing `npm pack`
+*.ts
+!*.d.ts
+coverage
+.nyc_output
+*.tgz


### PR DESCRIPTION
This caused a runtime error of `Cannot find module './alarm'`
only to be discovered post-installation of the bundle, which is
extremely late in the game.

Related to #217
