### PR TITLE
ci(integration-test-deployment): update workflow to build both stable and alpha integration test packages

### DIFF
--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -102,7 +102,7 @@ jobs:
         
       # Build integration test packages: @aws-cdk-testing/framework-integ (stable tests) and @aws-cdk/* (alpha tests)
       - name: Build Integration Test packages 
-        run: npx lerna run build --scope="{@aws-cdk/*,@aws-cdk-testing}"
+        run: npx lerna run build --scope="{@aws-cdk/*,@aws-cdk-testing/framework-integ}"
 
       - name: Run integration tests using integration-test-deployment script
         run: yarn run atmosphere-integ-test

--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -100,9 +100,9 @@ jobs:
       - name: Build deployment-integ
         run: yarn --cwd tools/@aws-cdk/integration-test-deployment build
         
-      # Build entire CDK for integration test packages: @aws-cdk-testing/framework-integ (stable tests) and @aws-cdk (alpha tests)
+      # Build integration test packages: @aws-cdk-testing/framework-integ (stable tests) and @aws-cdk/* (alpha tests)
       - name: Build Integration Test packages 
-        run: npx lerna run build --skip-nx-cache
+        run: npx lerna run build --scope="{@aws-cdk/*,@aws-cdk-testing}"
 
       - name: Run integration tests using integration-test-deployment script
         run: yarn run atmosphere-integ-test

--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -100,8 +100,9 @@ jobs:
       - name: Build deployment-integ
         run: yarn --cwd tools/@aws-cdk/integration-test-deployment build
         
-      - name: Build Integration Tests
-        run: npx lerna run build --scope=@aws-cdk-testing/framework-integ 
+      # Build entire CDK for integration test packages: @aws-cdk-testing/framework-integ (stable tests) and @aws-cdk (alpha tests)
+      - name: Build Integration Test packages 
+        run: npx lerna run build --skip-nx-cache
 
       - name: Run integration tests using integration-test-deployment script
         run: yarn run atmosphere-integ-test


### PR DESCRIPTION
### Issue # (if applicable)

### Reason for this change

The deployment integ test does not find snapshots of alpha packages. See this log: https://github.com/aws/aws-cdk/actions/runs/18824890075/job/53705955618?pr=35705#step:13:382

This was due to the fact that only integration test for stable packages where build and not for alpha packages.

### Description of changes
The change should build integration test for both alpha and stable packages.

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes
Test run: https://github.com/Abogical/aws-cdk/actions/runs/19066544528/job/54458557618
<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
