### PR TITLE
feat(aws-lambda-go): add builtin support for arm architecture

### DIFF
--- a/packages/@aws-cdk/aws-lambda-go/README.md
+++ b/packages/@aws-cdk/aws-lambda-go/README.md
@@ -80,9 +80,9 @@ by your function. Otherwise bundling will fail.
 
 The `GoFunction` can be used with either the `GO_1_X` runtime or the provided runtimes (`PROVIDED`/`PROVIDED_AL2`).
 By default it will use the `PROVIDED_AL2` runtime. The `GO_1_X` runtime does not support things like
-[Lambda Extensions](https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html), whereas the provided runtimes do.
-The [aws-lambda-go](https://github.com/aws/aws-lambda-go) library has built in support for the provided runtime as long as
-you name the handler `bootstrap` (which we do by default).
+[Lambda Extensions](https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html) or [Arm Architecture](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/), 
+whereas the provided runtimes do. The [aws-lambda-go](https://github.com/aws/aws-lambda-go) library has built in support for 
+the provided runtime as long as you name the handler `bootstrap` (which we do by default).
 
 ## Dependencies
 
@@ -199,6 +199,20 @@ an array of commands to run. Commands are chained with `&&`.
 
 The commands will run in the environment in which bundling occurs: inside the
 container for Docker bundling or on the host OS for local bundling.
+
+## Lambda Architecture
+
+For Go Lambda Functions you can specify either the `Architecture.X86_64` or `Architecture.ARM_64` architecture.
+The `GoFunction` construct will set the `GOARCH` environment variable based on the architecture you specify, with
+the default being `GOARCH=amd64`. All you need to do to switch your Go Lambda functions to use `ARM_64` is to set
+the `architectures`.
+
+```ts
+new GoFunction(this, 'handler', {
+  entry: 'app/cmd/api',
+  architectures: [lambda.Architecture.ARM_64],
+});
+```
 
 ## Additional considerations
 

--- a/packages/@aws-cdk/aws-lambda-go/lib/function.ts
+++ b/packages/@aws-cdk/aws-lambda-go/lib/function.ts
@@ -98,12 +98,18 @@ export class GoFunction extends lambda.Function {
     } else {
       const modFile = findUp('go.mod', entry);
       if (!modFile) {
-        throw new Error ('Cannot find go.mod. Please specify it with `moduleDir`.');
+        throw new Error('Cannot find go.mod. Please specify it with `moduleDir`.');
       }
       moduleDir = modFile;
     }
 
     const runtime = props.runtime ?? lambda.Runtime.PROVIDED_AL2;
+
+    const architecture = props.architectures !== undefined ? props.architectures[0] : undefined;
+
+    if (runtime !== lambda.Runtime.PROVIDED_AL2 && architecture === lambda.Architecture.ARM_64) {
+      throw new Error(`Runtime ${runtime} does not support the ARM_64 architecture. To use ARM_64 with Go Lambdas you must use the provided.al2 runtime`);
+    }
 
     super(scope, id, {
       ...props,
@@ -113,6 +119,7 @@ export class GoFunction extends lambda.Function {
         entry,
         runtime,
         moduleDir,
+        architecture,
       }),
       handler: 'bootstrap', // setting name to bootstrap so that the 'provided' runtime can also be used
     });

--- a/packages/@aws-cdk/aws-lambda-go/test/function.test.ts
+++ b/packages/@aws-cdk/aws-lambda-go/test/function.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { Template } from '@aws-cdk/assertions';
-import { Runtime } from '@aws-cdk/aws-lambda';
+import { Runtime, Architecture } from '@aws-cdk/aws-lambda';
 import { Stack } from '@aws-cdk/core';
 import { GoFunction } from '../lib';
 import { Bundling } from '../lib/bundling';
@@ -144,4 +144,20 @@ test('custom moduleDir with file path can be used', () => {
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'bootstrap',
   });
+});
+
+test('throws if using arm64 with go1.x runtime', () => {
+  expect(() => new GoFunction(stack, 'handler', {
+    entry: 'test/lambda-handler-vendor/cmd/api',
+    architectures: [Architecture.ARM_64],
+    runtime: Runtime.GO_1_X,
+  })).toThrow(/Runtime go1.x does not support the ARM_64 architecture/);
+});
+
+test('throws if using arm64 with provided runtime', () => {
+  expect(() => new GoFunction(stack, 'handler', {
+    entry: 'test/lambda-handler-vendor/cmd/api',
+    architectures: [Architecture.ARM_64],
+    runtime: Runtime.PROVIDED,
+  })).toThrow(/Runtime provided does not support the ARM_64 architecture/);
 });


### PR DESCRIPTION
go applications can be built for either arm64 or amd64 architectures
by setting the GOARCH environment variable when running go build.
this feature automatically sets the GOARCH variable based on the
lambda architecture. it also validates that you are using
the correct lambda runtime based on the architecture.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
