### PR TITLE
Also force the registry for the @aws-cdk scope.

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -59,6 +59,12 @@ if [ ${OLD_REGISTRY} != ${REGISTRY} ]; then
     npm config set registry ${REGISTRY}
     CLEANUP+=("echo '👈 Resetting NPM registry to ${OLD_REGISTRY}'" "npm config set registry ${OLD_REGISTRY}")
 fi
+OLD_SCOPE_REGISTRY=$(npm config get @aws-cdk:registry)
+if [ ${OLD_SCOPE_REGISTRY} != ${REGISTRY} ]; then
+    echo "👉 Switching to NPM registry ${REGISTRY} for @aws-cdk scope"
+    npm config set @aws-cdk:registry ${REGISTRY}
+    CLEANUP+=("echo '👈 Resetting NPM registry to ${OLD_SCOPE_REGISTRY} for @aws-cdk scope'" "npm config set @aws-cdk:registry ${OLD_SCOPE_REGISTRY}")
+fi
 
 TOKENS=$(npm token list 2>&1 || echo '')
 if echo ${TOKENS} | grep 'EAUTHUNKNOWN' > /dev/null; then


### PR DESCRIPTION
NPM can have registry configuration specified on a per-scope basis, which was overlooked in the first version of the `publish.sh` script. This revision makes sure the `@aws-cdk/`-scoped packages get published to the same registry than the un-scoped packages by forcing the `@aws-cdk:repository` configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) license.
