### PR TITLE
chore(ci): scope codebuild PR build to aws/aws-cdk

### DIFF
--- a/.github/workflows/codebuild-pr-build.yml
+++ b/.github/workflows/codebuild-pr-build.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   build:
+    # Runner exists only for aws-cdk repo
+    if: github.repository == 'aws/aws-cdk'
     runs-on: codebuild-aws-cdk-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
 
     env:


### PR DESCRIPTION
### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

Forks do not have any codebuild setup, so this pr-build should only run for aws/aws-cdk. Currently, it creates noise and the action stays in pending, eventually timing out. https://github.com/aws/aws-cdk/actions/workflows/pr-build.yml action runs on forks to test PR Build  

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
