### PR TITLE
ci(integration-test-deployment): bootstrap account before deployment

### DIFF
--- a/tools/@aws-cdk/integration-test-deployment/test/integration-test-deployment.test.ts
+++ b/tools/@aws-cdk/integration-test-deployment/test/integration-test-deployment.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, jest, test, beforeEach } from '@jest/globals';
 import { AtmosphereAllocationMock } from './atmosphere-mock';
-import { AtmosphereAllocation } from '../lib/atmosphere';
 import { gitDiffMock } from './git-mock';
-import * as utils from '../lib/utils';
+import { AtmosphereAllocation } from '../lib/atmosphere';
 import * as integRunner from '../lib/integration-test-runner';
+import * as utils from '../lib/utils';
 
 jest.mock('../lib/atmosphere');
+
+const env = {
+  AWS_ACCESS_KEY_ID: 'XXXXXXXXXXXXX',
+  AWS_SECRET_ACCESS_KEY: '123456789',
+  AWS_SESSION_TOKEN: '123456789',
+  AWS_REGION: 'us-east-1',
+  AWS_ACCOUNT_ID: '123456789',
+};
 
 describe('Run Inegration Tests with Atmosphere', () => {
   let mockAtmosphereAllocation: AtmosphereAllocationMock;
@@ -18,6 +26,7 @@ describe('Run Inegration Tests with Atmosphere', () => {
     jest.spyOn(utils, 'gitDiff').mockImplementation(gitDiffMock);
     jest.spyOn(mockAtmosphereAllocation, 'release');
     jest.spyOn(integRunner, 'deployIntegrationTests').mockImplementation(async () => {});
+    jest.spyOn(integRunner, 'bootstrap').mockImplementation(async () => {});
   });
 
   test('successful integration test', async () => {
@@ -26,13 +35,8 @@ describe('Run Inegration Tests with Atmosphere', () => {
 
     await integRunner.deployInegTestsWithAtmosphere({ endpoint, pool });
     expect(AtmosphereAllocation.acquire).toHaveBeenCalled();
-    expect(integRunner.deployIntegrationTests).toHaveBeenCalledWith(expect.objectContaining({
-      AWS_ACCESS_KEY_ID: 'XXXXXXXXXXXXX',
-      AWS_SECRET_ACCESS_KEY: '123456789',
-      AWS_SESSION_TOKEN: '123456789',
-      AWS_REGION: 'us-east-1',
-      AWS_ACCOUNT_ID: '123456789',
-    }));
+    expect(integRunner.bootstrap).toHaveBeenCalledWith(expect.objectContaining(env));
+    expect(integRunner.deployIntegrationTests).toHaveBeenCalledWith(expect.objectContaining(env));
     expect(mockAtmosphereAllocation.release).toHaveBeenCalled();
   });
 
@@ -49,13 +53,8 @@ describe('Run Inegration Tests with Atmosphere', () => {
     );
 
     expect(AtmosphereAllocation.acquire).toHaveBeenCalled();
-    expect(integRunner.deployIntegrationTests).toHaveBeenCalledWith(expect.objectContaining({
-      AWS_ACCESS_KEY_ID: 'XXXXXXXXXXXXX',
-      AWS_SECRET_ACCESS_KEY: '123456789',
-      AWS_SESSION_TOKEN: '123456789',
-      AWS_REGION: 'us-east-1',
-      AWS_ACCOUNT_ID: '123456789',
-    }));
+    expect(integRunner.bootstrap).toHaveBeenCalledWith(expect.objectContaining(env));
+    expect(integRunner.deployIntegrationTests).toHaveBeenCalledWith(expect.objectContaining(env));
     expect(mockAtmosphereAllocation.release).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Reason for this change

For integration deployment tests, accounts under atmosphere do not have the CDK bootstrap.

### Description of changes

Add a bootstrap step to the integration deployment test.

### Describe any new or updated permissions being added

No new IAM permissions added.

### Description of how you validated changes

Workflow runs successfully under fork: https://github.com/Abogical/aws-cdk/actions/runs/18687737855/job/53284876440

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
