### PR TITLE
feat(spec2cdk): generate a `grant()` method in L1 constructs

### DIFF
--- a/tools/@aws-cdk/spec2cdk/lib/cdk/cdk.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/cdk.ts
@@ -123,8 +123,14 @@ export class CdkCloudWatch extends ExternalModule {
   public readonly MetricOptions = Type.fromName(this, 'MetricOptions');
 }
 
+export class CdkIam extends ExternalModule {
+  public readonly Grant = $T(Type.fromName(this, 'Grant'));
+  public readonly IGrantable = $T(Type.fromName(this, 'IGrantable'));
+}
+
 export const CDK_CORE = new CdkCore('aws-cdk-lib');
 export const CDK_CLOUDWATCH = new CdkCloudWatch('aws-cdk-lib/aws-cloudwatch');
+export const CDK_IAM = new CdkIam('aws-cdk-lib/aws-iam');
 export const CONSTRUCTS = new Constructs();
 
 function makeCallableExpr(scope: IScope, name: string) {

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/resource-class.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/resource-class.ts
@@ -479,13 +479,14 @@ export class ResourceClass extends ClassType {
       return;
     }
 
-    CDK_IAM.import(this.module, 'iam');
+    if (!this.module.imports.some(imp => imp.module.fqn === CDK_IAM.fqn)) {
+      CDK_IAM.import(this.module, 'iam');
+    }
 
     const grant = this.addMethod({
       name: 'grant',
       docs: {
         summary: 'Grant the given IGrantable permissions to perform the actions specified in actions on this resource.',
-        stability: Stability.External,
       },
       returnType: CDK_IAM.Grant,
     });


### PR DESCRIPTION
Add a generic `grant()` method to L1 constructs, of the form:

```ts
/**
 * Grant the given IGrantable permissions to perform the actions specified in actions on this resource.
 *
 * @param grantee The principal to grant permissions to.
 * @param actions The actions to grant permissions for.
 * @param conditions The conditions under which the actions should be allowed.
 */
public grant(grantee: iam.IGrantable, actions: Array<string>, conditions?: Record<string, Record<string, unknown>>): iam.Grant {
  return iam.Grant.addToPrincipal({
    "grantee": grantee,
    "actions": actions,
    "resourceArns": [this.attrArn],
    "scope": this,
    "conditions": conditions
  });
}
```

The only variation between different constructs is the ARN attribute name, passed in an array to `resourceArns`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
