### PR TITLE
Use "npm" in cdk-init instead of "y-npm"

### DIFF
--- a/packages/aws-cdk/lib/init.ts
+++ b/packages/aws-cdk/lib/init.ts
@@ -204,7 +204,7 @@ async function postInstallTypescript() {
     const command = 'npm';
     print(`Executing ${colors.green(`${command} install`)}...`);
     try {
-        await execute('npm', 'install');
+        await execute(command, 'install');
     } catch (e) {
         throw new Error(`${colors.green(`${command} install`)} failed: ` + e.message);
     }


### PR DESCRIPTION
Since we are now going to publish to npm, we don't need y-npm anymore.

#440 proposes to allow customizing the NPM program.