### PR TITLE
feat(ec2) add instance requirement enums

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/accelerator-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/accelerator-types.ts
@@ -1,0 +1,77 @@
+/**
+ * Hardware accelerator categories available for EC2 instances.
+ *
+ * Defines the general type of hardware accelerator that can be attached
+ * to an instance, typically used in instance requirement specifications
+ * (e.g., GPUs for compute-intensive tasks, FPGAs for custom logic, or
+ * inference chips for ML workloads).
+ */
+export enum AcceleratorType {
+  /**
+   * Graphics Processing Unit accelerators, such as NVIDIA GPUs.
+   * Commonly used for machine learning training, graphics rendering,
+   * or high-performance parallel computing.
+   */
+  GPU = 'gpu',
+
+  /**
+   * Field Programmable Gate Array accelerators, such as Xilinx FPGAs.
+   * Used for hardware-level customization and specialized workloads.
+   */
+  FPGA = 'fpga',
+
+  /**
+   * Inference accelerators, such as AWS Inferentia.
+   * Purpose-built for efficient machine learning inference.
+   */
+  INFERENCE = 'inference',
+}
+
+/**
+ * Supported hardware accelerator manufacturers.
+ *
+ * Restricts instance selection to accelerators from a particular vendor.
+ * Useful for choosing specific ecosystems (e.g., NVIDIA CUDA, AWS chips).
+ */
+export enum AcceleratorManufacturer {
+  /** Amazon Web Services (e.g., Inferentia, Trainium accelerators). */
+  AWS = 'amazon-web-services',
+
+  /** AMD (e.g., Radeon Pro V520 GPU). */
+  AMD = 'amd',
+
+  /** NVIDIA (e.g., A100, V100, T4, K80, M60 GPUs). */
+  NVIDIA = 'nvidia',
+
+  /** Xilinx (e.g., VU9P FPGA). */
+  XILINX = 'xilinx',
+}
+
+/**
+ * Specific hardware accelerator models supported by EC2.
+ *
+ * Defines exact accelerator models that can be required or excluded
+ * when selecting instance types.
+ */
+export enum AcceleratorName {
+  /** NVIDIA A100 GPU. */
+  A100 = 'a100',
+
+  /** NVIDIA K80 GPU. */
+  K80 = 'k80',
+
+  /** NVIDIA M60 GPU. */
+  M60 = 'm60',
+
+  /** AMD Radeon Pro V520 GPU. */
+  RADEON_PRO_V520 = 'radeon-pro-v520',
+
+  /** NVIDIA T4 GPU. */
+  T4 = 't4',
+
+  /** NVIDIA V100 GPU. */
+  V100 = 'v100',
+
+  /** Xilinx VU9P FPGA. */
+  VU9P = 'vu9p',
+}

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
@@ -1,6 +1,131 @@
 import { UnscopedValidationError } from '../../core';
 
 /**
+ * Bare metal support requirements for EC2 instances.
+ *
+ * Controls whether selected instance types must, may, or must not
+ * be bare metal variants (i.e., instances that run directly on
+ * physical hardware without a hypervisor).
+ */
+export enum BareMetal {
+  /**
+   * Bare metal instance types are allowed, but non-bare-metal
+   * (virtualized) types may also be selected.
+   */
+  INCLUDED = 'included',
+
+  /**
+   * Only bare metal instance types are allowed.
+   * Non-bare-metal types will be excluded from selection.
+   */
+  REQUIRED = 'required',
+
+  /**
+   * Bare metal instance types are disallowed.
+   * Only non-bare-metal types may be selected.
+   */
+  EXCLUDED = 'excluded',
+}
+
+/**
+ * Burstable CPU performance requirements for EC2 instances.
+ *
+ * Controls whether selected instance types must, may, or must not
+ * support burstable vCPU performance (e.g., T3, T4g families).
+ */
+export enum BurstablePerformance {
+  /**
+   * Burstable-performance instance types are allowed, but
+   * non-burstable types may also be selected.
+   */
+  INCLUDED = 'included',
+
+  /**
+   * Only burstable-performance instance types are allowed.
+   * Non-burstable types will be excluded from selection.
+   */
+  REQUIRED = 'required',
+
+  /**
+   * Burstable-performance instance types are disallowed.
+   * Only non-burstable types may be selected.
+   */
+  EXCLUDED = 'excluded',
+}
+
+/**
+ * CPU manufacturers supported by EC2 instances.
+ *
+ * Restricts the acceptable CPU vendor for selected instance types.
+ */
+export enum CpuManufacturer {
+  /** Intel CPUs (e.g., Xeon families). */
+  INTEL = 'intel',
+
+  /** AMD CPUs (e.g., EPYC families). */
+  AMD = 'amd',
+
+  /** AWS-designed CPUs (e.g., Graviton families). */
+  AWS = 'amazon-web-services',
+
+  /** Apple CPUs (e.g., M1, M2). */
+  APPLE = 'apple',
+}
+
+/**
+ * Instance generation categories for EC2.
+ *
+ * Determines whether the instance type must belong to the latest
+ * (current) generation or to an older (previous) generation.
+ */
+export enum InstanceGeneration {
+  /** Current generation instances (latest families). */
+  CURRENT = 'current',
+
+  /** Previous generation instances (older families). */
+  PREVIOUS = 'previous',
+}
+
+/**
+ * Local storage support requirements for EC2 instances.
+ *
+ * Controls whether selected instance types must, may, or must not
+ * include directly attached local storage (instance store).
+ */
+export enum LocalStorage {
+  /**
+   * Instance types with local storage are allowed, but types without
+   * local storage may also be selected.
+   */
+  INCLUDED = 'included',
+
+  /**
+   * Only instance types with local storage are allowed.
+   * Types without local storage will be excluded.
+   */
+  REQUIRED = 'required',
+
+  /**
+   * Instance types with local storage are disallowed.
+   * Only types without local storage may be selected.
+   */
+  EXCLUDED = 'excluded',
+}
+
+/**
+ * Types of local storage available for EC2 instances.
+ *
+ * Specifies the physical medium used for local (instance store) storage.
+ */
+export enum LocalStorageType {
+  /** Hard disk drive storage. */
+  HDD = 'hdd',
+
+  /** Solid state drive storage. */
+  SSD = 'ssd',
+}
+
+/**
  * What class and generation of instance to use
  *
  * We have both symbolic and concrete enums for every type.


### PR DESCRIPTION
### Reason for this change

Adds enums for EC2 instance requirements. For now this PR just adds the enums, support for instance requirements in launch template does not exist yet in EC2 L2.

### Description of changes

Added:
- New `accelerator-types.ts` file with enums for hardware accelerator filtering:
  - `AcceleratorType` (GPU, FPGA, INFERENCE)
  - `AcceleratorManufacturer` (AWS, AMD, NVIDIA, XILINX)
  - `AcceleratorName` (A100, K80, M60, RADEON_PRO_V520, T4, V100, VU9P)
- New enums in `instance-types.ts` for instance filtering:
  - `BareMetal` (INCLUDED, REQUIRED, EXCLUDED)
  - `BurstablePerformance` (INCLUDED, REQUIRED, EXCLUDED)
  - `CpuManufacturer` (INTEL, AMD, AWS, APPLE)
  - `InstanceGeneration` (CURRENT, PREVIOUS)
  - `LocalStorage` (INCLUDED, REQUIRED, EXCLUDED)
  - `LocalStorageType` (HDD, SSD)

### Describe any new or updated permissions being added

None - these are just enum definitions for future use in instance requirements.

### Description of how you validated changes

No validation, the enums are copied from the SDK. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
