### PR TITLE
Correctly account for CDK::Metadata resource in `cdk diff``

### DIFF
--- a/packages/aws-cdk/bin/cdk.ts
+++ b/packages/aws-cdk/bin/cdk.ts
@@ -168,8 +168,8 @@ async function initCommandLine() {
     }
 
     async function main(command: string, args: any): Promise<number | string | {} | void> {
-        const toolkitStackName = completeConfig().get(['toolkitStackName']) || DEFAULT_TOOLKIT_STACK_NAME;
-        const trackVersions = completeConfig().get(['versionReporting']);
+        const toolkitStackName: string = completeConfig().get(['toolkitStackName']) || DEFAULT_TOOLKIT_STACK_NAME;
+        const trackVersions: boolean = completeConfig().get(['versionReporting']);
 
         args.STACKS = args.STACKS || [];
         args.ENVIRONMENTS = args.ENVIRONMENTS || [];
@@ -180,7 +180,7 @@ async function initCommandLine() {
                 return await cliList({ long: args.long });
 
             case 'diff':
-                return await diffStack(await findStack(args.STACK), args.template);
+                return await diffStack(await findStack(args.STACK), trackVersions, args.template);
 
             case 'bootstrap':
                 return await cliBootstrap(args.ENVIRONMENTS, toolkitStackName);


### PR DESCRIPTION
The arguments to the diff function were passed incorrectly, resulting in
the version tracking information not being forwarded correctly to
synthesizeTemplate.

Fixes #422

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) license.
