### PR TITLE
Run issue handling bot more frequently

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -4,7 +4,7 @@ name: "Close Stale Issues"
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 6 * * *"
+  - cron: "0 */4 * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
Instead of running once daily, run the close-stale issues bot 6 times
per day (once every 4 hours).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
