### PR TITLE
BREAKING: Move CodePipeline Lambda action into @aws-cdk/lambda

### DIFF
--- a/packages/@aws-cdk/codepipeline/test/test.action.ts
+++ b/packages/@aws-cdk/codepipeline/test/test.action.ts
@@ -1,8 +1,6 @@
-import { expect, haveResource } from '@aws-cdk/assert';
 import { Stack } from '@aws-cdk/core';
-import { Lambda, LambdaInlineCode, LambdaRuntime } from '@aws-cdk/lambda';
 import { Test } from 'nodeunit';
-import { Action, ActionArtifactBounds, ActionCategory, Artifact, InvokeLambdaAction, Pipeline, Stage } from '../lib';
+import { Action, ActionArtifactBounds, ActionCategory, Artifact, Pipeline, Stage } from '../lib';
 import { validateArtifactBounds, validateSourceAction } from '../lib/validation';
 
 // tslint:disable:object-literal-key-quotes
@@ -88,87 +86,6 @@ export = {
         });
         test.done();
     },
-
-    'InvokeLambdaAction can be used to invoke lambda functions from a pipeline'(test: Test) {
-        const stack = new Stack();
-
-        const lambda = new Lambda(stack, 'Function', {
-            code: new LambdaInlineCode('bla'),
-            handler: 'index.handler',
-            runtime: LambdaRuntime.NodeJS43,
-        });
-
-        const pipeline = new Pipeline(stack, 'Pipeline');
-
-        new InvokeLambdaAction(new Stage(pipeline, 'Stage'), 'InvokeAction', {
-            lambda,
-            userParameters: 'foo-bar/42'
-        });
-
-        expect(stack).to(haveResource('AWS::CodePipeline::Pipeline', {
-            "ArtifactStore": {
-              "Location": {
-                "Ref": "PipelineArtifactsBucket22248F97"
-              },
-              "Type": "S3"
-            },
-            "RoleArn": {
-              "Fn::GetAtt": [
-                "PipelineRoleD68726F7",
-                "Arn"
-              ]
-            },
-            "Stages": [
-              {
-                "Actions": [
-                  {
-                    "ActionTypeId": {
-                      "Category": "Invoke",
-                      "Owner": "AWS",
-                      "Provider": "Lambda",
-                      "Version": "1"
-                    },
-                    "Configuration": {
-                      "FunctionName": {
-                        "Ref": "Function76856677"
-                      },
-                      "UserParameters": "foo-bar/42"
-                    },
-                    "InputArtifacts": [],
-                    "Name": "InvokeAction",
-                    "OutputArtifacts": [],
-                    "RunOrder": 1
-                  }
-                ],
-                "Name": "Stage"
-              }
-            ]
-        }));
-
-        expect(stack).to(haveResource('AWS::IAM::Policy', {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "codepipeline:PutJobSuccessResult",
-                    "codepipeline:PutJobFailureResult"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*"
-                }
-              ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "FunctionServiceRoleDefaultPolicy2F49994A",
-            "Roles": [
-              {
-                "Ref": "FunctionServiceRole675BB04A"
-              }
-            ]
-        }));
-
-        test.done();
-    }
 };
 
 function boundsValidationResult(numberOfArtifacts: number, min: number, max: number): string[] {

--- a/packages/@aws-cdk/lambda/lib/index.ts
+++ b/packages/@aws-cdk/lambda/lib/index.ts
@@ -6,6 +6,7 @@ export * from './runtime';
 export * from './code';
 export * from './inline';
 export * from './lambda-version';
+export * from './pipeline-actions';
 
 // AWS::Lambda CloudFormation Resources:
 export * from './lambda.generated';

--- a/packages/@aws-cdk/lambda/lib/pipeline-actions.ts
+++ b/packages/@aws-cdk/lambda/lib/pipeline-actions.ts
@@ -1,0 +1,87 @@
+import { Action, ActionCategory, Artifact, Stage } from '@aws-cdk/codepipeline';
+import { PolicyStatement } from '@aws-cdk/core';
+import { LambdaRef } from './lambda-ref';
+
+export interface PipelineInvokeActionProps {
+    /**
+     * The lambda function to invoke.
+     */
+    lambda: LambdaRef;
+
+    /**
+     * String to be used in the event data parameter passed to the Lambda
+     * function
+     *
+     * See an example JSON event in the CodePipeline documentation.
+     *
+     * https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-invoke-lambda-function.html#actions-invoke-lambda-function-json-event-example
+     */
+    userParameters?: any;
+
+    /**
+     * Adds the "codepipeline:PutJobSuccessResult" and
+     * "codepipeline:PutJobFailureResult" for '*' resource to the Lambda
+     * execution role policy.
+     *
+     * NOTE: the reason we can't add the specific pipeline ARN as a resource is
+     * to avoid a cyclic dependency between the pipeline and the Lambda function
+     * (the pipeline references) the Lambda and the Lambda needs permissions on
+     * the pipeline.
+     *
+     * @see
+     * https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-invoke-lambda-function.html#actions-invoke-lambda-function-create-function
+     *
+     * @default true
+     */
+    addPutJobResultPolicy?: boolean;
+}
+
+/**
+ * @link https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-invoke-lambda-function.html
+ */
+export class PipelineInvokeAction extends Action {
+    constructor(parent: Stage, name: string, props: PipelineInvokeActionProps) {
+        super(parent, name, {
+            category: ActionCategory.Invoke,
+            provider: 'Lambda',
+            artifactBounds: {
+                minInputs: 0,
+                maxInputs: 5,
+                minOutputs: 0,
+                maxOutputs: 5
+            },
+            configuration: {
+                FunctionName: props.lambda.functionName,
+                UserParameters: props.userParameters
+            }
+        });
+
+        // allow pipeline to list functions
+        parent.pipeline.addToRolePolicy(new PolicyStatement()
+            .addAction('lambda:ListFunctions')
+            .addResource('*'));
+
+        // allow pipeline to invoke this lambda functionn
+        parent.pipeline.addToRolePolicy(new PolicyStatement()
+            .addAction('lambda:InvokeFunction')
+            .addResource(props.lambda.functionArn));
+
+        // allow lambda to put job results for this pipeline.
+        const addToPolicy = props.addPutJobResultPolicy !== undefined ? props.addPutJobResultPolicy : true;
+        if (addToPolicy) {
+            props.lambda.addToRolePolicy(new PolicyStatement()
+                .addResource('*') // to avoid cycles (see docs)
+                .addAction('codepipeline:PutJobSuccessResult')
+                .addAction('codepipeline:PutJobFailureResult'));
+        }
+    }
+
+    /**
+     * Add an input artifact
+     * @param artifact
+     */
+    public addInputArtifact(artifact: Artifact): PipelineInvokeAction {
+        super.addInputArtifact(artifact);
+        return this;
+    }
+}

--- a/packages/@aws-cdk/lambda/test/test.pipeline-actions.ts
+++ b/packages/@aws-cdk/lambda/test/test.pipeline-actions.ts
@@ -1,0 +1,91 @@
+import { expect, haveResource } from '@aws-cdk/assert';
+import * as codepipeline from '@aws-cdk/codepipeline';
+import { Stack } from '@aws-cdk/core';
+import { Test } from 'nodeunit';
+import { Lambda, LambdaInlineCode, LambdaRuntime, PipelineInvokeAction } from '../lib';
+
+// tslint:disable:object-literal-key-quotes
+
+export = {
+
+    'InvokeLambdaAction can be used to invoke lambda functions from a pipeline'(test: Test) {
+        const stack = new Stack();
+
+        const lambda = new Lambda(stack, 'Function', {
+            code: new LambdaInlineCode('bla'),
+            handler: 'index.handler',
+            runtime: LambdaRuntime.NodeJS43,
+        });
+
+        const pipeline = new codepipeline.Pipeline(stack, 'Pipeline');
+
+        new PipelineInvokeAction(new codepipeline.Stage(pipeline, 'Stage'), 'InvokeAction', {
+            lambda,
+            userParameters: 'foo-bar/42'
+        });
+
+        expect(stack).to(haveResource('AWS::CodePipeline::Pipeline', {
+            "ArtifactStore": {
+              "Location": {
+                "Ref": "PipelineArtifactsBucket22248F97"
+              },
+              "Type": "S3"
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "PipelineRoleD68726F7",
+                "Arn"
+              ]
+            },
+            "Stages": [
+              {
+                "Actions": [
+                  {
+                    "ActionTypeId": {
+                      "Category": "Invoke",
+                      "Owner": "AWS",
+                      "Provider": "Lambda",
+                      "Version": "1"
+                    },
+                    "Configuration": {
+                      "FunctionName": {
+                        "Ref": "Function76856677"
+                      },
+                      "UserParameters": "foo-bar/42"
+                    },
+                    "InputArtifacts": [],
+                    "Name": "InvokeAction",
+                    "OutputArtifacts": [],
+                    "RunOrder": 1
+                  }
+                ],
+                "Name": "Stage"
+              }
+            ]
+        }));
+
+        expect(stack).to(haveResource('AWS::IAM::Policy', {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "codepipeline:PutJobSuccessResult",
+                    "codepipeline:PutJobFailureResult"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "FunctionServiceRoleDefaultPolicy2F49994A",
+            "Roles": [
+              {
+                "Ref": "FunctionServiceRole675BB04A"
+              }
+            ]
+        }));
+
+        test.done();
+    }
+};


### PR DESCRIPTION
This is part of a broad change to move the CodePipeline action
types into the module of the service that each action works with.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
