### PR TITLE
cdk-cfnspec: Further improvements to update script

### DIFF
--- a/packages/@aws-cdk/cdk-cfnspec/build-tools/spec-diff.ts
+++ b/packages/@aws-cdk/cdk-cfnspec/build-tools/spec-diff.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs-extra';
+import * as util from 'util';
+
+// tslint:disable-next-line:no-var-requires
+const jsonDiff = require('json-diff').diff;
+
+function line(fmt: string = '', ...param: any[]) {
+    process.stdout.write(util.format(fmt, ...param));
+    process.stdout.write('\n');
+}
+
+async function main() {
+    const title = process.argv[2];
+    const oldSpecFile = process.argv[3];
+    const newSpecFile = process.argv[4];
+
+    const newSpec = await fs.readJSON(newSpecFile);
+    const oldSpec = await fs.readJSON(oldSpecFile);
+
+    const out = jsonDiff(oldSpec, newSpec);
+
+    if (!out) {
+        return; // no diff
+    }
+
+    const resourceTypeAdditions = new Set<string>();
+    const propertyChanges = new Array<string>();
+    const propertyTypeChanges = new Array<string>();
+
+    for (const key of Object.keys(out.ResourceTypes || {})) {
+        classifyResourceTypeUpdate(key, out.ResourceTypes[key]);
+    }
+
+    for (const key of Object.keys(out.PropertyTypes || {})) {
+        classifyPropertyTypeUpdate(key, out.PropertyTypes[key]);
+    }
+
+    line(`# ${title} v${newSpec.ResourceSpecificationVersion}`);
+    line();
+
+    line('## New Resource Types');
+    line();
+    resourceTypeAdditions.forEach(type => line(`* ${type}`));
+    line();
+
+    line('## Property Changes');
+    line();
+    propertyChanges.forEach(x => line(x));
+    line();
+
+    line('## Property Type Changes');
+    line();
+    propertyTypeChanges.forEach(x => line(x));
+
+    function classifyResourceTypeUpdate(resourceType: string, update: any) {
+        const added = isAdded(resourceType);
+        if (added) {
+            resourceTypeAdditions.add(added);
+            return;
+        }
+
+        const deleted = isDeleted(resourceType);
+        if (deleted) {
+            throw new Error('Something really bad happened. Resource types should never be deleted: ' + deleted);
+        }
+
+        if (Object.keys(update).length !== 1 && Object.keys(update)[0] === 'Properties') {
+            throw new Error('Unexpected update to a resource type. Expecting only "Properties" to change: ' + resourceType);
+        }
+
+        for (const prop of Object.keys(update.Properties)) {
+            describeChanges(resourceType, prop, update.Properties[prop]).forEach(change => {
+                propertyChanges.push(change);
+            });
+        }
+    }
+
+    function classifyPropertyTypeUpdate(propertyType: string, update: any) {
+        const added = isAdded(propertyType);
+        if (added) {
+            const resourceType = added.split('.')[0];
+            if (resourceTypeAdditions.has(resourceType)) {
+                return; // skipping property for added resource types
+            }
+
+            propertyTypeChanges.push(`* ${added} (__added__)`);
+            return;
+        }
+
+        if (Object.keys(update).length !== 1 && Object.keys(update)[0] === 'Properties') {
+            throw new Error('Unexpected update to a resource type. Expecting only "Properties" to change: ' + propertyType);
+        }
+
+        for (const prop of Object.keys(update.Properties)) {
+            describeChanges(propertyType, prop, update.Properties[prop]).forEach(change => {
+                propertyTypeChanges.push(change);
+            });
+        }
+    }
+
+    function isDeleted(key: string) {
+        return isSuffix(key, '__deleted');
+    }
+
+    function isAdded(key: string) {
+        return isSuffix(key, '__added');
+    }
+
+    function isSuffix(key: string, suffix: string) {
+        const index = key.indexOf(suffix);
+        return index === -1 ? undefined : key.substr(0, index);
+    }
+
+    function describeChanges(namespace: string, prefix: string, update: any) {
+        const changes = new Array<string>();
+
+        const added = isAdded(prefix);
+        if (added) {
+            changes.push(`* ${namespace} ${added} (__added__)`);
+            return changes;
+        }
+
+        const deleted = isDeleted(prefix);
+        if (deleted) {
+            changes.push(`* ${namespace} ${deleted} (__deleted__)`);
+            return changes;
+        }
+
+        if (typeof(update) !== 'object') {
+            throw new Error(`Unexpected change for ${namespace}.${prefix} ${JSON.stringify(update)}`);
+            return changes;
+        }
+
+        if ('__old' in update && '__new' in update) {
+            changes.push(`* ${namespace} ${prefix} (__changed__)`);
+            changes.push(`  * Old: ${update.__old}`);
+            changes.push(`  * New: ${update.__new}`);
+            return changes;
+        }
+
+        for (const key of Object.keys(update)) {
+            for (const change of describeChanges(namespace, `${prefix}.${key}`, update[key])) {
+                changes.push(change);
+            }
+        }
+
+        return changes;
+    }
+}
+
+main().catch(e => {
+    process.stderr.write(e.toString());
+    process.stderr.write('\n');
+    process.exit(1);
+});

--- a/packages/@aws-cdk/cdk-cfnspec/build-tools/update.sh
+++ b/packages/@aws-cdk/cdk-cfnspec/build-tools/update.sh
@@ -7,15 +7,49 @@
 
 set -euo pipefail
 
