### PR TITLE
fix(s3-deployment): handle empty string in Source.data()

### DIFF
--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/render-data.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/render-data.ts
@@ -34,6 +34,14 @@ class TokenToMarkerMapper implements ITokenMapper {
 export function renderData(data: string): Content {
   const tokenMapper = new TokenToMarkerMapper();
 
+  // Handle empty string case explicitly to avoid StringConcat.join(undefined, undefined)
+  if (data === '') {
+    return {
+      text: '',
+      markers: {},
+    };
+  }
+
   return {
     // Break down the string into its token fragments and replace each token with a marker.
     // Then rejoin the fragments with basic string concatenation.

--- a/packages/aws-cdk-lib/aws-s3-deployment/test/content.test.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/test/content.test.ts
@@ -111,3 +111,29 @@ test('lazy within a string is not resolved', () => {
     },
   });
 });
+test('empty string data', () => {
+  const stack = new Stack();
+  expect(renderData('')).toStrictEqual({
+    markers: {},
+    text: '',
+  });
+});
+
+test('Source.data with empty string - issue #35809 regression test', () => {
+  const stack = new Stack();
+  const handler = new lambda.Function(stack, 'Handler', {
+    runtime: lambda.Runtime.NODEJS_LATEST,
+    code: lambda.Code.fromInline('foo'),
+    handler: 'index.handler',
+  });
+
+  // This is the exact reproduction case from issue #35809
+  // Before the fix, this would throw: "The "data" argument must be of type string... Received undefined"
+  expect(() => {
+    const source = Source.data('path/to/empty', '');
+    const actual = source.bind(stack, { handlerRole: handler.role! });
+    expect(actual.markers).toStrictEqual({});
+    expect(actual.bucket).toBeDefined();
+    expect(actual.zipObjectKey).toBeDefined();
+  }).not.toThrow();
+});


### PR DESCRIPTION
### Issue # (if applicable)

Closes #35809.

### Reason for this change

`Source.data()` fails with a TypeError when called with an empty string as the data parameter in CDK v2.207.0+. This is a regression from v2.206.0 where empty string deployment worked correctly.

The issue manifests as:
```
TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
    at Object.writeFileSync (node:fs:2434:5)
```

This prevents users from deploying empty S3 objects using `Source.data("path", "")`, which is a valid use case for placeholder files, configuration templates, or initialization markers.

### Description of changes

Fixed the empty string handling issue by adding explicit empty string handling in the S3 deployment `renderData()` function. This targeted approach avoids modifying core CDK libraries and keeps the fix scoped to where the issue manifests.

**Root cause**: When `Source.data("path", "")` is processed during synthesis, the empty string goes through the `renderData("")` function. For empty strings, `TokenizedStringFragments` has zero fragments, causing `join()` to call `StringConcat.join(undefined, undefined)`, which returns `undefined` instead of the expected empty string. This `undefined` value eventually reaches `fs.writeFileSync()`, causing the TypeError.

**Technical changes**:
- Modified `renderData()` in `packages/aws-cdk-lib/aws-s3-deployment/lib/render-data.ts`
- Added explicit early return for empty string input: `if (data === '') return { text: '', markers: {} }`
- Added regression test for the exact reproduction case `Source.data('path/to/empty', '')`
- **Zero changes to core CDK libraries** - fix is isolated to S3 deployment module only

**Impact**: Restores v2.206.0 behavior for empty string deployment while maintaining a minimal, targeted fix with no risk to other CDK functionality.

### Describe any new or updated permissions being added

N/A - No IAM permissions or resource access changes. This is an internal S3 deployment module fix that only affects synthesis-time data rendering for empty strings.

### Description of how you validated changes

- **Unit tests**: Added test for empty string handling in `renderData()` function
- **Regression tests**: Added test for exact reproduction case `Source.data('path/to/empty', '')` in `packages/aws-cdk-lib/aws-s3-deployment/test/content.test.ts`
- **Integration tests**: All existing CloudFormation snapshots unchanged (as expected for synthesis-time fix)
- **Manual validation**: End-to-end verification that `Source.data("empty.txt", "")` works without throwing TypeError
- **Scope validation**: Confirmed no changes needed to core CDK libraries or other modules
- **Build verification**: TypeScript compilation, linting, and module builds all pass

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
