### PR TITLE
fix(pipelines): `additionalInputs` fails for deep directory

### DIFF
--- a/packages/@aws-cdk/pipelines/lib/codepipeline/_codebuild-factory.ts
+++ b/packages/@aws-cdk/pipelines/lib/codepipeline/_codebuild-factory.ts
@@ -333,8 +333,11 @@ function generateInputArtifactLinkCommands(artifacts: ArtifactMap, inputs: FileS
   return inputs.map(input => {
     const fragments = [];
 
-    if (!['.', '..'].includes(path.dirname(input.directory))) {
-      fragments.push(`mkdir -p -- "${input.directory}"`);
+    fragments.push(`[[ ! -d "${input.directory}" ]] || { echo 'additionalInputs: "${input.directory}" must not exist yet. If you want to merge multiple artifacts, use a "cp" command.'; exit 1; }`);
+
+    const parentDirectory = path.dirname(input.directory);
+    if (!['.', '..'].includes(parentDirectory)) {
+      fragments.push(`mkdir -p -- "${parentDirectory}"`);
     }
 
     const artifact = artifacts.toCodePipeline(input.fileSet);

--- a/packages/@aws-cdk/pipelines/test/codepipeline/codebuild-step.test.ts
+++ b/packages/@aws-cdk/pipelines/test/codepipeline/codebuild-step.test.ts
@@ -1,0 +1,44 @@
+import { Template, Match } from '@aws-cdk/assertions';
+import { Stack } from '@aws-cdk/core';
+import * as cdkp from '../../lib';
+import { PIPELINE_ENV, TestApp } from '../testhelpers';
+
+let app: TestApp;
+let pipelineStack: Stack;
+
+beforeEach(() => {
+  app = new TestApp();
+  pipelineStack = new Stack(app, 'PipelineStack', { env: PIPELINE_ENV });
+});
+
+afterEach(() => {
+  app.cleanup();
+});
+
+test('additionalinputs creates the right commands', () => {
+  // WHEN
+  new cdkp.CodePipeline(pipelineStack, 'Pipeline', {
+    synth: new cdkp.CodeBuildStep('Synth', {
+      commands: ['/bin/true'],
+      input: cdkp.CodePipelineSource.gitHub('test/test', 'main'),
+      additionalInputs: {
+        'some/deep/directory': cdkp.CodePipelineSource.gitHub('test2/test2', 'main'),
+      },
+    }),
+  });
+
+  // THEN
+  Template.fromStack(pipelineStack).hasResourceProperties('AWS::CodeBuild::Project', {
+    Source: {
+      BuildSpec: Match.serializedJson(Match.objectLike({
+        phases: {
+          install: {
+            commands: [
+              '[[ ! -d "some/deep/directory" ]] || { echo \'additionalInputs: "some/deep/directory" must not exist yet. If you want to merge multiple artifacts, use a "cp" command.\'; exit 1; } && mkdir -p -- "some/deep" && ln -s -- "$CODEBUILD_SRC_DIR_test2_test2_Source" "some/deep/directory"',
+            ],
+          },
+        },
+      })),
+    },
+  });
+});

--- a/packages/@aws-cdk/pipelines/test/compliance/synths.test.ts
+++ b/packages/@aws-cdk/pipelines/test/compliance/synths.test.ts
@@ -947,8 +947,8 @@ behavior('Multiple input sources in side-by-side directories', (suite) => {
           phases: {
             install: {
               commands: [
-                'ln -s -- "$CODEBUILD_SRC_DIR_foo_bar_Source" "../sibling"',
-                'ln -s -- "$CODEBUILD_SRC_DIR_Prebuild_Output" "sub"',
+                '[[ ! -d "../sibling" ]] || { echo \'additionalInputs: "../sibling" must not exist yet. If you want to merge multiple artifacts, use a "cp" command.\'; exit 1; } && ln -s -- "$CODEBUILD_SRC_DIR_foo_bar_Source" "../sibling"',
+                '[[ ! -d "sub" ]] || { echo \'additionalInputs: "sub" must not exist yet. If you want to merge multiple artifacts, use a "cp" command.\'; exit 1; } && ln -s -- "$CODEBUILD_SRC_DIR_Prebuild_Output" "sub"',
               ],
             },
             build: {


### PR DESCRIPTION
If the directory is nested deeper than one level underneath `.` or `..`,
the wrong directory gets created.

Also add in protection against the directory already existing, in which
case the same behavior would happen.

Fixes #16936.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
