### PR TITLE
fix(kinesisanalytics): deprecate using KinesisAnalyticsV2 from `aws-kinesisanalytics`, use `aws-kinesisanalyticsv2` instead

### DIFF
--- a/packages/aws-cdk-lib/scripts/gen.ts
+++ b/packages/aws-cdk-lib/scripts/gen.ts
@@ -32,9 +32,9 @@ async function main() {
 async function writeScopeMap(modules: ModuleMap) {
   const newScopeMap = Object.entries(modules)
     .sort(([modA], [modB]) => modA.localeCompare(modB))
-    .reduce((accum, [moduleName, { scopes }]) => {
+    .reduce((scopeMap, [moduleName, { scopes }]) => {
       return {
-        ...accum,
+        ...scopeMap,
         [moduleName]: scopes,
       };
     }, {});

--- a/packages/aws-cdk-lib/scripts/scope-map.json
+++ b/packages/aws-cdk-lib/scripts/scope-map.json
@@ -1,798 +1,1332 @@
 {
   "alexa-ask": [
-    "Alexa::ASK"
+    {
+      "namespace": "Alexa::ASK"
+    }
   ],
   "aws-accessanalyzer": [
-    "AWS::AccessAnalyzer"
+    {
+      "namespace": "AWS::AccessAnalyzer"
+    }
   ],
   "aws-acmpca": [
-    "AWS::ACMPCA"
+    {
+      "namespace": "AWS::ACMPCA"
+    }
   ],
   "aws-aiops": [
-    "AWS::AIOps"
+    {
+      "namespace": "AWS::AIOps"
+    }
   ],
   "aws-amazonmq": [
-    "AWS::AmazonMQ"
+    {
+      "namespace": "AWS::AmazonMQ"
+    }
   ],
   "aws-amplify": [
-    "AWS::Amplify"
+    {
+      "namespace": "AWS::Amplify"
+    }
   ],
   "aws-amplifyuibuilder": [
-    "AWS::AmplifyUIBuilder"
+    {
+      "namespace": "AWS::AmplifyUIBuilder"
+    }
   ],
   "aws-apigateway": [
-    "AWS::ApiGateway"
+    {
+      "namespace": "AWS::ApiGateway"
+    }
   ],
   "aws-apigatewayv2": [
-    "AWS::ApiGatewayV2"
+    {
+      "namespace": "AWS::ApiGatewayV2"
+    }
   ],
   "aws-appconfig": [
-    "AWS::AppConfig"
+    {
+      "namespace": "AWS::AppConfig"
+    }
   ],
   "aws-appflow": [
-    "AWS::AppFlow"
+    {
+      "namespace": "AWS::AppFlow"
+    }
   ],
   "aws-appintegrations": [
-    "AWS::AppIntegrations"
+    {
+      "namespace": "AWS::AppIntegrations"
+    }
   ],
   "aws-applicationautoscaling": [
-    "AWS::ApplicationAutoScaling"
+    {
+      "namespace": "AWS::ApplicationAutoScaling"
+    }
   ],
   "aws-applicationinsights": [
-    "AWS::ApplicationInsights"
+    {
+      "namespace": "AWS::ApplicationInsights"
+    }
   ],
   "aws-applicationsignals": [
-    "AWS::ApplicationSignals"
+    {
+      "namespace": "AWS::ApplicationSignals"
+    }
   ],
   "aws-appmesh": [
-    "AWS::AppMesh"
+    {
+      "namespace": "AWS::AppMesh"
+    }
   ],
   "aws-apprunner": [
-    "AWS::AppRunner"
+    {
+      "namespace": "AWS::AppRunner"
+    }
   ],
   "aws-appstream": [
-    "AWS::AppStream"
+    {
+      "namespace": "AWS::AppStream"
+    }
   ],
   "aws-appsync": [
-    "AWS::AppSync"
+    {
+      "namespace": "AWS::AppSync"
+    }
   ],
   "aws-apptest": [
-    "AWS::AppTest"
+    {
+      "namespace": "AWS::AppTest"
+    }
   ],
   "aws-aps": [
-    "AWS::APS"
+    {
+      "namespace": "AWS::APS"
+    }
   ],
   "aws-arcregionswitch": [
-    "AWS::ARCRegionSwitch"
+    {
+      "namespace": "AWS::ARCRegionSwitch"
+    }
   ],
   "aws-arczonalshift": [
-    "AWS::ARCZonalShift"
+    {
+      "namespace": "AWS::ARCZonalShift"
+    }
   ],
   "aws-athena": [
-    "AWS::Athena"
+    {
+      "namespace": "AWS::Athena"
+    }
   ],
   "aws-auditmanager": [
-    "AWS::AuditManager"
+    {
+      "namespace": "AWS::AuditManager"
+    }
   ],
   "aws-autoscaling": [
-    "AWS::AutoScaling"
+    {
+      "namespace": "AWS::AutoScaling"
+    }
   ],
   "aws-autoscalingplans": [
-    "AWS::AutoScalingPlans"
+    {
+      "namespace": "AWS::AutoScalingPlans"
+    }
   ],
   "aws-b2bi": [
-    "AWS::B2BI"
+    {
+      "namespace": "AWS::B2BI"
+    }
   ],
   "aws-backup": [
-    "AWS::Backup"
+    {
+      "namespace": "AWS::Backup"
+    }
   ],
   "aws-backupgateway": [
-    "AWS::BackupGateway"
+    {
+      "namespace": "AWS::BackupGateway"
+    }
   ],
   "aws-batch": [
-    "AWS::Batch"
+    {
+      "namespace": "AWS::Batch"
+    }
   ],
   "aws-bcmdataexports": [
-    "AWS::BCMDataExports"
+    {
+      "namespace": "AWS::BCMDataExports"
+    }
   ],
   "aws-bedrock": [
-    "AWS::Bedrock"
+    {
+      "namespace": "AWS::Bedrock"
+    }
   ],
   "aws-billing": [
-    "AWS::Billing"
+    {
+      "namespace": "AWS::Billing"
+    }
   ],
   "aws-billingconductor": [
-    "AWS::BillingConductor"
+    {
+      "namespace": "AWS::BillingConductor"
+    }
   ],
   "aws-budgets": [
-    "AWS::Budgets"
+    {
+      "namespace": "AWS::Budgets"
+    }
   ],
   "aws-cassandra": [
-    "AWS::Cassandra"
+    {
+      "namespace": "AWS::Cassandra"
+    }
   ],
   "aws-ce": [
-    "AWS::CE"
+    {
+      "namespace": "AWS::CE"
+    }
   ],
   "aws-certificatemanager": [
-    "AWS::CertificateManager"
+    {
+      "namespace": "AWS::CertificateManager"
+    }
   ],
   "aws-chatbot": [
-    "AWS::Chatbot"
+    {
+      "namespace": "AWS::Chatbot"
+    }
   ],
   "aws-cleanrooms": [
-    "AWS::CleanRooms"
+    {
+      "namespace": "AWS::CleanRooms"
+    }
   ],
   "aws-cleanroomsml": [
-    "AWS::CleanRoomsML"
+    {
+      "namespace": "AWS::CleanRoomsML"
+    }
   ],
   "aws-cloud9": [
-    "AWS::Cloud9"
+    {
+      "namespace": "AWS::Cloud9"
+    }
   ],
   "aws-cloudformation": [
-    "AWS::CloudFormation"
+    {
+      "namespace": "AWS::CloudFormation"
+    }
   ],
   "aws-cloudfront": [
-    "AWS::CloudFront"
+    {
+      "namespace": "AWS::CloudFront"
+    }
   ],
   "aws-cloudtrail": [
-    "AWS::CloudTrail"
+    {
+      "namespace": "AWS::CloudTrail"
+    }
   ],
   "aws-cloudwatch": [
-    "AWS::CloudWatch"
+    {
+      "namespace": "AWS::CloudWatch"
+    }
   ],
   "aws-codeartifact": [
-    "AWS::CodeArtifact"
+    {
+      "namespace": "AWS::CodeArtifact"
+    }
   ],
   "aws-codebuild": [
-    "AWS::CodeBuild"
+    {
+      "namespace": "AWS::CodeBuild"
+    }
   ],
   "aws-codecommit": [
-    "AWS::CodeCommit"
+    {
+      "namespace": "AWS::CodeCommit"
+    }
   ],
   "aws-codeconnections": [
-    "AWS::CodeConnections"
+    {
+      "namespace": "AWS::CodeConnections"
+    }
   ],
   "aws-codedeploy": [
-    "AWS::CodeDeploy"
+    {
+      "namespace": "AWS::CodeDeploy"
+    }
   ],
   "aws-codeguruprofiler": [
-    "AWS::CodeGuruProfiler"
+    {
+      "namespace": "AWS::CodeGuruProfiler"
+    }
   ],
   "aws-codegurureviewer": [
-    "AWS::CodeGuruReviewer"
+    {
+      "namespace": "AWS::CodeGuruReviewer"
+    }
   ],
   "aws-codepipeline": [
-    "AWS::CodePipeline"
+    {
+      "namespace": "AWS::CodePipeline"
+    }
   ],
   "aws-codestar": [
-    "AWS::CodeStar"
+    {
+      "namespace": "AWS::CodeStar"
+    }
   ],
   "aws-codestarconnections": [
-    "AWS::CodeStarConnections"
+    {
+      "namespace": "AWS::CodeStarConnections"
+    }
   ],
   "aws-codestarnotifications": [
-    "AWS::CodeStarNotifications"
+    {
+      "namespace": "AWS::CodeStarNotifications"
+    }
   ],
   "aws-cognito": [
-    "AWS::Cognito"
+    {
+      "namespace": "AWS::Cognito"
+    }
   ],
   "aws-comprehend": [
-    "AWS::Comprehend"
+    {
+      "namespace": "AWS::Comprehend"
+    }
   ],
   "aws-config": [
-    "AWS::Config"
+    {
+      "namespace": "AWS::Config"
+    }
   ],
   "aws-connect": [
-    "AWS::Connect"
+    {
+      "namespace": "AWS::Connect"
+    }
   ],
   "aws-connectcampaigns": [
-    "AWS::ConnectCampaigns"
+    {
+      "namespace": "AWS::ConnectCampaigns"
+    }
   ],
   "aws-connectcampaignsv2": [
-    "AWS::ConnectCampaignsV2"
+    {
+      "namespace": "AWS::ConnectCampaignsV2"
+    }
   ],
   "aws-controltower": [
-    "AWS::ControlTower"
+    {
+      "namespace": "AWS::ControlTower"
+    }
   ],
   "aws-cur": [
-    "AWS::CUR"
+    {
+      "namespace": "AWS::CUR"
+    }
   ],
   "aws-customerprofiles": [
-    "AWS::CustomerProfiles"
+    {
+      "namespace": "AWS::CustomerProfiles"
+    }
   ],
   "aws-databrew": [
-    "AWS::DataBrew"
+    {
+      "namespace": "AWS::DataBrew"
+    }
   ],
   "aws-datapipeline": [
-    "AWS::DataPipeline"
+    {
+      "namespace": "AWS::DataPipeline"
+    }
   ],
   "aws-datasync": [
-    "AWS::DataSync"
+    {
+      "namespace": "AWS::DataSync"
+    }
   ],
   "aws-datazone": [
-    "AWS::DataZone"
+    {
+      "namespace": "AWS::DataZone"
+    }
   ],
   "aws-dax": [
-    "AWS::DAX"
+    {
+      "namespace": "AWS::DAX"
+    }
   ],
   "aws-deadline": [
-    "AWS::Deadline"
+    {
+      "namespace": "AWS::Deadline"
+    }
   ],
   "aws-detective": [
-    "AWS::Detective"
+    {
+      "namespace": "AWS::Detective"
+    }
   ],
   "aws-devicefarm": [
-    "AWS::DeviceFarm"
+    {
+      "namespace": "AWS::DeviceFarm"
+    }
   ],
   "aws-devopsguru": [
-    "AWS::DevOpsGuru"
+    {
+      "namespace": "AWS::DevOpsGuru"
+    }
   ],
   "aws-directoryservice": [
-    "AWS::DirectoryService"
+    {
+      "namespace": "AWS::DirectoryService"
+    }
   ],
   "aws-dlm": [
-    "AWS::DLM"
+    {
+      "namespace": "AWS::DLM"
+    }
   ],
   "aws-dms": [
-    "AWS::DMS"
+    {
+      "namespace": "AWS::DMS"
+    }
   ],
   "aws-docdb": [
-    "AWS::DocDB"
+    {
+      "namespace": "AWS::DocDB"
+    }
   ],
   "aws-docdbelastic": [
-    "AWS::DocDBElastic"
+    {
+      "namespace": "AWS::DocDBElastic"
+    }
   ],
   "aws-dsql": [
-    "AWS::DSQL"
+    {
+      "namespace": "AWS::DSQL"
+    }
   ],
   "aws-dynamodb": [
-    "AWS::DynamoDB"
+    {
+      "namespace": "AWS::DynamoDB"
+    }
   ],
   "aws-ec2": [
-    "AWS::EC2"
+    {
+      "namespace": "AWS::EC2"
+    }
   ],
   "aws-ecr": [
-    "AWS::ECR"
+    {
+      "namespace": "AWS::ECR"
+    }
   ],
   "aws-ecs": [
-    "AWS::ECS"
+    {
+      "namespace": "AWS::ECS"
+    }
   ],
   "aws-efs": [
-    "AWS::EFS"
+    {
+      "namespace": "AWS::EFS"
+    }
   ],
   "aws-eks": [
-    "AWS::EKS"
+    {
+      "namespace": "AWS::EKS"
+    }
   ],
   "aws-elasticache": [
-    "AWS::ElastiCache"
+    {
+      "namespace": "AWS::ElastiCache"
+    }
   ],
   "aws-elasticbeanstalk": [
-    "AWS::ElasticBeanstalk"
+    {
+      "namespace": "AWS::ElasticBeanstalk"
+    }
   ],
   "aws-elasticloadbalancing": [
-    "AWS::ElasticLoadBalancing"
+    {
+      "namespace": "AWS::ElasticLoadBalancing"
+    }
   ],
   "aws-elasticloadbalancingv2": [
-    "AWS::ElasticLoadBalancingV2"
+    {
+      "namespace": "AWS::ElasticLoadBalancingV2"
+    }
   ],
   "aws-elasticsearch": [
-    "AWS::Elasticsearch"
+    {
+      "namespace": "AWS::Elasticsearch"
+    }
   ],
   "aws-emr": [
-    "AWS::EMR"
+    {
+      "namespace": "AWS::EMR"
+    }
   ],
   "aws-emrcontainers": [
-    "AWS::EMRContainers"
+    {
+      "namespace": "AWS::EMRContainers"
+    }
   ],
   "aws-emrserverless": [
-    "AWS::EMRServerless"
+    {
+      "namespace": "AWS::EMRServerless"
+    }
   ],
   "aws-entityresolution": [
-    "AWS::EntityResolution"
+    {
+      "namespace": "AWS::EntityResolution"
+    }
   ],
   "aws-events": [
-    "AWS::Events"
+    {
+      "namespace": "AWS::Events"
+    }
   ],
   "aws-eventschemas": [
-    "AWS::EventSchemas"
+    {
+      "namespace": "AWS::EventSchemas"
+    }
   ],
   "aws-evidently": [
-    "AWS::Evidently"
+    {
+      "namespace": "AWS::Evidently"
+    }
   ],
   "aws-evs": [
-    "AWS::EVS"
+    {
+      "namespace": "AWS::EVS"
+    }
   ],
   "aws-finspace": [
-    "AWS::FinSpace"
+    {
+      "namespace": "AWS::FinSpace"
+    }
   ],
   "aws-fis": [
-    "AWS::FIS"
+    {
+      "namespace": "AWS::FIS"
+    }
   ],
   "aws-fms": [
-    "AWS::FMS"
+    {
+      "namespace": "AWS::FMS"
+    }
   ],
   "aws-forecast": [
-    "AWS::Forecast"
+    {
+      "namespace": "AWS::Forecast"
+    }
   ],
   "aws-frauddetector": [
-    "AWS::FraudDetector"
+    {
+      "namespace": "AWS::FraudDetector"
+    }
   ],
   "aws-fsx": [
-    "AWS::FSx"
+    {
+      "namespace": "AWS::FSx"
+    }
   ],
   "aws-gamelift": [
-    "AWS::GameLift"
+    {
+      "namespace": "AWS::GameLift"
+    }
   ],
   "aws-gameliftstreams": [
-    "AWS::GameLiftStreams"
+    {
+      "namespace": "AWS::GameLiftStreams"
+    }
   ],
   "aws-globalaccelerator": [
-    "AWS::GlobalAccelerator"
+    {
+      "namespace": "AWS::GlobalAccelerator"
+    }
   ],
   "aws-glue": [
-    "AWS::Glue"
+    {
+      "namespace": "AWS::Glue"
+    }
   ],
   "aws-grafana": [
-    "AWS::Grafana"
+    {
+      "namespace": "AWS::Grafana"
+    }
   ],
   "aws-greengrass": [
-    "AWS::Greengrass"
+    {
+      "namespace": "AWS::Greengrass"
+    }
   ],
   "aws-greengrassv2": [
-    "AWS::GreengrassV2"
+    {
+      "namespace": "AWS::GreengrassV2"
+    }
   ],
   "aws-groundstation": [
-    "AWS::GroundStation"
+    {
+      "namespace": "AWS::GroundStation"
+    }
   ],
   "aws-guardduty": [
-    "AWS::GuardDuty"
+    {
+      "namespace": "AWS::GuardDuty"
+    }
   ],
   "aws-healthimaging": [
-    "AWS::HealthImaging"
+    {
+      "namespace": "AWS::HealthImaging"
+    }
   ],
   "aws-healthlake": [
-    "AWS::HealthLake"
+    {
+      "namespace": "AWS::HealthLake"
+    }
   ],
   "aws-iam": [
-    "AWS::IAM"
+    {
+      "namespace": "AWS::IAM"
+    }
   ],
   "aws-identitystore": [
-    "AWS::IdentityStore"
+    {
+      "namespace": "AWS::IdentityStore"
+    }
   ],
   "aws-imagebuilder": [
-    "AWS::ImageBuilder"
+    {
+      "namespace": "AWS::ImageBuilder"
+    }
   ],
   "aws-inspector": [
-    "AWS::Inspector"
+    {
+      "namespace": "AWS::Inspector"
+    }
   ],
   "aws-inspectorv2": [
-    "AWS::InspectorV2"
+    {
+      "namespace": "AWS::InspectorV2"
+    }
   ],
   "aws-internetmonitor": [
-    "AWS::InternetMonitor"
+    {
+      "namespace": "AWS::InternetMonitor"
+    }
   ],
   "aws-invoicing": [
-    "AWS::Invoicing"
+    {
+      "namespace": "AWS::Invoicing"
+    }
   ],
   "aws-iot": [
-    "AWS::IoT"
+    {
+      "namespace": "AWS::IoT"
+    }
   ],
   "aws-iotanalytics": [
-    "AWS::IoTAnalytics"
+    {
+      "namespace": "AWS::IoTAnalytics"
+    }
   ],
   "aws-iotcoredeviceadvisor": [
-    "AWS::IoTCoreDeviceAdvisor"
+    {
+      "namespace": "AWS::IoTCoreDeviceAdvisor"
+    }
   ],
   "aws-iotevents": [
-    "AWS::IoTEvents"
+    {
+      "namespace": "AWS::IoTEvents"
+    }
   ],
   "aws-iotfleethub": [
-    "AWS::IoTFleetHub"
+    {
+      "namespace": "AWS::IoTFleetHub"
+    }
   ],
   "aws-iotfleetwise": [
-    "AWS::IoTFleetWise"
+    {
+      "namespace": "AWS::IoTFleetWise"
+    }
   ],
   "aws-iotsitewise": [
-    "AWS::IoTSiteWise"
+    {
+      "namespace": "AWS::IoTSiteWise"
+    }
   ],
   "aws-iotthingsgraph": [
-    "AWS::IoTThingsGraph"
+    {
+      "namespace": "AWS::IoTThingsGraph"
+    }
   ],
   "aws-iottwinmaker": [
-    "AWS::IoTTwinMaker"
+    {
+      "namespace": "AWS::IoTTwinMaker"
+    }
   ],
   "aws-iotwireless": [
-    "AWS::IoTWireless"
+    {
+      "namespace": "AWS::IoTWireless"
+    }
   ],
   "aws-ivs": [
-    "AWS::IVS"
+    {
+      "namespace": "AWS::IVS"
+    }
   ],
   "aws-ivschat": [
-    "AWS::IVSChat"
+    {
+      "namespace": "AWS::IVSChat"
+    }
   ],
   "aws-kafkaconnect": [
-    "AWS::KafkaConnect"
+    {
+      "namespace": "AWS::KafkaConnect"
+    }
   ],
   "aws-kendra": [
-    "AWS::Kendra"
+    {
+      "namespace": "AWS::Kendra"
+    }
   ],
   "aws-kendraranking": [
-    "AWS::KendraRanking"
+    {
+      "namespace": "AWS::KendraRanking"
+    }
   ],
   "aws-kinesis": [
-    "AWS::Kinesis"
+    {
+      "namespace": "AWS::Kinesis"
+    }
   ],
   "aws-kinesisanalytics": [
-    "AWS::KinesisAnalytics",
-    "AWS::KinesisAnalyticsV2"
+    {
+      "namespace": "AWS::KinesisAnalytics"
+    },
+    {
+      "namespace": "AWS::KinesisAnalyticsV2",
+      "suffix": "V2",
+      "deprecated": "use `aws-kinesisanalyticsv2` instead"
+    }
   ],
   "aws-kinesisanalyticsv2": [
-    "AWS::KinesisAnalyticsV2"
+    {
+      "namespace": "AWS::KinesisAnalyticsV2"
+    }
   ],
   "aws-kinesisfirehose": [
-    "AWS::KinesisFirehose"
+    {
+      "namespace": "AWS::KinesisFirehose"
+    }
   ],
   "aws-kinesisvideo": [
-    "AWS::KinesisVideo"
+    {
+      "namespace": "AWS::KinesisVideo"
+    }
   ],
   "aws-kms": [
-    "AWS::KMS"
+    {
+      "namespace": "AWS::KMS"
+    }
   ],
   "aws-lakeformation": [
-    "AWS::LakeFormation"
+    {
+      "namespace": "AWS::LakeFormation"
+    }
   ],
   "aws-lambda": [
-    "AWS::Lambda"
+    {
+      "namespace": "AWS::Lambda"
+    }
   ],
   "aws-launchwizard": [
-    "AWS::LaunchWizard"
+    {
+      "namespace": "AWS::LaunchWizard"
+    }
   ],
   "aws-lex": [
-    "AWS::Lex"
+    {
+      "namespace": "AWS::Lex"
+    }
   ],
   "aws-licensemanager": [
-    "AWS::LicenseManager"
+    {
+      "namespace": "AWS::LicenseManager"
+    }
   ],
   "aws-lightsail": [
-    "AWS::Lightsail"
+    {
+      "namespace": "AWS::Lightsail"
+    }
   ],
   "aws-location": [
-    "AWS::Location"
+    {
+      "namespace": "AWS::Location"
+    }
   ],
   "aws-logs": [
-    "AWS::Logs"
+    {
+      "namespace": "AWS::Logs"
+    }
   ],
   "aws-lookoutequipment": [
-    "AWS::LookoutEquipment"
+    {
+      "namespace": "AWS::LookoutEquipment"
+    }
   ],
   "aws-lookoutmetrics": [
-    "AWS::LookoutMetrics"
+    {
+      "namespace": "AWS::LookoutMetrics"
+    }
   ],
   "aws-lookoutvision": [
-    "AWS::LookoutVision"
+    {
+      "namespace": "AWS::LookoutVision"
+    }
   ],
   "aws-m2": [
-    "AWS::M2"
+    {
+      "namespace": "AWS::M2"
+    }
   ],
   "aws-macie": [
-    "AWS::Macie"
+    {
+      "namespace": "AWS::Macie"
+    }
   ],
   "aws-managedblockchain": [
-    "AWS::ManagedBlockchain"
+    {
+      "namespace": "AWS::ManagedBlockchain"
+    }
   ],
   "aws-mediaconnect": [
-    "AWS::MediaConnect"
+    {
+      "namespace": "AWS::MediaConnect"
+    }
   ],
   "aws-mediaconvert": [
-    "AWS::MediaConvert"
+    {
+      "namespace": "AWS::MediaConvert"
+    }
   ],
   "aws-medialive": [
-    "AWS::MediaLive"
+    {
+      "namespace": "AWS::MediaLive"
+    }
   ],
   "aws-mediapackage": [
-    "AWS::MediaPackage"
+    {
+      "namespace": "AWS::MediaPackage"
+    }
   ],
   "aws-mediapackagev2": [
-    "AWS::MediaPackageV2"
+    {
+      "namespace": "AWS::MediaPackageV2"
+    }
   ],
   "aws-mediastore": [
-    "AWS::MediaStore"
+    {
+      "namespace": "AWS::MediaStore"
+    }
   ],
   "aws-mediatailor": [
-    "AWS::MediaTailor"
+    {
+      "namespace": "AWS::MediaTailor"
+    }
   ],
   "aws-memorydb": [
-    "AWS::MemoryDB"
+    {
+      "namespace": "AWS::MemoryDB"
+    }
   ],
   "aws-mpa": [
-    "AWS::MPA"
+    {
+      "namespace": "AWS::MPA"
+    }
   ],
   "aws-msk": [
-    "AWS::MSK"
+    {
+      "namespace": "AWS::MSK"
+    }
   ],
   "aws-mwaa": [
-    "AWS::MWAA"
+    {
+      "namespace": "AWS::MWAA"
+    }
   ],
   "aws-neptune": [
-    "AWS::Neptune"
+    {
+      "namespace": "AWS::Neptune"
+    }
   ],
   "aws-neptunegraph": [
-    "AWS::NeptuneGraph"
+    {
+      "namespace": "AWS::NeptuneGraph"
+    }
   ],
   "aws-networkfirewall": [
-    "AWS::NetworkFirewall"
+    {
+      "namespace": "AWS::NetworkFirewall"
+    }
   ],
   "aws-networkmanager": [
-    "AWS::NetworkManager"
+    {
+      "namespace": "AWS::NetworkManager"
+    }
   ],
   "aws-nimblestudio": [
-    "AWS::NimbleStudio"
+    {
+      "namespace": "AWS::NimbleStudio"
+    }
   ],
   "aws-notifications": [
-    "AWS::Notifications"
+    {
+      "namespace": "AWS::Notifications"
+    }
   ],
   "aws-notificationscontacts": [
-    "AWS::NotificationsContacts"
+    {
+      "namespace": "AWS::NotificationsContacts"
+    }
   ],
   "aws-oam": [
-    "AWS::Oam"
+    {
+      "namespace": "AWS::Oam"
+    }
   ],
   "aws-observabilityadmin": [
-    "AWS::ObservabilityAdmin"
+    {
+      "namespace": "AWS::ObservabilityAdmin"
+    }
   ],
   "aws-odb": [
-    "AWS::ODB"
+    {
+      "namespace": "AWS::ODB"
+    }
   ],
   "aws-omics": [
-    "AWS::Omics"
+    {
+      "namespace": "AWS::Omics"
+    }
   ],
   "aws-opensearchserverless": [
-    "AWS::OpenSearchServerless"
+    {
+      "namespace": "AWS::OpenSearchServerless"
+    }
   ],
   "aws-opensearchservice": [
-    "AWS::OpenSearchService"
+    {
+      "namespace": "AWS::OpenSearchService"
+    }
   ],
   "aws-opsworks": [
-    "AWS::OpsWorks"
+    {
+      "namespace": "AWS::OpsWorks"
+    }
   ],
   "aws-opsworkscm": [
-    "AWS::OpsWorksCM"
+    {
+      "namespace": "AWS::OpsWorksCM"
+    }
   ],
   "aws-organizations": [
-    "AWS::Organizations"
+    {
+      "namespace": "AWS::Organizations"
+    }
   ],
   "aws-osis": [
-    "AWS::OSIS"
+    {
+      "namespace": "AWS::OSIS"
+    }
   ],
   "aws-panorama": [
-    "AWS::Panorama"
+    {
+      "namespace": "AWS::Panorama"
+    }
   ],
   "aws-paymentcryptography": [
-    "AWS::PaymentCryptography"
+    {
+      "namespace": "AWS::PaymentCryptography"
+    }
   ],
   "aws-pcaconnectorad": [
-    "AWS::PCAConnectorAD"
+    {
+      "namespace": "AWS::PCAConnectorAD"
+    }
   ],
   "aws-pcaconnectorscep": [
-    "AWS::PCAConnectorSCEP"
+    {
+      "namespace": "AWS::PCAConnectorSCEP"
+    }
   ],
   "aws-pcs": [
-    "AWS::PCS"
+    {
+      "namespace": "AWS::PCS"
+    }
   ],
   "aws-personalize": [
-    "AWS::Personalize"
+    {
+      "namespace": "AWS::Personalize"
+    }
   ],
   "aws-pinpoint": [
-    "AWS::Pinpoint"
+    {
+      "namespace": "AWS::Pinpoint"
+    }
   ],
   "aws-pinpointemail": [
-    "AWS::PinpointEmail"
+    {
+      "namespace": "AWS::PinpointEmail"
+    }
   ],
   "aws-pipes": [
-    "AWS::Pipes"
+    {
+      "namespace": "AWS::Pipes"
+    }
   ],
   "aws-proton": [
-    "AWS::Proton"
+    {
+      "namespace": "AWS::Proton"
+    }
   ],
   "aws-qbusiness": [
-    "AWS::QBusiness"
+    {
+      "namespace": "AWS::QBusiness"
+    }
   ],
   "aws-qldb": [
-    "AWS::QLDB"
+    {
+      "namespace": "AWS::QLDB"
+    }
   ],
   "aws-quicksight": [
-    "AWS::QuickSight"
+    {
+      "namespace": "AWS::QuickSight"
+    }
   ],
   "aws-ram": [
-    "AWS::RAM"
+    {
+      "namespace": "AWS::RAM"
+    }
   ],
   "aws-rbin": [
-    "AWS::Rbin"
+    {
+      "namespace": "AWS::Rbin"
+    }
   ],
   "aws-rds": [
-    "AWS::RDS"
+    {
+      "namespace": "AWS::RDS"
+    }
   ],
   "aws-redshift": [
-    "AWS::Redshift"
+    {
+      "namespace": "AWS::Redshift"
+    }
   ],
   "aws-redshiftserverless": [
-    "AWS::RedshiftServerless"
+    {
+      "namespace": "AWS::RedshiftServerless"
+    }
   ],
   "aws-refactorspaces": [
-    "AWS::RefactorSpaces"
+    {
+      "namespace": "AWS::RefactorSpaces"
+    }
   ],
   "aws-rekognition": [
-    "AWS::Rekognition"
+    {
+      "namespace": "AWS::Rekognition"
+    }
   ],
   "aws-resiliencehub": [
-    "AWS::ResilienceHub"
+    {
+      "namespace": "AWS::ResilienceHub"
+    }
   ],
   "aws-resourceexplorer2": [
-    "AWS::ResourceExplorer2"
+    {
+      "namespace": "AWS::ResourceExplorer2"
+    }
   ],
   "aws-resourcegroups": [
-    "AWS::ResourceGroups"
+    {
+      "namespace": "AWS::ResourceGroups"
+    }
   ],
   "aws-robomaker": [
-    "AWS::RoboMaker"
+    {
+      "namespace": "AWS::RoboMaker"
+    }
   ],
   "aws-rolesanywhere": [
-    "AWS::RolesAnywhere"
+    {
+      "namespace": "AWS::RolesAnywhere"
+    }
   ],
   "aws-route53": [
-    "AWS::Route53"
+    {
+      "namespace": "AWS::Route53"
+    }
   ],
   "aws-route53profiles": [
-    "AWS::Route53Profiles"
+    {
+      "namespace": "AWS::Route53Profiles"
+    }
   ],
   "aws-route53recoverycontrol": [
-    "AWS::Route53RecoveryControl"
+    {
+      "namespace": "AWS::Route53RecoveryControl"
+    }
   ],
   "aws-route53recoveryreadiness": [
-    "AWS::Route53RecoveryReadiness"
+    {
+      "namespace": "AWS::Route53RecoveryReadiness"
+    }
   ],
   "aws-route53resolver": [
-    "AWS::Route53Resolver"
+    {
+      "namespace": "AWS::Route53Resolver"
+    }
   ],
   "aws-rum": [
-    "AWS::RUM"
+    {
+      "namespace": "AWS::RUM"
+    }
   ],
   "aws-s3": [
-    "AWS::S3"
+    {
+      "namespace": "AWS::S3"
+    }
   ],
   "aws-s3express": [
-    "AWS::S3Express"
+    {
+      "namespace": "AWS::S3Express"
+    }
   ],
   "aws-s3objectlambda": [
-    "AWS::S3ObjectLambda"
+    {
+      "namespace": "AWS::S3ObjectLambda"
+    }
   ],
   "aws-s3outposts": [
-    "AWS::S3Outposts"
+    {
+      "namespace": "AWS::S3Outposts"
+    }
   ],
   "aws-s3tables": [
-    "AWS::S3Tables"
+    {
+      "namespace": "AWS::S3Tables"
+    }
   ],
   "aws-sagemaker": [
-    "AWS::SageMaker"
+    {
+      "namespace": "AWS::SageMaker"
+    }
   ],
   "aws-sam": [
-    "AWS::Serverless"
+    {
+      "namespace": "AWS::Serverless"
+    }
   ],
   "aws-scheduler": [
-    "AWS::Scheduler"
+    {
+      "namespace": "AWS::Scheduler"
+    }
   ],
   "aws-sdb": [
-    "AWS::SDB"
+    {
+      "namespace": "AWS::SDB"
+    }
   ],
   "aws-secretsmanager": [
-    "AWS::SecretsManager"
+    {
+      "namespace": "AWS::SecretsManager"
+    }
   ],
   "aws-securityhub": [
-    "AWS::SecurityHub"
+    {
+      "namespace": "AWS::SecurityHub"
+    }
   ],
   "aws-securitylake": [
-    "AWS::SecurityLake"
+    {
+      "namespace": "AWS::SecurityLake"
+    }
   ],
   "aws-servicecatalog": [
-    "AWS::ServiceCatalog"
+    {
+      "namespace": "AWS::ServiceCatalog"
+    }
   ],
   "aws-servicecatalogappregistry": [
-    "AWS::ServiceCatalogAppRegistry"
+    {
+      "namespace": "AWS::ServiceCatalogAppRegistry"
+    }
   ],
   "aws-servicediscovery": [
-    "AWS::ServiceDiscovery"
+    {
+      "namespace": "AWS::ServiceDiscovery"
+    }
   ],
   "aws-ses": [
-    "AWS::SES"
+    {
+      "namespace": "AWS::SES"
+    }
   ],
   "aws-shield": [
-    "AWS::Shield"
+    {
+      "namespace": "AWS::Shield"
+    }
   ],
   "aws-signer": [
-    "AWS::Signer"
+    {
+      "namespace": "AWS::Signer"
+    }
   ],
   "aws-simspaceweaver": [
-    "AWS::SimSpaceWeaver"
+    {
+      "namespace": "AWS::SimSpaceWeaver"
+    }
   ],
   "aws-sns": [
-    "AWS::SNS"
+    {
+      "namespace": "AWS::SNS"
+    }
   ],
   "aws-sqs": [
-    "AWS::SQS"
+    {
+      "namespace": "AWS::SQS"
+    }
   ],
   "aws-ssm": [
-    "AWS::SSM"
+    {
+      "namespace": "AWS::SSM"
+    }
   ],
   "aws-ssmcontacts": [
-    "AWS::SSMContacts"
+    {
+      "namespace": "AWS::SSMContacts"
+    }
   ],
   "aws-ssmguiconnect": [
-    "AWS::SSMGuiConnect"
+    {
+      "namespace": "AWS::SSMGuiConnect"
+    }
   ],
   "aws-ssmincidents": [
-    "AWS::SSMIncidents"
+    {
+      "namespace": "AWS::SSMIncidents"
+    }
   ],
   "aws-ssmquicksetup": [
-    "AWS::SSMQuickSetup"
+    {
+      "namespace": "AWS::SSMQuickSetup"
+    }
   ],
   "aws-sso": [
-    "AWS::SSO"
+    {
+      "namespace": "AWS::SSO"
+    }
   ],
   "aws-stepfunctions": [
-    "AWS::StepFunctions"
+    {
+      "namespace": "AWS::StepFunctions"
+    }
   ],
   "aws-supportapp": [
-    "AWS::SupportApp"
+    {
+      "namespace": "AWS::SupportApp"
+    }
   ],
   "aws-synthetics": [
-    "AWS::Synthetics"
+    {
+      "namespace": "AWS::Synthetics"
+    }
   ],
   "aws-systemsmanagersap": [
-    "AWS::SystemsManagerSAP"
+    {
+      "namespace": "AWS::SystemsManagerSAP"
+    }
   ],
   "aws-timestream": [
-    "AWS::Timestream"
+    {
+      "namespace": "AWS::Timestream"
+    }
   ],
   "aws-transfer": [
-    "AWS::Transfer"
+    {
+      "namespace": "AWS::Transfer"
+    }
   ],
   "aws-verifiedpermissions": [
-    "AWS::VerifiedPermissions"
+    {
+      "namespace": "AWS::VerifiedPermissions"
+    }
   ],
   "aws-voiceid": [
-    "AWS::VoiceID"
+    {
+      "namespace": "AWS::VoiceID"
+    }
   ],
   "aws-vpclattice": [
-    "AWS::VpcLattice"
+    {
+      "namespace": "AWS::VpcLattice"
+    }
   ],
   "aws-waf": [
-    "AWS::WAF"
+    {
+      "namespace": "AWS::WAF"
+    }
   ],
   "aws-wafregional": [
-    "AWS::WAFRegional"
+    {
+      "namespace": "AWS::WAFRegional"
+    }
   ],
   "aws-wafv2": [
-    "AWS::WAFv2"
+    {
+      "namespace": "AWS::WAFv2"
+    }
   ],
   "aws-wisdom": [
-    "AWS::Wisdom"
+    {
+      "namespace": "AWS::Wisdom"
+    }
   ],
   "aws-workspaces": [
-    "AWS::WorkSpaces"
+    {
+      "namespace": "AWS::WorkSpaces"
+    }
   ],
   "aws-workspacesinstances": [
-    "AWS::WorkspacesInstances"
+    {
+      "namespace": "AWS::WorkspacesInstances"
+    }
   ],
   "aws-workspacesthinclient": [
-    "AWS::WorkSpacesThinClient"
+    {
+      "namespace": "AWS::WorkSpacesThinClient"
+    }
   ],
   "aws-workspacesweb": [
-    "AWS::WorkSpacesWeb"
+    {
+      "namespace": "AWS::WorkSpacesWeb"
+    }
   ],
   "aws-xray": [
-    "AWS::XRay"
+    {
+      "namespace": "AWS::XRay"
+    }
   ],
   "core": [
-    "AWS::CloudFormation"
+    {
+      "namespace": "AWS::CloudFormation"
+    }
   ]
 }

--- a/packages/aws-cdk-lib/scripts/submodules/index.ts
+++ b/packages/aws-cdk-lib/scripts/submodules/index.ts
@@ -22,7 +22,7 @@ async function ensureSubmodule(submodule: ModuleMapEntry, modulePath: string) {
   // README.md
   const readmePath = path.join(modulePath, 'README.md');
   if (!fs.existsSync(readmePath)) {
-    await createLibraryReadme(submodule.scopes[0], readmePath);
+    await createLibraryReadme(submodule.scopes[0].namespace, readmePath);
   }
 
   // index.ts
@@ -34,7 +34,7 @@ async function ensureSubmodule(submodule: ModuleMapEntry, modulePath: string) {
   // lib/index.ts
   const sourcePath = path.join(modulePath, 'lib');
   if (!fs.existsSync(path.join(sourcePath, 'index.ts'))) {
-    const lines = submodule.scopes.map((s: string) => `// ${s} Cloudformation Resources`);
+    const lines = submodule.scopes.map(({ namespace }) => `// ${namespace} Cloudformation Resources`);
     lines.push(...submodule.files
       .map((f) => {
         // New codegen uses absolute paths

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/ast.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/ast.ts
@@ -34,6 +34,13 @@ export interface AstBuilderProps {
    * Append a suffix at the end of generated names.
    */
   readonly nameSuffix?: string;
+
+  /**
+   * Mark everything in the service as deprecated using the provided deprecation message.
+   *
+   * @default - not deprecated
+   */
+  readonly deprecated?: string;
 }
 
 export class AstBuilder<T extends Module> {
@@ -77,6 +84,7 @@ export class AstBuilder<T extends Module> {
    */
   public readonly resources: Record<string, string> = {};
   private nameSuffix?: string;
+  private deprecated?: string;
 
   protected constructor(
     public readonly module: T,
@@ -86,6 +94,7 @@ export class AstBuilder<T extends Module> {
   ) {
     this.db = props.db;
     this.nameSuffix = props.nameSuffix;
+    this.deprecated = props.deprecated;
 
     CDK_CORE.import(this.module, 'cdk', { fromLocation: props.importLocations?.core });
     CONSTRUCTS.import(this.module, 'constructs');
@@ -94,7 +103,10 @@ export class AstBuilder<T extends Module> {
   }
 
   public addResource(resource: Resource) {
-    const resourceClass = new ResourceClass(this.module, this.db, resource, this.nameSuffix);
+    const resourceClass = new ResourceClass(this.module, this.db, resource, {
+      suffix: this.nameSuffix,
+      deprecated: this.deprecated,
+    });
     this.resources[resource.cloudFormationType] = resourceClass.spec.name;
 
     resourceClass.build();

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/resource-class.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/resource-class.ts
@@ -21,6 +21,7 @@ import {
   ObjectLiteral,
   Module,
   InterfaceType,
+  DocsSpec,
 } from '@cdklabs/typewriter';
 import { CDK_CORE, CONSTRUCTS } from './cdk';
 import { CloudFormationMapping } from './cloudformation-mapping';
@@ -44,6 +45,11 @@ export interface ITypeHost {
 // This convenience typewriter builder is used all over the place
 const $this = $E(expr.this_());
 
+export interface ResourceClassProps {
+  readonly suffix?: string;
+  readonly deprecated?: string;
+}
+
 export class ResourceClass extends ClassType {
   private readonly propsType: StructType;
   private readonly refInterface?: InterfaceType;
@@ -55,25 +61,26 @@ export class ResourceClass extends ClassType {
     scope: IScope,
     private readonly db: SpecDatabase,
     private readonly resource: Resource,
-    private readonly suffix?: string,
+    private readonly props: ResourceClassProps = {},
   ) {
     let refInterface: InterfaceType | undefined;
     if (shouldBuildReferenceInterface(resource)) {
       // IBucketRef { bucketRef: BucketRef }
       refInterface = new InterfaceType(scope, {
         export: true,
-        name: `I${resource.name}${suffix ?? ''}Ref`,
+        name: `I${resource.name}${props.suffix ?? ''}Ref`,
         extends: [CONSTRUCTS.IConstruct],
         docs: {
           summary: `Indicates that this resource can be referenced as a ${resource.name}.`,
           stability: Stability.Experimental,
+          ...maybeDeprecated(props.deprecated),
         },
       });
     }
 
     super(scope, {
       export: true,
-      name: classNameFromResource(resource, suffix),
+      name: classNameFromResource(resource, props.suffix),
       docs: {
         ...splitDocumentation(resource.documentation),
         stability: Stability.External,
@@ -81,6 +88,7 @@ export class ResourceClass extends ClassType {
         see: cloudFormationDocLink({
           resourceType: resource.cloudFormationType,
         }),
+        ...maybeDeprecated(props.deprecated),
       },
       extends: CDK_CORE.CfnResource,
       implements: [CDK_CORE.IInspectable, refInterface?.type, ...ResourceDecider.taggabilityInterfaces(resource)].filter(isDefined),
@@ -91,13 +99,14 @@ export class ResourceClass extends ClassType {
 
     this.propsType = new StructType(this.scope, {
       export: true,
-      name: propStructNameFromResource(this.resource, this.suffix),
+      name: propStructNameFromResource(this.resource, this.props.suffix),
       docs: {
         summary: `Properties for defining a \`${classNameFromResource(this.resource)}\``,
         stability: Stability.External,
         see: cloudFormationDocLink({
           resourceType: this.resource.cloudFormationType,
         }),
+        ...maybeDeprecated(props.deprecated),
       },
     });
 
@@ -183,10 +192,11 @@ export class ResourceClass extends ClassType {
     // BucketRef { bucketName, bucketArn }
     const refPropsStruct = new StructType(this.scope, {
       export: true,
-      name: `${this.resource.name}${this.suffix ?? ''}Reference`,
+      name: `${this.resource.name}${this.props.suffix ?? ''}Reference`,
       docs: {
         summary: `A reference to a ${this.resource.name} resource.`,
         stability: Stability.External,
+        ...maybeDeprecated(this.props.deprecated),
       },
     });
 
@@ -456,4 +466,28 @@ export class ResourceClass extends ClassType {
  */
 function isDefined<T>(x: T | undefined): x is T {
   return x !== undefined;
+}
+
+/**
+ * Compute stability taking into account deprecation status.
+ */
+function stability(isDeprecated: boolean = false, defaultStability: Stability = Stability.External): Stability {
+  if (isDeprecated) {
+    return Stability.Deprecated;
+  }
+  return defaultStability;
+}
+
+/**
+ * Returns deprecation props if deprecated.
+ */
+function maybeDeprecated(deprecationNotice?: string, defaultStability: Stability = Stability.External): Pick<DocsSpec, 'deprecated' | 'stability'> {
+  if (deprecationNotice) {
+    return {
+      deprecated: deprecationNotice,
+      stability: stability(Boolean(deprecationNotice), defaultStability),
+    };
+  }
+
+  return {};
 }

--- a/tools/@aws-cdk/spec2cdk/lib/cfn2ts/cfn2ts.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cfn2ts/cfn2ts.ts
@@ -35,6 +35,7 @@ async function main() {
   }
 
   if (!argv.scope) {
+    // eslint-disable-next-line @cdklabs/no-throw-default-error
     throw new Error(
       '--scope is not provided and cannot be auto-detected from package.json (under "cdk-build.cloudformation")',
     );
@@ -42,6 +43,7 @@ async function main() {
 
   await generate(argv.scope, argv.out, {
     coreImport: argv['core-import'],
+    autoGenerateSuffixes: true, // for backwards compat
   });
 }
 

--- a/tools/@aws-cdk/spec2cdk/lib/cfn2ts/types.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cfn2ts/types.ts
@@ -8,6 +8,13 @@ export interface CodeGeneratorOptions {
    * @default '@aws-cdk/core'
    */
   readonly coreImport?: string;
+
+  /**
+   * Automatically generate service suffixes
+   *
+   * @default false
+   */
+  readonly autoGenerateSuffixes?: boolean;
 }
 
 export interface AugmentationsGeneratorOptions {
@@ -36,12 +43,21 @@ export interface GenerateAllOptions extends CodeGeneratorOptions, AugmentationsG
 }
 
 /**
+ * A data structure holding information about a single scope in a generated module.
+ */
+export interface ModuleMapScope {
+  readonly namespace: string;
+  readonly suffix?: string;
+  readonly deprecated?: string;
+}
+
+/**
  * A data structure holding information about a generated module.
  */
 export interface ModuleMapEntry {
   name: string;
   definition?: pkglint.ModuleDefinition;
-  scopes: string[];
+  scopes: ModuleMapScope[];
   resources: Record<string, string>;
   files: string[];
 }

--- a/tools/@aws-cdk/spec2cdk/lib/cli/cli.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cli/cli.ts
@@ -125,7 +125,7 @@ export async function main(argv: string[]) {
       if (!service.includes('::')) {
         throw new EvalError(`Each service must be in the form <Partition>::<Service>, e.g. AWS::S3. Got: ${service}`);
       }
-      moduleMap[service.toLocaleLowerCase().split('::').join('-')] = { services: [service] };
+      moduleMap[service.toLocaleLowerCase().split('::').join('-')] = { services: [{ namespace: service }] };
     }
     await generate(moduleMap, generatorOptions);
     return;
@@ -139,6 +139,7 @@ function stringOr(pat: unknown, def: string) {
     return def;
   }
   if (typeof pat !== 'string') {
+    // eslint-disable-next-line @cdklabs/no-throw-default-error
     throw new Error(`Expected string, got: ${JSON.stringify(pat)}`);
   }
   return pat;

--- a/tools/@aws-cdk/spec2cdk/lib/util/db.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/util/db.ts
@@ -1,4 +1,5 @@
-import { SpecDatabase } from '@aws-cdk/service-spec-types';
+import { Service, SpecDatabase } from '@aws-cdk/service-spec-types';
+import { GenerateServiceRequest } from '../generate';
 
 export function getAllServices(db: SpecDatabase) {
   return db.all('service');
@@ -6,4 +7,13 @@ export function getAllServices(db: SpecDatabase) {
 
 export function getServicesByCloudFormationNamespace(db: SpecDatabase, namespaces: string[]) {
   return namespaces.flatMap((ns) => db.lookup('service', 'cloudFormationNamespace', 'equals', ns));
+}
+
+export function getServicesByGenerateServiceRequest(db: SpecDatabase, requests: GenerateServiceRequest[]): Array<[GenerateServiceRequest, Service]> {
+  const requestMap = new Map(requests.map(s => [s.namespace, s]));
+  return requests
+    .flatMap((s) => db.lookup('service', 'cloudFormationNamespace', 'equals', s.namespace))
+    .map(
+      (service) => [requestMap.get(service.cloudFormationNamespace)!, service] as [GenerateServiceRequest, Service],
+    );
 }

--- a/tools/@aws-cdk/spec2cdk/test/__snapshots__/fake-services.test.ts.snap
+++ b/tools/@aws-cdk/spec2cdk/test/__snapshots__/fake-services.test.ts.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can codegen deprecated service 1`] = `
+"/* eslint-disable prettier/prettier, @stylistic/max-len */
+import * as cdk from "aws-cdk-lib";
+import * as constructs from "constructs";
+import * as cfn_parse from "aws-cdk-lib/core/lib/helpers-internal";
+import * as cdk_errors from "aws-cdk-lib/core/lib/errors";
+
+/**
+ * Indicates that this resource can be referenced as a Resource.
+ *
+ * @deprecated in favour of something else
+ * @stability deprecated
+ */
+export interface IResourceRef extends constructs.IConstruct {
+  /**
+   * A reference to a Resource resource.
+   */
+  readonly resourceRef: ResourceReference;
+}
+
+/**
+ * @deprecated in favour of something else
+ * @cloudformationResource AWS::Some::Resource
+ * @stability deprecated
+ * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-some-resource.html
+ */
+export class CfnResource extends cdk.CfnResource implements cdk.IInspectable, IResourceRef {
+  /**
+   * The CloudFormation resource type name for this resource class.
+   */
+  public static readonly CFN_RESOURCE_TYPE_NAME: string = "AWS::Some::Resource";
+
+  /**
+   * Build a CfnResource from CloudFormation properties
+   *
+   * A factory method that creates a new instance of this class from an object
+   * containing the CloudFormation properties of this resource.
+   * Used in the @aws-cdk/cloudformation-include module.
+   *
+   * @internal
+   */
+  public static _fromCloudFormation(scope: constructs.Construct, id: string, resourceAttributes: any, options: cfn_parse.FromCloudFormationOptions): CfnResource {
+    resourceAttributes = resourceAttributes || {};
+    const resourceProperties = options.parser.parseValue(resourceAttributes.Properties);
+    const propsResult = CfnResourcePropsFromCloudFormation(resourceProperties);
+    if (cdk.isResolvableObject(propsResult.value)) {
+      throw new cdk_errors.ValidationError("Unexpected IResolvable", scope);
+    }
+    const ret = new CfnResource(scope, id, propsResult.value);
+    for (const [propKey, propVal] of Object.entries(propsResult.extraProperties)) {
+      ret.addPropertyOverride(propKey, propVal);
+    }
+    options.parser.handleAttributes(ret, resourceAttributes, id);
+    return ret;
+  }
+
+  /**
+   * The identifier of the resource.
+   */
+  public id?: string;
+
+  /**
+   * @param scope Scope in which this resource is defined
+   * @param id Construct identifier for this resource (unique in its scope)
+   * @param props Resource properties
+   */
+  public constructor(scope: constructs.Construct, id: string, props: CfnResourceProps = {}) {
+    super(scope, id, {
+      "type": CfnResource.CFN_RESOURCE_TYPE_NAME,
+      "properties": props
+    });
+
+    this.id = props.id;
+  }
+
+  public get resourceRef(): ResourceReference {
+    return {
+      "resourceId": this.ref
+    };
+  }
+
+  protected get cfnProperties(): Record<string, any> {
+    return {
+      "id": this.id
+    };
+  }
+
+  /**
+   * Examines the CloudFormation resource and discloses attributes
+   *
+   * @param inspector tree inspector to collect and process attributes
+   */
+  public inspect(inspector: cdk.TreeInspector): void {
+    inspector.addAttribute("aws:cdk:cloudformation:type", CfnResource.CFN_RESOURCE_TYPE_NAME);
+    inspector.addAttribute("aws:cdk:cloudformation:props", this.cfnProperties);
+  }
+
+  protected renderProperties(props: Record<string, any>): Record<string, any> {
+    return convertCfnResourcePropsToCloudFormation(props);
+  }
+}
+
+/**
+ * Properties for defining a \`CfnResource\`
+ *
+ * @struct
+ * @deprecated in favour of something else
+ * @stability deprecated
+ * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-some-resource.html
+ */
+export interface CfnResourceProps {
+  /**
+   * The identifier of the resource.
+   *
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-some-resource.html#cfn-some-resource-id
+   */
+  readonly id?: string;
+}
+
+/**
+ * A reference to a Resource resource.
+ *
+ * @struct
+ * @deprecated in favour of something else
+ * @stability deprecated
+ */
+export interface ResourceReference {
+  /**
+   * The Id of the Resource resource.
+   */
+  readonly resourceId: string;
+}
+
+/**
+ * Determine whether the given properties match those of a \`CfnResourceProps\`
+ *
+ * @param properties - the TypeScript properties of a \`CfnResourceProps\`
+ *
+ * @returns the result of the validation.
+ */
+// @ts-ignore TS6133
+function CfnResourcePropsValidator(properties: any): cdk.ValidationResult {
+  if (!cdk.canInspect(properties)) return cdk.VALIDATION_SUCCESS;
+  const errors = new cdk.ValidationResults();
+  if (!(properties && typeof properties == 'object' && !Array.isArray(properties))) {
+    errors.collect(new cdk.ValidationResult("Expected an object, but received: " + JSON.stringify(properties)));
+  }
+  errors.collect(cdk.propertyValidator("id", cdk.validateString)(properties.id));
+  return errors.wrap("supplied properties not correct for \\"CfnResourceProps\\"");
+}
+
+// @ts-ignore TS6133
+function convertCfnResourcePropsToCloudFormation(properties: any): any {
+  if (!cdk.canInspect(properties)) return properties;
+  CfnResourcePropsValidator(properties).assertSuccess();
+  return {
+    "Id": cdk.stringToCloudFormation(properties.id)
+  };
+}
+
+// @ts-ignore TS6133
+function CfnResourcePropsFromCloudFormation(properties: any): cfn_parse.FromCloudFormationResult<CfnResourceProps | cdk.IResolvable> {
+  if (cdk.isResolvableObject(properties)) {
+    return new cfn_parse.FromCloudFormationResult(properties);
+  }
+  properties = ((properties == null) ? {} : properties);
+  if (!(properties && typeof properties == 'object' && !Array.isArray(properties))) {
+    return new cfn_parse.FromCloudFormationResult(properties);
+  }
+  const ret = new cfn_parse.FromCloudFormationPropertyObject<CfnResourceProps>();
+  ret.addPropertyResult("id", "Id", (properties.Id != null ? cfn_parse.FromCloudFormation.getString(properties.Id) : undefined));
+  ret.addUnrecognizedPropertiesAsExtra(properties);
+  return ret;
+}"
+`;

--- a/tools/@aws-cdk/spec2cdk/test/fake-services.test.ts
+++ b/tools/@aws-cdk/spec2cdk/test/fake-services.test.ts
@@ -1,0 +1,40 @@
+import { Service, SpecDatabase, emptyDatabase } from '@aws-cdk/service-spec-types';
+import { TypeScriptRenderer } from '@cdklabs/typewriter';
+import { AstBuilder } from '../lib/cdk/ast';
+
+const renderer = new TypeScriptRenderer();
+let db: SpecDatabase;
+let service: Service;
+
+beforeEach(async () => {
+  db = emptyDatabase();
+
+  service = db.allocate('service', {
+    name: 'aws-some',
+    shortName: 'some',
+    capitalized: 'Some',
+    cloudFormationNamespace: 'AWS::Some',
+  });
+});
+
+test('can codegen deprecated service', () => {
+  // GIVEN
+  const resource = db.allocate('resource', {
+    name: 'Resource',
+    primaryIdentifier: ['Id'],
+    attributes: {},
+    properties: {
+      Id: {
+        type: { type: 'string' },
+        documentation: 'The identifier of the resource',
+      },
+    },
+    cloudFormationType: 'AWS::Some::Resource',
+  });
+  db.link('hasResource', service, resource);
+
+  const ast = AstBuilder.forService(service, { db, deprecated: 'in favour of something else' });
+
+  const rendered = renderer.render(ast.module);
+  expect(rendered).toMatchSnapshot();
+});


### PR DESCRIPTION
### Reason for this change

Sometimes services introduces a `V2` version of their APIs and CloudFormation resources.
In the past we had thought it's a good idea if `KinesisAnalyticsV2` constructs would just be included in the original `aws-kinesisanalytics` module. However since then we have come to a different view and think it's better to strictly follow what the services are doing. As of today `KinesisAnalyticsV2` is the only service that got this treatment.

We now want to clearly indicate that this is not supported and deprecate the usage from within the "V1" module.

### Description of changes

Update the `spec2cdk` package to allow services being deprecated.
I've also changed the suffix handling to be explicit instead of computed when reading from a service map. Given that we only have that one module with multiple services, this seems prudent.

### Describe any new or updated permissions being added

n/a

### Description of how you validated changes

All existing tests pass. `jsii-diff` reports no issues. Test case added for codegen of deprecated service.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
