### PR TITLE
feat(ec2): add Interface VPC Endpoints for ACM and ACM-PCA

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
@@ -417,6 +417,8 @@ export class InterfaceVpcEndpointAwsService implements IInterfaceVpcEndpointServ
   public static readonly BILLING_AND_COST_MANAGEMENT_TAX = new InterfaceVpcEndpointAwsService('tax');
   public static readonly BILLING_CONDUCTOR = new InterfaceVpcEndpointAwsService('billingconductor');
   public static readonly BRAKET = new InterfaceVpcEndpointAwsService('braket');
+  public static readonly CERTIFICATE_MANAGER = new InterfaceVpcEndpointAwsService('acm');
+  public static readonly CERTIFICATE_MANAGER_FIPS = new InterfaceVpcEndpointAwsService('acm-fips');
   public static readonly CLEAN_ROOMS = new InterfaceVpcEndpointAwsService('cleanrooms');
   public static readonly CLEAN_ROOMS_ML = new InterfaceVpcEndpointAwsService('cleanrooms-ml');
   public static readonly CLOUD_CONTROL_API = new InterfaceVpcEndpointAwsService('cloudcontrolapi');
@@ -661,6 +663,7 @@ export class InterfaceVpcEndpointAwsService implements IInterfaceVpcEndpointServ
   public static readonly POLLY = new InterfaceVpcEndpointAwsService('polly');
   public static readonly PRIVATE_5G = new InterfaceVpcEndpointAwsService('private-networks');
   public static readonly PRIVATE_CERTIFICATE_AUTHORITY = new InterfaceVpcEndpointAwsService('acm-pca');
+  public static readonly PRIVATE_CERTIFICATE_AUTHORITY_FIPS = new InterfaceVpcEndpointAwsService('acm-pca-fips');
   public static readonly PRIVATE_CERTIFICATE_AUTHORITY_CONNECTOR_AD = new InterfaceVpcEndpointAwsService('pca-connector-ad');
   public static readonly PRIVATE_CERTIFICATE_AUTHORITY_CONNECTOR_SCEP = new InterfaceVpcEndpointAwsService('pca-connector-scep');
   public static readonly PROMETHEUS = new InterfaceVpcEndpointAwsService('aps');


### PR DESCRIPTION
### Issue # (if applicable)

None

### Reason for this change

AWS supports Interface VPC Endpoints for ACM and ACM-PCA, 
but AWS CDK currently only supports `acm-pca`. 
This change adds missing support for `acm`, `acm-fips`, and `acm-pca-fips`.

### Description of changes

Add interface VPC endpoints
- `acm`
- `acm-fips`
- `acm-pca-fips`
### Describe any new or updated permissions being added

None

### Description of how you validated changes

Executed AWS CLI
```bash
$ aws ec2 describe-vpc-endpoint-services --filters "Name=service-name,Values=*acm*" --region us-east-1 --query "ServiceNames[]"
[
  "com.amazonaws.us-east-1.acm",
  "com.amazonaws.us-east-1.acm-fips",
  "com.amazonaws.us-east-1.acm-pca",
  "com.amazonaws.us-east-1.acm-pca-fips"
]
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
