### PR TITLE
codebuild: Metrics

### DIFF
--- a/packages/@aws-cdk/aws-codebuild/lib/project.ts
+++ b/packages/@aws-cdk/aws-codebuild/lib/project.ts
@@ -1,3 +1,4 @@
+import cloudwatch = require('@aws-cdk/aws-cloudwatch');
 import events = require('@aws-cdk/aws-events');
 import iam = require('@aws-cdk/aws-iam');
 import kms = require('@aws-cdk/aws-kms');
@@ -169,6 +170,85 @@ export abstract class BuildProjectRef extends cdk.Construct implements events.IE
             }
         });
         return rule;
+    }
+
+    /**
+     * @returns a CloudWatch metric associated with this build project.
+     * @param metricName The name of the metric
+     * @param props Customization properties
+     */
+    public metric(metricName: string, props: cloudwatch.MetricCustomization) {
+        return new cloudwatch.Metric({
+            namespace: 'AWS/CodeBuild',
+            metricName,
+            dimensions: { ProjectName: this.projectName },
+            ...props
+        });
+    }
+
+    /**
+     * Measures the number of builds triggered.
+     *
+     * Units: Count
+     *
+     * Valid CloudWatch statistics: Sum
+     *
+     * @default sum over 5 minutes
+     */
+    public metricBuilds(props?: cloudwatch.MetricCustomization) {
+        return this.metric('Builds', {
+            statistic: 'sum',
+            ...props,
+        });
+    }
+
+    /**
+     * Measures the duration of all builds over time.
+     *
+     * Units: Seconds
+     *
+     * Valid CloudWatch statistics: Average (recommended), Maximum, Minimum
+     *
+     * @default average over 5 minutes
+     */
+    public metricDuration(props?: cloudwatch.MetricCustomization) {
+        return this.metric('Duration', {
+            statistic: 'avg',
+            ...props
+        });
+    }
+
+    /**
+     * Measures the number of successful builds.
+     *
+     * Units: Count
+     *
+     * Valid CloudWatch statistics: Sum
+     *
+     * @default sum over 5 minutes
+     */
+    public metricSucceededBuilds(props?: cloudwatch.MetricCustomization) {
+        return this.metric('SucceededBuilds', {
+            statistic: 'sum',
+            ...props,
+        });
+    }
+
+    /**
+     * Measures the number of builds that failed because of client error or
+     * because of a timeout.
+     *
+     * Units: Count
+     *
+     * Valid CloudWatch statistics: Sum
+     *
+     * @default sum over 5 minutes
+     */
+    public metricFailedBuilds(props?: cloudwatch.MetricCustomization) {
+        return this.metric('FailedBuilds', {
+            statistic: 'sum',
+            ...props,
+        });
     }
 
     /**

--- a/packages/@aws-cdk/aws-codebuild/package.json
+++ b/packages/@aws-cdk/aws-codebuild/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@aws-cdk/aws-codecommit": "^0.7.3-beta",
     "@aws-cdk/aws-codepipeline": "^0.7.3-beta",
+    "@aws-cdk/aws-cloudwatch": "^0.7.3-beta",
     "@aws-cdk/aws-events": "^0.7.3-beta",
     "@aws-cdk/aws-iam": "^0.7.3-beta",
     "@aws-cdk/aws-kms": "^0.7.3-beta",

--- a/packages/@aws-cdk/aws-codebuild/test/test.codebuild.ts
+++ b/packages/@aws-cdk/aws-codebuild/test/test.codebuild.ts
@@ -830,5 +830,27 @@ export = {
         }));
 
         test.done();
+    },
+
+    '.metricXxx() methods can be used to obtain Metrics for CodeBuild projects'(test: Test) {
+        const stack = new cdk.Stack();
+
+        const project = new codebuild.BuildProject(stack, 'MyBuildProject', { source: new codebuild.CodePipelineSource() });
+
+        const metricBuilds = project.metricBuilds();
+        test.same(metricBuilds.dimensions!.ProjectName, project.projectName);
+        test.deepEqual(metricBuilds.namespace, 'AWS/CodeBuild');
+        test.deepEqual(metricBuilds.statistic, 'sum', 'default stat is SUM');
+        test.deepEqual(metricBuilds.metricName, 'Builds');
+
+        const metricDuration = project.metricDuration({ label: 'hello' });
+
+        test.deepEqual(metricDuration.metricName, 'Duration');
+        test.deepEqual(metricDuration.label, 'hello');
+
+        test.deepEqual(project.metricFailedBuilds().metricName, 'FailedBuilds');
+        test.deepEqual(project.metricSucceededBuilds().metricName, 'SucceededBuilds');
+
+        test.done();
     }
 };


### PR DESCRIPTION
Adds `metricXxx` methods to `BuildProjectRef` following our design
pattern for metrics.
