### PR TITLE
Enable incremental builds for documentation

### DIFF
--- a/packages/@aws-cdk/core/lib/cloudformation/arn.ts
+++ b/packages/@aws-cdk/core/lib/cloudformation/arn.ts
@@ -47,7 +47,7 @@ export class Arn extends Token {
      * components and `resourceName` will be set to the rest of the string.
      *
      * @returns an ArnComponents object which allows access to the various
-     * components of the ARN.
+     *          components of the ARN.
      */
     public static parse(arn: string): ArnComponents {
         const components = arn.split(':') as Array<string | undefined>;

--- a/packages/aws-cdk-docs/build-docs.sh
+++ b/packages/aws-cdk-docs/build-docs.sh
@@ -2,14 +2,16 @@
 set -euo pipefail
 
 PYTHON_DEPS="$PWD/python-deps"
-mkdir -p "${PYTHON_DEPS}"
-
-export PYTHONPATH=${PYTHON_DEPS}/lib/python3.6/site-packages:${PYTHON_DEPS}/lib/python3.7/site-packages
-export PATH=${PYTHON_DEPS}/bin:$PATH
 
 #----------------------------------------------------------------------
 # Install python depednencies to a local tree
-pip install --ignore-installed --install-option="--prefix=${PYTHON_DEPS}" -r requirements.txt
+if [ ! -d ${PYTHON_DEPS} ]; then
+    mkdir -p "${PYTHON_DEPS}"
+    pip install --ignore-installed --install-option="--prefix=${PYTHON_DEPS}" -r requirements.txt
+fi
+
+export PYTHONPATH=${PYTHON_DEPS}/lib/python3.6/site-packages:${PYTHON_DEPS}/lib/python3.7/site-packages
+export PATH=${PYTHON_DEPS}/bin:$PATH
 
 #----------------------------------------------------------------------
 # CONFIG
@@ -31,7 +33,6 @@ fi
 # DO THE WORK
 
 echo "Staging Sphinx doc site under ${staging}"
-rm -fr ${staging}
 mkdir -p ${staging}
 rsync -av src/ ${staging}
 


### PR DESCRIPTION
* Only perform `pip install` if the `python-deps` folder doesn't exist yet
* Stop removing `dist/staging` so incremental generation is performed

*Note:* this works even without the related change in `jsii-pacmak` (awslabs/jsii#71), except the benefits will be lesser, since the docs under `refs` will always be re-generated, instead of only when the assembly's changed.