### PR TITLE
cdk-integ: Improvements

### DIFF
--- a/tools/cdk-integ-tools/README.md
+++ b/tools/cdk-integ-tools/README.md
@@ -1,9 +1,39 @@
-CDK Build Tools
-================
+# Integration Test Tools
 
-These scripts wrap the common operations that need to happen
-during a CDK build, in a common place so it's easy to change
-the build for all packages.
+A testing tool for CDK constructs integration testing.
 
-Written in TypeScript instead of shell so that they can work
-on Windows with no extra effort.
+Integration tests are simple CDK apps under `test/integ.*.js`. Each one defines
+a single stack.
+
+There are two modes of operation:
+
+1. `cdk-integ`: Executed by developers against their developer account. This
+   command actually deploys the stack and stores a local copy of the synthesized
+   CloudFormation template under `<test>.expected.json`.
+2. `cdk-integ-assert`: Executed during build (CI/CD). It will only synthesize
+   the template and then compare the result to the stored copy. If they differ,
+   the test will fail the build.
+
+This approach pragmatically ensures that unexpected changes are not introduced
+without a developer actually deploying a stack and verifying them.
+
+## cdk-integ
+
+Usage:
+
+    cdk-integ [TEST...] [--no-clean] [--verbose]
+
+Will deploy test stacks from `test/integ.*.js` and store the synthesized output
+under `test/integ.*.expected.json`.
+
+* Optionally, you can specify a list of test `integ.*.js` files (they must be
+  under `test/`) to execute only a subset of the tests.
+* Use `--no-clean` to skip the clean up of the stack. This is useful in case you
+  wish to manually examine the stack to ensure that the result is what you
+  expected.
+* Use `--verbose` to print verbose output from `cdk` executions.
+
+## cdk-integ-assert
+
+No arguments - will synthesize all `test/integ.*.js` apps and compare them to
+their `.expected.json` counterparts.

--- a/tools/cdk-integ-tools/bin/cdk-integ-assert.ts
+++ b/tools/cdk-integ-tools/bin/cdk-integ-assert.ts
@@ -6,7 +6,7 @@ import { IntegrationTests, STATIC_TEST_CONTEXT } from '../lib/integ-helpers';
 // tslint:disable:no-console
 
 async function main() {
-    const tests = await new IntegrationTests('test').fromCliArgs(process.argv);
+    const tests = await new IntegrationTests('test').fromCliArgs(); // always assert all tests
     const failures: string[] = [];
 
     for (const test of tests) {
@@ -17,7 +17,7 @@ async function main() {
         }
 
         const expected = await test.readExpected();
-        const actual = await test.invoke(['--json', 'synth'], true, STATIC_TEST_CONTEXT);
+        const actual = await test.invoke(['--json', 'synth'], { json: true, context: STATIC_TEST_CONTEXT });
 
         const diff = diffTemplate(expected, actual);
 

--- a/tools/cdk-integ-tools/bin/cdk-integ.ts
+++ b/tools/cdk-integ-tools/bin/cdk-integ.ts
@@ -1,27 +1,45 @@
 #!/usr/bin/env node
 // Exercise all integ stacks and if they deploy, update the expected synth files
+import yargs = require('yargs');
 import { IntegrationTests, STATIC_TEST_CONTEXT } from '../lib/integ-helpers';
 
 // tslint:disable:no-console
 
 async function main() {
-    const tests = await new IntegrationTests('test').fromCliArgs(process.argv);
+    const argv = yargs
+        .usage('Usage: cdk-integ [TEST...]')
+            .option('clean', { type: 'boolean', default: true, desc: 'Skipps stack clean up after test is completed (use --no-clean to negate)' })
+            .option('verbose', { type: 'boolean', default: false, alias: 'v', desc: 'Verbose logs' })
+            .argv;
+
+    const tests = await new IntegrationTests('test').fromCliArgs(argv._);
 
     for (const test of tests) {
-
         console.error(`Trying to deploy ${test.name}`);
 
+        // injects "--verbose" to the command line of "cdk" if we are in verbose mode
+        const makeArgs = (...args: string[]) => !argv.verbose ? args : [ '--verbose', ...args ];
+
         try {
-            await test.invoke(['deploy']); // Note: no context, so use default user settings!
+            await test.invoke(makeArgs('deploy'), { verbose: argv.verbose }); // Note: no context, so use default user settings!
 
             console.error(`Success! Writing out reference synth.`);
 
             // If this all worked, write the new expectation file
-            const actual = await test.invoke(['--json', 'synth'], true, STATIC_TEST_CONTEXT);
+            const actual = await test.invoke(makeArgs('--json', 'synth'), {
+                json: true,
+                context: STATIC_TEST_CONTEXT,
+                verbose: argv.verbose
+            });
+
             await test.writeExpected(actual);
         } finally {
-            console.error(`Cleaning up.`);
-            await test.invoke(['destroy', '--force']);
+            if (argv.clean) {
+                console.error(`Cleaning up.`);
+                await test.invoke(['destroy', '--force']);
+            } else {
+                console.error('Skipping clean up (--no-clean).');
+            }
         }
     }
 }

--- a/tools/cdk-integ-tools/chmod.bat
+++ b/tools/cdk-integ-tools/chmod.bat
@@ -1,2 +1,0 @@
-@rem Just here so that running 'chmod' doesn't fail on Windows.
-@rem Doesn't actually do anything, because it doesn't need to.


### PR DESCRIPTION
* `--verbose`: emits verbose output from "cdk"
* `--no-clean`: skips stack cleanup
* README

Fixes #40
