### PR TITLE
fix(@aws-cdk/assert): make expect() use a feature test on the input c…

### DIFF
--- a/packages/@aws-cdk/assert/lib/expect.ts
+++ b/packages/@aws-cdk/assert/lib/expect.ts
@@ -3,11 +3,17 @@ import * as api from '@aws-cdk/cx-api';
 import { StackInspector } from './inspector';
 
 export function expect(stack: api.SynthesizedStack | Stack): StackInspector {
-    const sstack: api.SynthesizedStack = stack instanceof Stack ? {
+    // Can't use 'instanceof' here, that breaks if we have multiple copies
+    // of this library.
+    const sstack: api.SynthesizedStack = isStackClassInstance(stack) ? {
         name: 'test',
         template: stack.toCloudFormation(),
         metadata: {}
     } : stack;
 
     return new StackInspector(sstack);
+}
+
+function isStackClassInstance(x: api.SynthesizedStack | Stack): x is Stack {
+    return 'toCloudFormation' in x;
 }


### PR DESCRIPTION
…lass

The 'instanceof' test is unreliable if for whatever reason you happen to
have different versions of @aws-cdk/core on the search path, because
the prototypes might be different.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
