### PR TITLE
ci(mergify): disable queued/dequeued labels

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,8 @@
 merge_queue:
   # Required to force mergify to merge in place, see https://docs.mergify.com/merge-queue/parallel-checks/#inplace-checks-no-drafts
   max_parallel_checks: 1
+  dequeued_label: null
+  queued_label: null
 queue_rules:
   - name: default-merge
     # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)


### PR DESCRIPTION
https://changelog.mergify.com/
Mergfiy added a new “dequeued” label 3 days go when dequeuing prs from the merge queue. I think this also happens when Mergify attempts to merge a PR from the queue, it has to dequeue it first and that triggers the label.

https://docs.mergify.com/merge-queue/lifecycle/
> the validation is successful, meaning all the merge_conditions are met, the pull request leaves the queue and is merged into the base branch. 

This PR disables the queued and dequeued labels