### PR TITLE
chore(mergify): remove once-only label requirement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,6 @@
 # See https://doc.mergify.io
 
-pull_request_rules:    
+pull_request_rules:
   - name: automatic merge
     actions:
       comment:


### PR DESCRIPTION
After mergify update, no longer requires a blocking label for one comment only


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

<!-- 
Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/aws/aws-cdk/blob/master/CONTRIBUTING.md
 -->
