### PR TITLE
feat: add custom name support to RDS OptionGroup

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/README.md
+++ b/packages/aws-cdk-lib/aws-rds/README.md
@@ -1245,6 +1245,7 @@ new rds.OptionGroup(this, 'Options', {
   engine: rds.DatabaseInstanceEngine.oracleSe2({
     version: rds.OracleEngineVersion.VER_19,
   }),
+  optionGroupName: 'MyCustomOptionGroup', // Optional - custom name for the option group
   configurations: [
     {
       name: 'OEM',

--- a/packages/aws-cdk-lib/aws-rds/lib/option-group.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/option-group.ts
@@ -85,6 +85,13 @@ export interface OptionGroupProps {
   readonly engine: IInstanceEngine;
 
   /**
+   * The name of this option group.
+   *
+   * @default - CloudFormation-generated name
+   */
+  readonly optionGroupName?: string;
+
+  /**
    * A description of the option group.
    *
    * @default a CDK generated description
@@ -127,6 +134,7 @@ export class OptionGroup extends Resource implements IOptionGroup {
   public readonly optionConnections: { [key: string]: ec2.Connections } = {};
 
   private readonly configurations: OptionConfiguration[] = [];
+  private readonly optionGroupNameProp?: string;
 
   constructor(scope: Construct, id: string, props: OptionGroupProps) {
     super(scope, id);
@@ -140,11 +148,14 @@ export class OptionGroup extends Resource implements IOptionGroup {
 
     props.configurations.forEach(config => this.addConfiguration(config));
 
+    this.optionGroupNameProp = props.optionGroupName;
+
     const optionGroup = new CfnOptionGroup(this, 'Resource', {
       engineName: props.engine.engineType,
       majorEngineVersion,
       optionGroupDescription: props.description || `Option group for ${props.engine.engineType} ${majorEngineVersion}`,
       optionConfigurations: Lazy.any({ produce: () => this.renderConfigurations(this.configurations) }),
+      optionGroupName: this.optionGroupNameProp,
     });
 
     this.optionGroupName = optionGroup.ref;

--- a/packages/aws-cdk-lib/aws-rds/test/option-group.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/option-group.test.ts
@@ -127,6 +127,36 @@ describe('option group', () => {
     });
   });
 
+  test('option group with custom name', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new OptionGroup(stack, 'Options', {
+      engine: DatabaseInstanceEngine.oracleSe2({
+        version: OracleEngineVersion.VER_12_1,
+      }),
+      optionGroupName: 'MyCustomOptionGroup',
+      configurations: [
+        {
+          name: 'XMLDB',
+        },
+      ],
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::RDS::OptionGroup', {
+      EngineName: 'oracle-se2',
+      MajorEngineVersion: '12.1',
+      OptionGroupName: 'MyCustomOptionGroup',
+      OptionConfigurations: [
+        {
+          OptionName: 'XMLDB',
+        },
+      ],
+    });
+  });
+
   test('throws when using an option with port and no vpc', () => {
     // GIVEN
     const stack = new cdk.Stack();


### PR DESCRIPTION
Closes #35720.

### Reason for this change
AWS CDK lacked ability to set custom names for RDS option groups despite CloudFormation support.

### Description of changes
- Added `optionGroupName?: string` to `OptionGroupProps` 
- Updated constructor and CloudFormation resource to use custom name
- Added test coverage and README documentation

### Description of how you validated changes
- Added unit test for custom name functionality
- Verified backward compatibility

### Checklist
- [x] Follows CDK contribution guidelines