### PR TITLE
Fix inconsistencies between types and their ancestors.

### DIFF
--- a/packages/@aws-cdk/aws-codepipeline/lib/actions.ts
+++ b/packages/@aws-cdk/aws-codepipeline/lib/actions.ts
@@ -514,7 +514,7 @@ export class InvokeLambdaAction extends Action {
      * Add an input artifact
      * @param artifact
      */
-    public addInputArtifact(artifact: Artifact): InvokeLambdaAction {
+    protected addInputArtifact(artifact: Artifact): Action {
         super.addInputArtifact(artifact);
         return this;
     }

--- a/packages/@aws-cdk/aws-events/lib/rule.ts
+++ b/packages/@aws-cdk/aws-events/lib/rule.ts
@@ -64,7 +64,7 @@ export interface EventRuleProps {
  * Defines a CloudWatch Event Rule in this stack.
  */
 export class EventRule extends EventRuleRef {
-    public ruleArn: RuleArn;
+    public readonly ruleArn: RuleArn;
 
     private readonly targets = new Array<cloudformation.RuleResource.TargetProperty>();
     private readonly eventPattern: EventPattern = { };

--- a/packages/@aws-cdk/aws-lambda/lib/alias.ts
+++ b/packages/@aws-cdk/aws-lambda/lib/alias.ts
@@ -73,7 +73,7 @@ export class Alias extends LambdaRef {
      */
     public readonly role?: iam.Role | undefined;
 
-    protected canCreatePermissions: boolean = true; // Not used anyway
+    protected readonly canCreatePermissions: boolean = true; // Not used anyway
 
     /**
      * The actual Lambda function object that this Alias is pointing to

--- a/packages/@aws-cdk/aws-sns/lib/topic.ts
+++ b/packages/@aws-cdk/aws-sns/lib/topic.ts
@@ -32,7 +32,7 @@ export class Topic extends TopicRef {
     public readonly topicArn: TopicArn;
     public readonly topicName: TopicName;
 
-    protected autoCreatePolicy: boolean = true;
+    protected readonly autoCreatePolicy: boolean = true;
 
     constructor(parent: Construct, name: string, props: TopicProps = {}) {
         super(parent, name);


### PR DESCRIPTION
Fix the following inconsistencies, all of which cause invalid `.NET` code to be generated:

1. Inconsistent access modifier (in `.NET`, they must match exactly)
2. Inconsistent return type (in `.NET`, they must match exactly)
3. Inconsistent accessors (in `.NET`, a override of a `get`-only property must not have a setter)