### PR TITLE
chore: mergify team update and stale review rule update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       label:
         add: [ contribution/core ]
     conditions:
-      - author~=^(eladb|RomainMuller|garnaat|nija-at|shivlaks|skinny85|rix0rrr|NGL321|Jerry-AWS|SomayaB|MrArnoldPalmer|NetaNir|iliapolo)$
+      - author~=^(eladb|RomainMuller|garnaat|nija-at|shivlaks|skinny85|rix0rrr|NGL321|Jerry-AWS|SomayaB|MrArnoldPalmer|NetaNir|iliapolo|njlynch)$
       - -label~="contribution/core"
   - name: automatic merge
     actions:
@@ -66,20 +66,7 @@ pull_request_rules:
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
-        # List out all the people whose work is okay to provisionally approve
-      - author!=eladb
-      - author!=RomainMuller
-      - author!=garnaat
-      - author!=nija-at
-      - author!=shivlaks
-      - author!=skinny85
-      - author!=rix0rrr
-      - author!=NGL321
-      - author!=Jerry-AWS
-      - author!=SomayaB
-      - author!=MrArnoldPalmer
-      - author!=NetaNir
-      - author!=iliapolo
+      - label!=contribution/core
       - base=master
       - -merged
       - -closed


### PR DESCRIPTION
Updating the team list and adopting the same contribution/core adjustment to the stale review rule as is used on the jsii project.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
