### PR TITLE
docs(aws-s3 README): Clarify `autoDeleteObjects` warning to include "deploy" step.

### DIFF
--- a/packages/@aws-cdk/aws-s3/README.md
+++ b/packages/@aws-cdk/aws-s3/README.md
@@ -447,6 +447,6 @@ const bucket = new Bucket(this, 'MyTempFileBucket', {
 ```
 
 **Warning** if you have deployed a bucket with `autoDeleteObjects: true`,
-switching this to `false` in a CDK version *before* `1.126.0` will lead to all
-objects in the bucket being deleted. Be sure to update to version `1.126.0` or
-later before switching this value to `false`.
+switching this to `false` in a CDK version *before* `1.126.0` will lead to
+all objects in the bucket being deleted. Be sure to update your bucket resources
+by deploying with CDK version `1.126.0` or later **before** switching this value to `false`.


### PR DESCRIPTION
## Summary

This PR is a continuation of https://github.com/aws/aws-cdk/pull/16828#pullrequestreview-773025044

We want to make sure users know to deploy with the latest CDK version before toggling the `autoDeleteObjects` prop to `false`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
