### PR TITLE
ci(integration-test-deployment): use AssumeRole instead of OIDC

### DIFF
--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -39,12 +39,24 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ vars.CDK_ATMOSPHERE_OIDC_ROLE }}
-          role-session-name: run-tests@aws-cdk-deployment-integ
-          aws-region: us-east-1
+      - name: Assume Atmosphere Role
+        id: creds
+        run: |
+          # Assume role and capture the JSON output
+          CREDS=$(aws sts assume-role \
+          --role-arn ${{ vars.CDK_ATMOSPHERE_OIDC_ROLE }} \
+          --role-session-name run-tests@aws-cdk-deployment-integ)
+          # Parse the JSON output and set environment variables
+          AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.Credentials.AccessKeyId')
+          AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.Credentials.SecretAccessKey')
+          AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Credentials.SessionToken')
+          echo "::add-mask::$AWS_ACCESS_KEY_ID"
+          echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
+          echo "::add-mask::$AWS_SESSION_TOKEN"
+          
+          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
+          echo "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
### Reason for this change

OIDC is not setup in prod, and it isn't needed as we already can use the role in Codebuild to assume the Atmosphere role.

### Description of changes

Use AssumeRole instead of OIDC. This is done by using AWS CLI STS directly.

No new permissions added.

A workflow has been run successfully with this configuration here: https://github.com/Abogical/aws-cdk/actions/runs/18465794651/job/52607352315?pr=15

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
