### PR TITLE
chore: run issue cleanup action more frequently

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -4,7 +4,7 @@ name: "Close Stale Issues"
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 6 * * *"
+  - cron: "0 /4 * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
This changes the issue cleanup action to run 6 times per day (once every
four hours) instead of only once per day.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
