### PR TITLE
chore(assertions): remove `rosetta:extract` from build command

### DIFF
--- a/packages/@aws-cdk/assertions/package.json
+++ b/packages/@aws-cdk/assertions/package.json
@@ -55,11 +55,6 @@
       }
     }
   },
-  "cdk-build": {
-    "post": [
-      "yarn rosetta:extract"
-    ]
-  },
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",


### PR DESCRIPTION
This form of executing Rosetta is not mocked by the jsii integ tests
(which try executing a CDK build using a new version of the jsii tools).

The jsii integ tests rely on passing environment variables `$CDK_BUILD_JSII`,
`$PACMAK` and `$ROSETTA` (instead of replacing symlinks in the Node module farm).

This leads to the generation of `.jsii.tabl.json` during build using the
NPM-installed version of `jsii-rosetta`, which subsequently interferes with
the run of `$PACMAK` which *is* the new version (since Rosetta tablets
are supposed to be short-lived, there is no backwards compatibility guarantee
between different versions).

There will be a supported mechanism to achieve what this single post-build command is trying to achieve,
so remove it.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

(cherry picked from commit ac54842ba15991b2359181a27d2530158622d9f9)


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
