### PR TITLE
fix(s3-deployment): prevent log group deletion before Lambda execution

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-s3-deployment/test/integ.bucket-deployment-loggroup.js.snapshot/test-bucket-deployment-loggroup.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-s3-deployment/test/integ.bucket-deployment-loggroup.js.snapshot/test-bucket-deployment-loggroup.template.json
@@ -366,7 +366,8 @@
    },
    "DependsOn": [
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265"
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+    "LogGroupF5B46931"
    ]
   }
  },

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-s3-deployment/test/integ.bucket-deployment-loggroup.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-s3-deployment/test/integ.bucket-deployment-loggroup.ts
@@ -17,13 +17,15 @@ class TestBucketDeployment extends cdk.Stack {
       autoDeleteObjects: true, // needed for integration test cleanup
     });
 
+    const logGroup = new logs.LogGroup(this, 'LogGroup', {
+      retention: logs.RetentionDays.ONE_DAY,
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // cleanup integ test
+    });
+
     new s3deploy.BucketDeployment(this, 'DeployMe', {
       sources: [s3deploy.Source.asset(path.join(__dirname, 'my-website'))],
       destinationBucket,
-      logGroup: new logs.LogGroup(this, 'LogGroup', {
-        retention: logs.RetentionDays.ONE_DAY,
-        removalPolicy: cdk.RemovalPolicy.DESTROY, // cleanup integ test
-      }),
+      logGroup,
       retainOnDelete: false, // default is true, which will block the integration test cleanup
     });
   }

--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
@@ -398,6 +398,13 @@ export class BucketDeployment extends Construct {
     if (!handlerRole) { throw new ValidationError('lambda.SingletonFunction should have created a Role', this); }
     this.handlerRole = handlerRole;
 
+    // Ensure that the log group won't be deleted before the Lambda function.
+    // Otherwise, the Lambda can be invoked during stack deletion after the log group is deleted,
+    // which can lead to log group recreation even though it's marked as deleted in the stack.
+    if (props.logGroup) {
+      handler.node.addDependency(props.logGroup);
+    }
+
     this.sources = props.sources.map((source: ISource) => source.bind(this, { handlerRole: this.handlerRole }));
 
     this.destinationBucket.grantReadWrite(handler);


### PR DESCRIPTION
## Summary
- Adds explicit dependency between Lambda handler and custom log group in BucketDeployment
- Prevents log group from being deleted before Lambda completes during stack deletion
- Resolves issue where deleted log groups were automatically recreated by Lambda

## Rationale
When a custom `logGroup` is provided to `BucketDeployment`, CloudFormation may delete the log group before the Lambda function finishes executing during stack deletion. This causes AWS Lambda to automatically recreate the log group when it attempts to write logs, resulting in orphaned log groups that appear deleted in CloudFormation but still exist in AWS.

## Changes
- Added `handler.node.addDependency(props.logGroup)` when a custom log group is provided
- Ensures the Lambda function is deleted before the log group during stack deletion
- Follows the same pattern used for VPC dependencies in the construct

Fixes #35632