### PR TITLE
chore(mergify): force in place checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,11 @@
 # See https://doc.mergify.io
 merge_queue:
-  # Hopefully this gets Mergify to stop creating PRs just to test merges (it both messes with statistics and our automatic validations)
+  # Required to force mergify to merge in place, see https://docs.mergify.com/merge-queue/parallel-checks/#inplace-checks-no-drafts
   max_parallel_checks: 1
 queue_rules:
   - name: default-merge
+    # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
+    batch_size: 1
     update_method: merge
     merge_method: merge
     conditions:
@@ -24,6 +26,8 @@ queue_rules:
       {{ body }}
 
   - name: priority-squash
+    # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
+    batch_size: 1
     update_method: merge
     merge_method: squash
     conditions:
@@ -44,6 +48,8 @@ queue_rules:
       {{ body }}
 
   - name: default-squash
+    # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
+    batch_size: 1
     update_method: merge
     merge_method: squash
     conditions:


### PR DESCRIPTION
### Issue # (if applicable)


### Reason for this change

Mergify is failing to merge with the following message: 

> The branch protection setting Require branches to be up to date before merging is not compatible with draft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks: set merge_queue.max_parallel_checks: 1, set every queue rule batch_size: 1, and avoid two-step CI (make merge_conditions identical to queue_conditions). Otherwise, disable this branch protection.

See: https://github.com/aws/aws-cdk/pull/35616/checks?check_run_id=51597461858 for example

This is due to not properly configuring in place merges, which requires batch size 1 for all queue rules

### Description of changes

added `batch_size: 1` to all queue rules
### Describe any new or updated permissions being added

None

### Description of how you validated changes

No real way unless we try it out

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
