### PR TITLE
ci(mergify): rename conditions to queue_conditions to fix in place checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ queue_rules:
     batch_size: 1
     update_method: merge
     merge_method: merge
-    conditions:
+    queue_conditions:
       - -title~=(WIP|wip)
       - -label~=(blocked|do-not-merge)
       # Only if no-squash is set
@@ -30,7 +30,7 @@ queue_rules:
     batch_size: 1
     update_method: merge
     merge_method: squash
-    conditions:
+    queue_conditions:
       - base!=release
       - -title~=(WIP|wip)
       - -label~=(blocked|do-not-merge|no-squash)
@@ -52,7 +52,7 @@ queue_rules:
     batch_size: 1
     update_method: merge
     merge_method: squash
-    conditions:
+    queue_conditions:
       - base!=release
       - -title~=(WIP|wip)
       - -label~=(blocked|do-not-merge|no-squash|priority-pr)


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

The Mergify configuration currently uses the deprecated `conditions` key inside `queue_rules`.  
Mergify now interprets `conditions` as `merge_conditions`, which unintentionally makes the setup a two-step CI.  
This prevents in-place checks from working and causes conflicts with GitHub’s branch protection rule *“Require branches to be up to date before merging.”*  


Response from Mergify team:
> You still have a conditions key in your queue rules, which translate to merge_conditions since the conditions attribute is deprecated. Having merge_conditions in your queue rules makes it a 2-step CI.
You can see more details on inplace checks in our documentation: https://docs.mergify.com/merge-queue/parallel-checks/#inplace-checks-no-drafts



### Description of changes

- Updated all `queue_rules` entries to use **`queue_conditions`** instead of `conditions`.  

### Describe any new or updated permissions being added

N/A — no IAM changes required.  

### Description of how you validated changes

- Only way to test is to merge it.
- 
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
