### PR TITLE
chore: silence JSII deprecated Node.js version warnings in PR builds

### DIFF
--- a/.github/workflows/codebuild-pr-build.yml
+++ b/.github/workflows/codebuild-pr-build.yml
@@ -30,6 +30,7 @@ jobs:
 
     env:
       PR_BUILD: true
+      JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,6 +25,7 @@ jobs:
 
     env:
       PR_BUILD: true
+      JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Reason for this change

JSII is emitting deprecated Node.js version warnings during PR builds, which creates noise in the build logs and may cause confusion. Suppressing the warnings is okay. We will deal with this upgrade as part of our SOP to deprecate Node 18 support later in the year.

### Description of changes

Added `JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: true` environment variable to both PR build workflows:
- `.github/workflows/codebuild-pr-build.yml`
- `.github/workflows/pr-build.yml`

This suppresses the deprecated Node.js version warnings from JSII without affecting functionality.

### Describe any new or updated permissions being added

No new permissions required.

### Description of how you validated changes

This change only adds an environment variable to silence warnings and doesn't affect build functionality.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*