### PR TITLE
fix(ec2-alpha): imports of SubnetReference and VPCReference from aws-cdk-lib/aws-ec2

### DIFF
--- a/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
@@ -7,9 +7,9 @@ import {
   ISubnet,
   NetworkAcl,
   SubnetNetworkAclAssociation,
+  SubnetReference,
   SubnetType,
 } from 'aws-cdk-lib/aws-ec2';
-import { SubnetReference } from 'aws-cdk-lib/aws-ec2/lib/ec2.generated';
 import { addConstructMetadata, MethodMetadata } from 'aws-cdk-lib/core/lib/metadata-resource';
 import { propertyInjectable } from 'aws-cdk-lib/core/lib/prop-injectable';
 import { Construct, DependencyGroup, IDependable } from 'constructs';

--- a/packages/@aws-cdk/aws-ec2-alpha/lib/vpc-v2-base.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/vpc-v2-base.ts
@@ -18,12 +18,12 @@ import {
   SubnetFilter,
   SubnetSelection,
   SubnetType,
+  VPCReference,
   VpnConnection,
   VpnConnectionOptions,
   VpnConnectionType,
   VpnGateway,
 } from 'aws-cdk-lib/aws-ec2';
-import { VPCReference } from 'aws-cdk-lib/aws-ec2/lib/ec2.generated';
 import { AccountPrincipal, Effect, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
 import { Dependable, DependencyGroup, IConstruct, IDependable } from 'constructs';
 import {


### PR DESCRIPTION
### Reason for this change

When attempting to use @aws-cdk/aws-ec2-alpha I get the following import error:

```
node_modules/.pnpm/@aws-cdk+aws-ec2-alpha@2.219.0-alpha.0_aws-cdk-lib@2.219.0_constructs@10.4.2__constructs@10.4.2/node_modules/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.d.ts:5:33 -
  error TS2307: Cannot find module 'aws-cdk-lib/aws-ec2/lib/ec2.generated' or its corresponding type declarations.

5 import { SubnetReference } from 'aws-cdk-lib/aws-ec2/lib/ec2.generated';
```

I'm using pnpm as the package manager, and typescript is using `bundler` as the `moduleResolution`. Following the typescript module resolution output from `tsc --traceResolution` it seems like `./aws-ec2/lib/ec2.generated` is not exposed publicly in the `package.json`, and it will not attempt to load the file directly since it is a module-import and not a local import.

From what I can tell it was introduced by https://github.com/aws/aws-cdk/pull/35032

### Description of changes

This PR changes the imports of `SubnetReference` and `VPCReference` to use the publicly available symbols from `aws-cdk-lib/aws-ec2` instead of importing them directly from the file itself. The alternative would be to add `./aws-ec2/lib/ec2.generated` to `aws-cdk-lib`'s `package.json` `exports`.

### Description of how you validated changes

Manual update of the relevant `.d.ts`-files in a project importing `@aws-cdk/aws-ec2-alpha` will solve the issue.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
