### PR TITLE
fix(kms): cannot access aliasTargetKey on an Alias imported by Alias.fromAliasName

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/lib/alias.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/alias.ts
@@ -220,7 +220,10 @@ export class Alias extends AliasBase {
       }
 
       public get keyRef(): KeyReference {
-        return this.aliasTargetKey.keyRef;
+        return {
+          keyArn: this.keyArn,
+          keyId: this.keyId,
+        };
       }
 
       public grant(grantee: iam.IGrantable, ...actions: string[]): iam.Grant {

--- a/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
+++ b/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
@@ -986,6 +986,33 @@ describe('subscription filter', () => {
   });
 });
 
+test('encrypting log group with referenced alias', () => {
+  const stack = new Stack();
+
+  const alias = kms.Alias.fromAliasName(stack, 'KmsAlias', 'alias/some-alias');
+
+  new LogGroup(stack, 'LogGroup', {
+    encryptionKey: alias,
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::Logs::LogGroup', {
+    KmsKeyId: {
+      'Fn::Join': [
+        '',
+        [
+          'arn:',
+          { Ref: 'AWS::Partition' },
+          ':kms:',
+          { Ref: 'AWS::Region' },
+          ':',
+          { Ref: 'AWS::AccountId' },
+          ':alias/some-alias',
+        ],
+      ],
+    },
+  });
+});
+
 test('create a Add Key transformer against a log group', () => {
   // GIVEN
   const stack = new Stack();


### PR DESCRIPTION
If an Alias is ~~imported~~ referenced using `fromAliasName`, it doesn't have an `IKey` object it's associated with.

If an Alias is then used in place of a Key and the consuming site uses the `IKey.keyRef` interface to obtain the key ARN, we should return the Alias ARN and not try to delegate to the underlying key... because there is none!

Closes #35520 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
