### PR TITLE
chore: include RELEASE_NOTES in packed distribution

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -92,8 +92,9 @@ cat > ${distdir}/build.json <<HERE
 }
 HERE
 
-# copy CHANGELOG.md to dist/ for github releases
+# copy CHANGELOG.md and RELEASE_NOTES.md to dist/ for github releases
 cp ${changelog_file} ${distdir}/CHANGELOG.md
+cp RELEASE_NOTES.md ${distdir}/RELEASE_NOTES.md
 
 # defensive: make sure our artifacts don't use the version marker (this means
 # that "pack" will always fails when building in a dev environment)


### PR DESCRIPTION
We now create and generate a `RELEASE_NOTES.md` file as part of our build, with
the intent to use it for our GitHub release publishing. See (#16942) and
https://github.com/cdklabs/aws-delivlib/pull/1044.

What I missed is that after the build, we pack, and then only include what ends
up in `./dist` in the final build artifact that goes to publishing. This fix
includes the release notes in the dist folder so it will be picked up and used
by the release process.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