-src="spec-source"
+function update-spec() {
+    local title=$1
+    local url=$2
+    local target=$3
+    local gunzip=$4
 
-rm -f ${src}/000_CloudFormationResourceSpecification.json
-curl -L "https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json" \
-    | gunzip - > ${src}/000_CloudFormationResourceSpecification.json
+    local intermediate="$(mktemp -d)/new.json"
 
-rm -fr ${src}/000_sam.spec.json
-curl -L "https://raw.githubusercontent.com/awslabs/goformation/master/generate/sam-2016-10-31.json" \
-    > ${src}/000_sam.spec.json
+    echo >&2 "Downloading from ${url}..."
+    if ${gunzip}; then
+        curl -sL "${url}" | gunzip - > ${intermediate}
+    else
+        curl -sL "${url}" > ${intermediate}
+    fi
 
-# sort hash keys to help identify *real* changes
-sort-json ${src}/*.json
+    echo >&2 "Sorting..."
+    sort-json ${intermediate}
+
+    echo >&2 "Updaging CHANGELOG.md..."
+    touch CHANGELOG.md
+    mv CHANGELOG.md CHANGELOG.md.bak
+    rm -f CHANGELOG.md
+    node build-tools/spec-diff.js "${title}" "${target}" "${intermediate}" > CHANGELOG.md
+    echo "" >> CHANGELOG.md
+    cat CHANGELOG.md.bak >> CHANGELOG.md
+    rm CHANGELOG.md.bak
+
+    echo >&2 "Updarting source spec..."
+    rm -f ${target}
+    cp ${intermediate} ${target}
+}
+
+update-spec \
+    "CloudFormation Resource Specification" \
+    "https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json" \
+    spec-source/000_CloudFormationResourceSpecification.json \
+    true
+
+update-spec \
+    "Serverless Application Model (SAM) Resource Specification" \
+    "https://raw.githubusercontent.com/awslabs/goformation/master/generate/sam-2016-10-31.json" \
+    spec-source/000_sam.spec.json \
+    false
+
+echo >&2 "Creating missing AWS construct libraries for new resource types..."
+(cd ../../.. && ./create-missing-libraries.sh)

--- a/packages/@aws-cdk/cdk-cfnspec/package-lock.json
+++ b/packages/@aws-cdk/cdk-cfnspec/package-lock.json
@@ -33,6 +33,15 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
+		"cli-color": {
+			"version": "0.1.7",
+			"resolved": "http://localhost:6000/cli-color/-/cli-color-0.1.7.tgz",
+			"integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "0.8.x"
+			}
+		},
 		"crypt": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -54,6 +63,30 @@
 			"version": "2.1.0",
 			"resolved": "http://localhost:6000/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"difflib": {
+			"version": "0.2.4",
+			"resolved": "http://localhost:6000/difflib/-/difflib-0.2.4.tgz",
+			"integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+			"dev": true,
+			"requires": {
+				"heap": ">= 0.2.0"
+			}
+		},
+		"dreamopt": {
+			"version": "0.6.0",
+			"resolved": "http://localhost:6000/dreamopt/-/dreamopt-0.6.0.tgz",
+			"integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+			"dev": true,
+			"requires": {
+				"wordwrap": ">=0.0.2"
+			}
+		},
+		"es5-ext": {
+			"version": "0.8.2",
+			"resolved": "http://localhost:6000/es5-ext/-/es5-ext-0.8.2.tgz",
+			"integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
 			"dev": true
 		},
 		"fast-json-patch": {
@@ -82,10 +115,27 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
+		"heap": {
+			"version": "0.2.6",
+			"resolved": "http://localhost:6000/heap/-/heap-0.2.6.tgz",
+			"integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+			"dev": true
+		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"json-diff": {
+			"version": "0.5.2",
+			"resolved": "http://localhost:6000/json-diff/-/json-diff-0.5.2.tgz",
+			"integrity": "sha512-N7oapTQdD4rLMUtA7d1HATCPY/BpHuSNL1mhvIuoS0u5NideDvyR+gB/ntXB7ejFz/LM0XzPLNUJQcC68n5sBw==",
+			"dev": true,
+			"requires": {
+				"cli-color": "~0.1.6",
+				"difflib": "~0.2.1",
+				"dreamopt": "~0.6.0"
+			}
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -127,6 +177,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "http://localhost:6000/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		}
 	}

--- a/packages/@aws-cdk/cdk-cfnspec/package.json
+++ b/packages/@aws-cdk/cdk-cfnspec/package.json
@@ -16,6 +16,7 @@
         "@types/md5": "^2.1.32",
         "fast-json-patch": "^2.0.6",
         "fs-extra": "^4.0.3",
+        "json-diff": "^0.5.2",
         "sort-json": "^2.0.0"
     },
     "dependencies": {


### PR DESCRIPTION
* Auto-create a CHANGELOG entry which describes the updates to the spec (which resources were added, properties, property types, etc).
* Invoke `create-missing-libraries.sh` after each update to initialize AWS construct libraries for new resource types.

Here's an [example] for a changelog entry.

Related to #255

[example]: https://github.com/awslabs/aws-cdk/blob/a7fa135e7b9ab6332cc7b9e9479bbc4ce4f5729f/packages/%40aws-cdk/cdk-cfnspec/CHANGELOG.md