### PR TITLE
chore: patch jsii-pacmak to fix parallel packing bug

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -28,16 +28,10 @@ lerna success exec Executed command in 219 packages: "pwd"
         1.11 real         0.99 user         0.82 sys
 ```
 
-## jsii-rosetta+1.28.0.patch
+## jsii-pacmak+1.38.0.patch
 
-jsii-rosetta uses multiple worker threads by default to speed up sample extraction.
-It defaults to spawning workers equal to half the number of cores. On extremely
-powerful build machines (e.g., CodeBuild X2_LARGE compute with 72 vCPUs),
-the high number of workers (36) results in thrash and high memory usage due to
-duplicate loads of source files. This was causing the v2 builds to fail with:
-"FATAL ERROR: NewSpace::Rebalance Allocation failed - JavaScript heap out of memory"
-
-The patch simply limits the top number of worker threads to an arbitrarily-chosen
-maximum limit of 16. We could simply disable the worker threads, but this takes much
-longer to process. With single-threading, rosetta takes ~35 minutes to extract samples
-from the CDK; with 16 workers, it takes ~3.5 minutes.
+jsii-pacmak@1.38.0 has a bug that means all packages are packed in parallel for
+several languages. This can cause issues on the v2 build, where the alpha modules
+rely on aws-cdk-lib, but may be packed first. A fix will go out in 1.39.0, but in
+the meantime, this patch allows us to more quickly verify the fix and get our
+pipeline green again.

--- a/patches/jsii-pacmak+1.38.0.patch
+++ b/patches/jsii-pacmak+1.38.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/jsii-pacmak/lib/builder.js b/node_modules/jsii-pacmak/lib/builder.js
+index 3d0f8b3..0d1e868 100644
+--- a/node_modules/jsii-pacmak/lib/builder.js
++++ b/node_modules/jsii-pacmak/lib/builder.js
+@@ -15,10 +15,16 @@ class OneByOneBuilder {
+         this.options = options;
+     }
+     async buildModules() {
+-        const promises = this.modules.map((module) => this.options.codeOnly
+-            ? this.generateModuleCode(module, this.options)
+-            : this.buildModule(module, this.options));
+-        await Promise.all(promises);
++        for (const module of this.modules) {
++            if (this.options.codeOnly) {
++                // eslint-disable-next-line no-await-in-loop
++                await this.generateModuleCode(module, this.options);
++            }
++            else {
++                // eslint-disable-next-line no-await-in-loop
++                await this.buildModule(module, this.options);
++            }
++        }
+     }
+     async generateModuleCode(module, options) {
+         const outputDir = this.finalOutputDir(module, options);


### PR DESCRIPTION
jsii-pacmak has a bug where modules are packed in parallel, rather than
sequentially. This causes packing failures on v2, where the alpha modules depend
on aws-cdk-lib, but may be packed first.

The jsii fix is https://github.com/aws/jsii/pull/3045. However, to shortcut the
build+test+upgrade+merge+deploy cycle, creating this patch to speed up
verification.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
