### PR TITLE
chore(mergify): automerge dependabot, allow provisional approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,7 +81,7 @@ pull_request_rules:
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
-      - author!=@aws-cdk-core
+      - author!=@aws/aws-cdk-core
       - base=master
   - name: if fails conventional commits
     actions:


### PR DESCRIPTION
Two changes to the Mergify config (hoping that I've done it correctly):

- Automatically merge commits from dependabot. Having to go through
  approve/rebase/approve cycles is tiresome.
- Don't dimiss stale approvals if the PR author is someone from the core
  team. This allows doing provisional approvals ("it's okay but change
  this one thing before you merge").



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

<!-- 
Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/aws/aws-cdk/blob/master/CONTRIBUTING.md
 -->
