### PR TITLE
feat(ecs-patterns): add blue/green deployment support for application load balanced services

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs-patterns/README.md
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/README.md
@@ -87,6 +87,8 @@ If you need to encrypt the traffic between the load balancer and the ECS tasks, 
 To configure blue/green deployments for your ApplicationLoadBalanced services, you can use the `blueGreenDeployment` property. This enables zero-downtime deployments by routing traffic between two identical environments.
 
 ```ts
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+
 declare const cluster: ecs.Cluster;
 declare const alternateTargetGroup: elbv2.ApplicationTargetGroup;
 declare const productionListener: elbv2.ApplicationListenerRule;


### PR DESCRIPTION
Closes #35467.

### Reason for this change

AWS CDK users need a high-level API to configure blue/green deployments for ApplicationLoadBalanced ECS patterns. Currently, users must manually configure low-level ECS service properties and alternate target groups, which is complex and error-prone. This feature request adds blue/green deployment support directly to the ECS patterns API, making it accessible through a simple, declarative interface.

### Description of changes

Added optional blue/green deployment configuration to ApplicationLoadBalanced ECS patterns:

- **New Interface**: `BlueGreenDeploymentConfiguration` interface with properties for alternate target group, production listener, optional test listener, and optional IAM role
- **Extended Props**: Added optional `blueGreenDeployment` property to `ApplicationLoadBalancedServiceBaseProps` interface
- **Enhanced Service Target**: Modified `addServiceAsTarget()` method to create `AlternateTarget` configuration when blue/green properties are specified
- **CloudFormation Integration**: Generates `AdvancedConfiguration` in ECS Service LoadBalancers array with proper alternate target group and listener rule references
- **Backward Compatibility**: All changes are additive and optional - existing applications continue to work unchanged

The implementation leverages existing `AlternateTarget` infrastructure from the aws-ecs module, providing a clean separation between high-level pattern configuration and low-level ECS service setup.

### Describe any new or updated permissions being added

N/A - No new IAM permissions are introduced. The feature leverages existing IAM role creation and managed policies from the underlying `AlternateTarget` class in the aws-ecs module.

### Description of how you validated changes

- **Unit tests**: Added 4 comprehensive unit tests covering all blue/green deployment scenarios:
  - Basic blue/green configuration with production listener only
  - Blue/green configuration with both production and test listeners  
  - Blue/green configuration with custom IAM role
  - Backward compatibility verification (services without blue/green work unchanged)
- **Integration tests**: Leverages existing aws-ecs integration tests for `AlternateTarget` functionality
- **CloudFormation validation**: Tests verify that `AdvancedConfiguration` is properly generated in ECS Service LoadBalancers with correct alternate target group ARN, role ARN, and listener rule configurations
- **Regression testing**: Full test suite execution (15,928/15,937 tests passing) confirms no breaking changes to existing functionality
- **JSII compatibility**: Fixed and verified JSII compilation by creating separate interface instead of inline object literal type

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*