### PR TITLE
chore: fix Python TypeError: Cannot create a consistent method resolution order (MRO)

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/deployment-lifecycle-hook-target.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/deployment-lifecycle-hook-target.ts
@@ -65,7 +65,6 @@ export interface IDeploymentLifecycleHookTarget {
    * Bind this target to a deployment lifecycle hook
    *
    * @param scope The construct scope
-   * @param id A unique identifier for this binding
    */
   bind(scope: IConstruct): DeploymentLifecycleHookTargetConfig;
 }

--- a/packages/aws-cdk-lib/aws-efs/lib/efs-file-system.ts
+++ b/packages/aws-cdk-lib/aws-efs/lib/efs-file-system.ts
@@ -4,7 +4,7 @@ import { CfnFileSystem, CfnMountTarget } from './efs.generated';
 import * as ec2 from '../../aws-ec2';
 import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
-import { ArnFormat, FeatureFlags, IResource, Lazy, Names, RemovalPolicy, Resource, Size, Stack, Tags, Token, ValidationError } from '../../core';
+import { ArnFormat, FeatureFlags, Lazy, Names, RemovalPolicy, Resource, Size, Stack, Tags, Token, ValidationError } from '../../core';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import * as cxapi from '../../cx-api';
@@ -141,7 +141,7 @@ export enum ReplicationOverwriteProtection {
 /**
  * Represents an Amazon EFS file system
  */
-export interface IFileSystem extends ec2.IConnectable, IResource, iam.IResourceWithPolicy {
+export interface IFileSystem extends ec2.IConnectable, iam.IResourceWithPolicy {
   /**
    * The ID of the file system, assigned by Amazon EFS.
    *

--- a/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
@@ -11,11 +11,11 @@ import { IProcessor, Transformer } from './transformer';
 import * as cloudwatch from '../../aws-cloudwatch';
 import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
-import { Arn, ArnFormat, IResource, RemovalPolicy, Resource, Stack, Token, ValidationError } from '../../core';
+import { Arn, ArnFormat, RemovalPolicy, Resource, Stack, Token, ValidationError } from '../../core';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 
-export interface ILogGroup extends IResource, iam.IResourceWithPolicy {
+export interface ILogGroup extends iam.IResourceWithPolicy {
   /**
    * The ARN of this log group, with ':*' appended
    *


### PR DESCRIPTION
### Issue # (if applicable)

Build on main failing with

```
    E   TypeError: Cannot create a consistent method resolution
    E   order (MRO) for bases IResource, IResourceWithPolicy, Protocol
```

### Reason for this change

There's a bug in jsii-pakmak. We can avoid the bug my not including the interface twice.

### Description of changes

`iam.IResourceWithPolicy` already extends `IResource`, so we can remove it from the two places that extended both

### Describe any new or updated permissions being added

n/a


### Description of how you validated changes

Build, packaged and executed the python lib.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
