### PR TITLE
chore(cloudfront): validate `minimumProtocolVersion, sslSupportMethod` must be used with custom certificate

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -367,6 +367,13 @@ export class Distribution extends Resource implements IDistribution {
       if ((props.domainNames ?? []).length === 0) {
         Annotations.of(this).addWarningV2('@aws-cdk/aws-cloudfront:emptyDomainNames', 'No domain names are specified. You will need to specify it after running associate-alias CLI command manually. See the "Moving an alternate domain name to a different distribution" section of module\'s README for more info.');
       }
+    } else {
+      if (props.minimumProtocolVersion !== undefined) {
+        throw new ValidationError('minimumProtocolVersion can only be specified when using a custom certificate.', this);
+      }
+      if (props.sslSupportMethod !== undefined) {
+        throw new ValidationError('sslSupportMethod can only be specified when using a custom certificate.', this);
+      }
     }
 
     this.httpVersion = props.httpVersion ?? HttpVersion.HTTP2;

--- a/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
@@ -531,6 +531,26 @@ describe('certificates', () => {
       },
     });
   });
+
+  test('throw when minimumProtocolVersion specified without certificate', () => {
+    const origin = defaultOrigin();
+    expect(() => {
+      new Distribution(stack, 'Dist', {
+        defaultBehavior: { origin },
+        minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2016,
+      });
+    }).toThrow(/minimumProtocolVersion can only be specified when using a custom certificate/);
+  });
+
+  test('throw when sslSupportMethod specified without certificate', () => {
+    const origin = defaultOrigin();
+    expect(() => {
+      new Distribution(stack, 'Dist', {
+        defaultBehavior: { origin },
+        sslSupportMethod: SSLMethod.STATIC_IP,
+      });
+    }).toThrow(/sslSupportMethod can only be specified when using a custom certificate/);
+  });
 });
 
 describe('custom error responses', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #35404

### Reason for this change
`minimumProtocolVersion, sslSupportMethod` silently ignored without `certificate`. Users are unaware that their security setting is non-compliant.

### Description of changes
Validate `minimumProtocolVersion, sslSupportMethod` must be used with custom certificate

### Description of how you validated changes
Unit test

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
