### PR TITLE
cdk-init bug fix

### DIFF
--- a/packages/@aws-cdk/cfnspec/build-tools/spec-diff.ts
+++ b/packages/@aws-cdk/cfnspec/build-tools/spec-diff.ts
@@ -128,7 +128,6 @@ async function main() {
 
         if (typeof(update) !== 'object') {
             throw new Error(`Unexpected change for ${namespace}.${prefix} ${JSON.stringify(update)}`);
-            return changes;
         }
 
         if ('__old' in update && '__new' in update) {

--- a/packages/aws-cdk/lib/init.ts
+++ b/packages/aws-cdk/lib/init.ts
@@ -104,7 +104,7 @@ export class InitTemplate {
 
     private expand(template: string, project: ProjectInfo) {
         const MATCH_VER_BUILD = /\+[a-f0-9]+$/; // Matches "+BUILD" in "x.y.z-beta+BUILD"
-        const cdkVersion = require('@aws-cdk/cdk/package.json').version.replace(MATCH_VER_BUILD, '');
+        const cdkVersion = require('../package.json').version.replace(MATCH_VER_BUILD, '');
         return template.replace(/%name%/g, project.name)
                        .replace(/%name\.camelCased%/g, camelCase(project.name))
                        .replace(/%name\.PascalCased%/g, camelCase(project.name, { pascalCase: true }))


### PR DESCRIPTION
Since the toolkit doesn't depend on the framework anymore, "cdk init" cannot obtain
the version of @aws-cdk/cdk when it expands
templates. Since our repo currently uses a
monolithic version number, we can just use
the toolkit's version for that.

Also, remove unreachable code from spec-diff.ts

Fixes #409
