### PR TITLE
chore: revert activate 'rosetta infuse' feature

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -39,15 +39,10 @@ function lerna_scopes() {
 # Compile examples with respect to "decdk" directory, as all packages will
 # be symlinked there so they can all be included.
 echo "Extracting code samples" >&2
-$ROSETTA extract \
+node --experimental-worker $(which $ROSETTA) \
   --compile \
   --output samples.tabl.json \
   --directory packages/decdk \
-  $(cat $TMPDIR/jsii.txt)
-
-echo "Infusing examples back into assemblies" >&2
-$ROSETTA infuse \
-  samples.tabl.json \
   $(cat $TMPDIR/jsii.txt)
 
 # Jsii packaging (all at once using jsii-pacmak)


### PR DESCRIPTION
The examples we copy into docblocks may contain block comments themselves.

However, the docblock renderer does not escape the docblock *closing* text, so the doc block gets terminated early and compiling fails:

```java
/**
 * Initialization props for the `NestedStack` construct.
 * <p>
 * Example:
 * <p>
 * <blockquote><pre>{@code
 * // Example automatically generated. See https://github.com/aws/jsii/issues/826
 * import software.amazon.awscdk.core.App;
 * import software.amazon.awscdk.core.CfnOutput;
 * import software.amazon.awscdk.core.NestedStack;
 * import lib.RestApi;
 * import lib.Stage;
 * /**
 *  * This file showcases how to split up a RestApi's Resources and Methods across nested stacks.
 *  *
 *  * The root stack 'RootStack' first defines a RestApi.
 *  * Two nested stacks BooksStack and PetsStack, create corresponding Resources '/books' and '/pets'.
 *  * They are then deployed to a 'prod' Stage via a third nested stack - DeployStack.
 *  *
 *  * To verify this worked, go to the APIGateway
 *  */    <------------ OOOPS!
 * public class RootStack extends Stack {
 *     public RootStack(Construct scope) {
 *         super(scope, "integ-restapi-import-RootStack");
 *         RestApi restApi = RestApi.Builder.cre

```

Revert this until we can address the quoting issue.

Reverts aws/aws-cdk#17191

