### PR TITLE
chore(ec2): extract grant logic to a helper class

### DIFF
--- a/packages/aws-cdk-lib/aws-iam/lib/grant.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/grant.ts
@@ -423,6 +423,10 @@ interface GrantProps {
   readonly policyDependable?: IDependable;
 }
 
+export interface IResourceWithKey {
+  grantKey(grantee: IGrantable, actions: string[], conditions?: Record<string, Record<string, unknown>>): void;
+}
+
 /**
  * A resource with a resource policy that can be added to
  */


### PR DESCRIPTION
Move the logic from `VolumeBase.grantAttachVolumeByResourceTag()` and `VolumeBase.grantAttachVolume()` to a new helper class, called `VolumeGrants`. With this, we can give grants to L1s and L2s in a uniform way:

```ts
const instance = new Instance(stack, 'Instance', ...);

// Basic usage:
const volume = new CfnVolume(stack, 'Volume', {
  availabilityZone: 'us-east-1a',
});

VolumeGrants.fromVolume(volume).grantAttachVolumeByResourceTag(instance.grantPrincipal, [instance]);
```

If the instance of `IVolumeRef` that we have also happens to implement `IResourceWithKey`, we can do:

```ts
const volume = new Volume(stack, 'Volume', {
  availabilityZone: 'us-east-1a',
});

VolumeGrants.fromVolumeWithKey(volume).grantAttachVolumeByResourceTag(instance.grantPrincipal, [instance]);
//                ^----- Different factory method
```

which will also give the grantee permission to `kms:CreateGrant` on the encryption key, if one is defined.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
