### PR TITLE
fix(eks-v2-alpha): remove hyphen from Go package name

### DIFF
--- a/packages/@aws-cdk/aws-eks-v2-alpha/package.json
+++ b/packages/@aws-cdk/aws-eks-v2-alpha/package.json
@@ -30,7 +30,7 @@
       },
       "go": {
         "moduleName": "github.com/aws/aws-cdk-go",
-        "packageName": "awscdkeks-v2alpha"
+        "packageName": "awscdkeksv2alpha"
       }
     },
     "metadata": {


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The previous Go package name `awscdkeks-v2alpha` was not usable in Go because hyphens are not allowed in Go package names. This made the package effectively unusable for Go developers.

### Description of changes

Updated the Go package name in `package.json` from `awscdkeks-v2alpha` to `awscdkeksv2alpha` by removing the hyphen. Since the old name was not functional in Go, this rename does not break any existing usage.

### Describe any new or updated permissions being added

No permission changes.

### Description of how you validated changes

This is a metadata-only change to the package configuration that makes the Go package usable.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
