### PR TITLE
fix(ecs): imported services don't have account & region set correctly

### DIFF
--- a/packages/@aws-cdk/aws-ecs/lib/base/from-service-attributes.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/from-service-attributes.ts
@@ -54,5 +54,7 @@ export function fromServiceAtrributes(scope: Construct, id: string, attrs: Servi
     public readonly serviceName = name;
     public readonly cluster = attrs.cluster;
   }
-  return new Import(scope, id);
+  return new Import(scope, id, {
+    environmentFromArn: arn,
+  });
 }

--- a/packages/@aws-cdk/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/@aws-cdk/aws-ecs/test/ec2/ec2-service.test.ts
@@ -3292,6 +3292,8 @@ describe('ec2 service', () => {
       expect(service.serviceArn).toEqual('arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
       expect(service.serviceName).toEqual('my-http-service');
 
+      expect(service.env.account).toEqual('123456789012');
+      expect(service.env.region).toEqual('us-west-2');
 
     });
 

--- a/packages/@aws-cdk/aws-ecs/test/fargate/fargate-service.test.ts
+++ b/packages/@aws-cdk/aws-ecs/test/fargate/fargate-service.test.ts
@@ -2124,6 +2124,8 @@ describe('fargate service', () => {
       expect(service.serviceArn).toEqual('arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
       expect(service.serviceName).toEqual('my-http-service');
 
+      expect(service.env.account).toEqual('123456789012');
+      expect(service.env.region).toEqual('us-west-2');
 
     });
 


### PR DESCRIPTION
This is a fix for the region issue raised by #11199 allowing multi regional ecs deployments

fixes #11199

supersedes #15944, merged master and added tests

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
