### PR TITLE
ci(auto-enum-updater): replacing searching for pr with head  and base instead of title  

### DIFF
--- a/.github/workflows/enum-auto-updater.yml
+++ b/.github/workflows/enum-auto-updater.yml
@@ -79,9 +79,12 @@ jobs:
               echo "ERROR: Cannot find module directory for $module"
               continue
             fi
-            
+
+            # Branch name for the module            
+            branchName="enum-update/${moduleName#aws-}"
+
             # Check for existing PR with the same name
-            prExists=$(gh pr list --state open --search "chore(${moduleName#aws-}): add new enum values for ${moduleName#aws-}" --json number,title -q '.[].number')
+            prExists=$(gh pr list --state open --head ${branchName} --base main --json number,title -q '.[].number')
             
             # If a PR exists, close it
             if [[ -n "$prExists" ]]; then
@@ -92,7 +95,6 @@ jobs:
             fi
             
             # Create/switch to branch for the module
-            branchName="enum-update/${moduleName#aws-}"
             echo "Creating/switching to branch: $branchName"
             git checkout -B "$branchName" $original_branch  # -B forces branch creation/reset
   


### PR DESCRIPTION
### Reason for this change
The Auto Enum Updater action is failing because it attempts to create a new PR when there's already an existing PR with identical changes. The workflow should handle this scenario by closing the existing PR and creating a new one, but this functionality appears to be broken.

- Failed Job URL: https://github.com/aws/aws-cdk/actions/runs/18874502066/job/53878253437
- Workflow: `.github/workflows/enum-auto-updater.yml`

The issue is that when the workflow trying to find existing pr with `--search $}{tittle}`, it's not working.

### Description of changes
Instead of listing the existing pr using `--search`, this change lists the pr using `--base` and `--head`.

### Description of how you validated changes
The workflow has been tested in fork.
- Job: https://github.com/abidhasan-aws/aws-cdk/actions/runs/18906468702/job/53965818347

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
