### PR TITLE
fix(lambda-nodejs): use official bun installer for ARM64 compatibility

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
@@ -9,8 +9,12 @@ RUN npm install --global yarn@1.22.5
 # Install pnpm
 RUN npm install --global pnpm@7.33.7
 
-# Install bun
-RUN npm install --global bun@1.1.30
+# Install bun using official installer instead of npm (fixes ARM64 compatibility)
+# CDK's original: RUN npm install --global bun@1.1.30
+# Issue: @oven/bun-linux-x64-baseline npm package doesn't exist for ARM64
+# Solution: Use official installer that downloads correct platform binary
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.1.30" && \
+    ln -s /root/.bun/bin/bun /usr/local/bin/bun
 
 # Install typescript
 RUN npm install --global typescript

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
@@ -9,12 +9,8 @@ RUN npm install --global yarn@1.22.5
 # Install pnpm
 RUN npm install --global pnpm@7.33.7
 
-# Install bun using official installer instead of npm (fixes ARM64 compatibility)
-# CDK's original: RUN npm install --global bun@1.1.30
-# Issue: @oven/bun-linux-x64-baseline npm package doesn't exist for ARM64
-# Solution: Use official installer that downloads correct platform binary
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.1.30" && \
-    ln -s /root/.bun/bin/bun /usr/local/bin/bun
+# Install bun
+RUN npm install --global bun@1.2.23
 
 # Install typescript
 RUN npm install --global typescript


### PR DESCRIPTION
## Description

Fixes Docker bundling failures when using bun on ARM64 architectures (AWS Graviton instances).

### Problem
The current Dockerfile uses `npm install --global bun@1.1.30` which fails on ARM64 because the npm package `@oven/bun-linux-x64-baseline` doesn't exist for ARM64 architecture.

### Solution
Replace npm-based installation with the official bun installer that automatically detects and downloads the correct platform binary.

### Changes
- Replace `RUN npm install --global bun@1.1.30` 
- With `RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.1.30" && ln -s /root/.bun/bin/bun /usr/local/bin/bun`
- Added explanatory comments

### Security Considerations
⚠️ **Supply Chain Risk**: This change introduces an additional external dependency (bun.sh) in the build process. While this follows bun's official installation method and doesn't necessarily increase overall risk compared to npm registry dependencies, it does change our security posture by adding another potential attack vector. The bun.sh domain could theoretically be compromised to serve malicious installers.

**Risk Mitigation Options** (for future consideration):
- Pin to specific commit hash of the install script
- Download and vendor the installer script
- Use checksum verification

### Testing
- ✅ Verified on AWS Graviton instance (GitHub Actions)
- ✅ Maintains compatibility with existing x64 builds

Closes #35534

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*