### PR TITLE
Changes to bundle zip as a prep for publishing

### DIFF
--- a/bundle-beta.sh
+++ b/bundle-beta.sh
@@ -33,7 +33,7 @@ echo "Preparing local NPM registry"
 mkdir -p y/npm
 export Y_NPM_REPOSITORY="${staging}/y/npm"
 Y_NPM="${root}/tools/y-npm/bin/y-npm"
-for tarball in $(find ${root}/.local-npm -iname '*.tgz') $(find ${root}/pack -iname '*.tgz'); do
+for tarball in $(find ${root}/pack -iname '*.tgz'); do
     ${Y_NPM} publish ${tarball}
 done
 

--- a/packages/aws-cdk-docs/package.json
+++ b/packages/aws-cdk-docs/package.json
@@ -2,6 +2,7 @@
   "name": "aws-cdk-docs",
   "version": "0.7.4-beta",
   "description": "AWS CDK Documentation",
+  "private": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {


### PR DESCRIPTION
1. Remove jsii modules
2. Remove aws-cdk-docs

Here's the list of packages we have under y/npm:

```
@aws-cdk/applet-js
@aws-cdk/assert
@aws-cdk/assets
@aws-cdk/aws-apigateway
@aws-cdk/aws-applicationautoscaling
@aws-cdk/aws-appsync
@aws-cdk/aws-athena
@aws-cdk/aws-autoscaling
@aws-cdk/aws-autoscalingplans
@aws-cdk/aws-batch
@aws-cdk/aws-budgets
@aws-cdk/aws-certificatemanager
@aws-cdk/aws-cloud9
@aws-cdk/aws-cloudformation
@aws-cdk/aws-cloudfront
@aws-cdk/aws-cloudtrail
@aws-cdk/aws-cloudwatch
@aws-cdk/aws-codebuild
@aws-cdk/aws-codebuild-codepipeline
@aws-cdk/aws-codecommit
@aws-cdk/aws-codecommit-codepipeline
@aws-cdk/aws-codedeploy
@aws-cdk/aws-codepipeline
@aws-cdk/aws-cognito
@aws-cdk/aws-config
@aws-cdk/aws-custom-resources
@aws-cdk/aws-datapipeline
@aws-cdk/aws-dax
@aws-cdk/aws-directoryservice
@aws-cdk/aws-dms
@aws-cdk/aws-dynamodb
@aws-cdk/aws-ec2
@aws-cdk/aws-ecr
@aws-cdk/aws-ecs
@aws-cdk/aws-efs
@aws-cdk/aws-eks
@aws-cdk/aws-elasticache
@aws-cdk/aws-elasticbeanstalk
@aws-cdk/aws-elasticloadbalancing
@aws-cdk/aws-elasticloadbalancingv2
@aws-cdk/aws-elasticsearch
@aws-cdk/aws-emr
@aws-cdk/aws-events
@aws-cdk/aws-gamelift
@aws-cdk/aws-glue
@aws-cdk/aws-guardduty
@aws-cdk/aws-iam
@aws-cdk/aws-inspector
@aws-cdk/aws-iot
@aws-cdk/aws-kinesis
@aws-cdk/aws-kinesisanalytics
@aws-cdk/aws-kinesisfirehose
@aws-cdk/aws-kms
@aws-cdk/aws-lambda
@aws-cdk/aws-lambda-codepipeline
@aws-cdk/aws-logs
@aws-cdk/aws-neptune
@aws-cdk/aws-opsworks
@aws-cdk/aws-quickstarts
@aws-cdk/aws-rds
@aws-cdk/aws-redshift
@aws-cdk/aws-route53
@aws-cdk/aws-s3
@aws-cdk/aws-sdb
@aws-cdk/aws-serverless
@aws-cdk/aws-servicecatalog
@aws-cdk/aws-servicediscovery
@aws-cdk/aws-ses
@aws-cdk/aws-sns
@aws-cdk/aws-sqs
@aws-cdk/aws-ssm
@aws-cdk/aws-stepfunctions
@aws-cdk/aws-waf
@aws-cdk/aws-wafregional
@aws-cdk/aws-workspaces
@aws-cdk/cdk
@aws-cdk/cfnspec
@aws-cdk/cloudformation-diff
@aws-cdk/cx-api
@aws-cdk/rtv
@aws-cdk/util
aws-cdk
aws-cdk-docs
simple-resource-bundler
y-npm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) license.
