### PR TITLE
feat(cloudtrail): Grant encrypt on kmsKey to cloudtrail service princ…

### DIFF
--- a/packages/@aws-cdk/aws-cloudtrail/lib/index.ts
+++ b/packages/@aws-cdk/aws-cloudtrail/lib/index.ts
@@ -182,6 +182,10 @@ export class Trail extends Resource {
       };
       this.eventSelectors.push(managementEvent);
     }
+    
+    if (props.kmsKey) {
+        props.kmsKey.grantEncrypt(new iam.ServicePrincipal("cloudtrail.amazonaws.com"))
+    }
 
     // TODO: not all regions support validation. Use service configuration data to fail gracefully
     const trail = new CfnTrail(this, 'Resource', {


### PR DESCRIPTION
<!-- Please write here a description of what is included in your pull request -->

When adding a kmsKey, the user currently has to manually add cloudtrail as a service principal (and this is not documented anywhere). It would be best if this was transparent as the error message CFN provides without it is very unhelpful:

AuditTrailFF0F2BB5 | CREATE_FAILED | Insufficient permissions to access S3 bucket...

<!-- 
Please read the [contribution guidelines][1] and follow the pull-request checklist.

[1]: https://github.com/aws/aws-cdk/blob/master/CONTRIBUTING.md
 -->

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
