### PR TITLE
docs(general-issue.yml): removed needs-triage from guidance issues' default labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.yml
+++ b/.github/ISSUE_TEMPLATE/general-issue.yml
@@ -1,7 +1,7 @@
 name: General Issue
 description: Create a new issue
 title: "(module name): short issue description"
-labels: [needs-triage, guidance]
+labels: [guidance]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

This PR removes the automatic labeling of `needs-triage` on guidance issues.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
