### PR TITLE
chore(ec2): add r8gb instance class

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
@@ -503,6 +503,16 @@ export enum InstanceClass {
   R8GN = 'r8gn',
 
   /**
+   * Memory and EBS optimized instances, 8th generation with Graviton4 processors
+   */
+  MEMORY8_GRAVITON4_EBS_OPTIMIZED = 'memory8-graviton4-ebs-optimized',
+
+  /**
+   * Memory and EBS optimized instances, 8th generation with Graviton4 processors
+   */
+  R8GB = 'r8gb',
+
+  /**
    * Compute optimized instances, 3rd generation
    */
   COMPUTE3 = 'compute3',
@@ -1861,6 +1871,8 @@ export class InstanceType {
       [InstanceClass.R8GD]: 'r8gd',
       [InstanceClass.MEMORY8_GRAVITON4_HIGH_NETWORK_BANDWIDTH]: 'r8gn',
       [InstanceClass.R8GN]: 'r8gn',
+      [InstanceClass.MEMORY8_GRAVITON4_EBS_OPTIMIZED]: 'r8gb',
+      [InstanceClass.R8GB]: 'r8gb',
       [InstanceClass.MEMORY8_INTEL_BASE]: 'r8i',
       [InstanceClass.R8I]: 'r8i',
       [InstanceClass.MEMORY8_INTEL_FLEX]: 'r8i-flex',


### PR DESCRIPTION
### Reason for this change
https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ec2-r8gb-instances/

### Description of changes
Add r8gb instance class

### Description of how you validated changes
```console
$ aws ec2 describe-instance-types \
  --filters "Name=instance-type,Values=r8gb.*" \
  --query "InstanceTypes[].InstanceType" \
  --output table
-----------------------
|DescribeInstanceTypes|
+---------------------+
|  r8gb.8xlarge       |
|  r8gb.4xlarge       |
|  r8gb.large         |
|  r8gb.12xlarge      |
|  r8gb.16xlarge      |
|  r8gb.medium        |
|  r8gb.metal-24xl    |
|  r8gb.xlarge        |
|  r8gb.2xlarge       |
|  r8gb.24xlarge      |
+---------------------+
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
