### PR TITLE
feat(apigatewayv2): expose disableExecuteApiEndpoint option in WebSocketApi configuration

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-apigatewayv2-integrations/test/websocket/integ.disable-execute-api-endpoint.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-apigatewayv2-integrations/test/websocket/integ.disable-execute-api-endpoint.ts
@@ -1,0 +1,39 @@
+import { WebSocketApi, WebSocketStage } from 'aws-cdk-lib/aws-apigatewayv2';
+import * as cdk from 'aws-cdk-lib';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+import { WebSocketMockIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+
+/*
+ * Stack verification steps:
+ * 1. Verify that the new property 'disableExecuteApiEndpoint' is set to 'true', and that it is not callable.
+ */
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'integ-apigwv2-disable-execute-api-endpoint');
+
+// API Gateway WebSocket API
+const webSocketApi = new WebSocketApi(stack, 'webSocketApi', {
+  description: 'Test stack for the disableExecuteApiEndpoint property.',
+  disableExecuteApiEndpoint: true,
+  defaultRouteOptions: { integration: new WebSocketMockIntegration('DefaultIntegration') },
+});
+
+// Optionally, create a WebSocket stage
+new WebSocketStage(stack, 'DevStage', {
+  webSocketApi: webSocketApi,
+  stageName: 'dev',
+  autoDeploy: true,
+});
+
+new IntegTest(app, 'DisableExecuteApiEndpointPropIntegrationTest', {
+  testCases: [stack],
+  cdkCommandOptions: {
+    deploy: {
+      args: {
+        rollback: true,
+      },
+    },
+  },
+});
+
+app.synth();

--- a/packages/aws-cdk-lib/aws-apigatewayv2/test/websocket/api.test.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/test/websocket/api.test.ts
@@ -130,6 +130,30 @@ describe('WebSocketApi', () => {
     });
   });
 
+  test('disableExecuteApiEndpoint is enabled', () => {
+    const stack = new Stack();
+    new WebSocketApi(stack, 'api', {
+      disableExecuteApiEndpoint: true,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::Api', {
+      Name: 'api',
+      ProtocolType: 'WEBSOCKET',
+      DisableExecuteApiEndpoint: true,
+    });
+  });
+
+  test('throws when accessing apiEndpoint and disableExecuteApiEndpoint is true', () => {
+    const stack = new Stack();
+    const api = new WebSocketApi(stack, 'api', {
+      disableExecuteApiEndpoint: true,
+    });
+
+    expect(() => api.apiEndpoint).toThrow(
+      /apiEndpoint is not accessible when disableExecuteApiEndpoint is set to true./,
+    );
+  });
+
   test('import', () => {
     // GIVEN
     const stack = new Stack();


### PR DESCRIPTION
### Issue #35516

Closes #35516

### Reason for this change

This change addresses a feature request to add the `disableExecuteApiEndpoint` property to the WebSocketApi construct. This property allows users to disable the default execute-api endpoint and enforce the use of a custom domain name. The underlying `CfnApi` construct already supports this property, and the `HttpApi` construct in the same module already implements it, so this change provides consistency across API Gateway v2 constructs.

### Description of changes

I've made the following code changes to expose the disableExecuteApiEndpoint property in the WebSocketApi construct:

- Added a `disableExecuteApiEndpoint?: boolean` property to the WebSocketApiProps interface.
- Added a `disableExecuteApiEndpoint?: boolean` property to the WebSocketApi class.
- Passed the `disableExecuteApiEndpoint` property to the underlying CfnApi construct's properties.
- Modified the public attribute `apiEndpoint` in the WebSocketApi class to be private.
- Added a getter for the private `_apiEndpoint` property that throws a ValidationError if `disableExecuteApiEndpoint` is set to true. This prevents the use of a disabled endpoint.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

I validated these changes by adding two unit tests and one integration test. The unit tests confirm that the `disableExecuteApiEndpoint` property is correctly set on the CloudFormation template and that the `apiEndpoint` getter throws an error as expected. The integration test successfully deploys a stack with the new property enabled. All tests pass.

My steps to verify:
1. Successfully building the project with: `$ npx lerna run build --skip-nx-cache`.
2. Running unit tests with: `$ npx jest packages/aws-cdk-lib/aws-apigatewayv2/test/websocket/api.test.ts`.
3. Running integration test with: `$ yarn integ test/aws-apigatewayv2-integrations/test/websocket/integ.disable-execute-api-endpoint.js --update-on-failed`

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
