### PR TITLE
chore: fix pip init template test by limiting what is installed

### DIFF
--- a/packages/aws-cdk/test/integ/run-wrappers/dist/pip_
+++ b/packages/aws-cdk/test/integ/run-wrappers/dist/pip_
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -eu
 if [[ "${1:-}" == "install" ]]; then
-  # Just install all wheels from the source repository.
-  # It's too hard to figure out what was actually requested, and
-  # this is pretty quick anyway.
-  exec pip install $PYTHON_WHEELS/*.whl
+  # We will receive `pip install -r requirements.txt` and need to
+  # install the packages from the local dist. We previously just
+  # installed everything under $PYTHON_WHEELS ($PYTHON_WHEELS/*.whl).
+  # However, there is a bug that arises on v2 when we install everything,
+  # including both `aws-cdk-lib` and `cx-api`, because the latter is also
+  # packaged in the former and causes conflicts. This can lead to errors like:
+  # "Unknown type: aws-cdk-lib.cx_api.CloudAssembly"
+  # Since we only need aws-cdk-lib anyway (for now), just install it alone.
+  exec pip install ${PYTHON_WHEELS}/aws_cdk_lib*.whl
 fi
 
 exec pip "$@"


### PR DESCRIPTION
This `pip_` wrapper is used during the init template tests in the pipeline.  It
hijacks the `pip install -r requirements` command to install the packages from
the local distribution. We previously just installed everything under
$PYTHON_WHEELS ($PYTHON_WHEELS/*.whl).  However, there is a bug that arises on
v2 when we install everything, including both `aws-cdk-lib` and `cx-api`,
because the latter is also packaged in the former and causes conflicts. This can
lead to errors like: "Unknown type: aws-cdk-lib.cx_api.CloudAssembly". Since we
only need aws-cdk-lib anyway (for now), just install it alone.

related #16432 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
