### PR TITLE
chore: Dependency table@^6.7.1 from @aws-cdk/assertions-alpha not present in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,7 +1583,7 @@
   dependencies:
     "@types/glob" "*"
 
-"@types/aws-lambda@^8.10.84":
+"@types/aws-lambda@^8.10.83", "@types/aws-lambda@^8.10.84":
   version "8.10.84"
   resolved "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.84.tgz#b1f391ceeb6908b28d8416d93f27afe8d1348d4e"
   integrity sha512-5V78eLtmN0d4RA14hKDwcsMQRl3JotQJlhGFDBo/jdE2TyDFRaYwB/UmMUC4SzhSvRGn+YMkh7jGPnXi8COAng==
@@ -9027,7 +9027,7 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-table@*, table@^6.0.9, table@^6.7.2:
+table@*, table@^6.0.9, table@^6.7.1, table@^6.7.2:
   version "6.7.2"
   resolved "https://registry.npmjs.org/table/-/table-6.7.2.tgz#a8d39b9f5966693ca8b0feba270a78722cbaf3b0"
   integrity sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==


### PR DESCRIPTION
I don't know how this happened, but this commit fixes it (and thereby the build).


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
