### PR TITLE
Remove cached com.amazonaws maven packages from ~/.m2

### DIFF
--- a/packages/aws-cdk-java/generate.sh
+++ b/packages/aws-cdk-java/generate.sh
@@ -5,6 +5,7 @@ mkdir -p project
 
 # deploy jsii-runtime to the local maven repo so it will be discoverable
 jsii_runtime_repo=$(node -e "console.log(path.join(path.dirname(require.resolve('jsii-java-runtime/package.json')), 'maven-repo'))")
+rm -fr ~/.m2/repository/com/amazonaws
 mkdir -p ~/.m2/repository
 rsync -av ${jsii_runtime_repo}/ ~/.m2/repository/
 


### PR DESCRIPTION
To ensure a fresh load during build. It's not an ideal solution,
which we will change after we release jsii.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
