### PR TITLE
chore(events-targets): correct typos in comments

### DIFF
--- a/packages/aws-cdk-lib/aws-events-targets/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/lib/log-group.ts
@@ -37,7 +37,7 @@ export interface LogGroupTargetInputOptions {
  */
 export abstract class LogGroupTargetInput {
   /**
-   * Pass a JSON object to the the log group event target
+   * Pass a JSON object to the log group event target
    *
    * May contain strings returned by `EventField.from()` to substitute in parts of the
    * matched event.

--- a/packages/aws-cdk-lib/aws-events/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/rule.ts
@@ -222,7 +222,7 @@ export class Rule extends Resource implements IRule {
         // and trigger on it there (there will be issues with construct references, for example). Especially
         // in the case of scheduled events, we will just trigger both rules in parallel in both environments.
         //
-        // A better solution would be to have the source rule add a unique token to the the event,
+        // A better solution would be to have the source rule add a unique token to the event,
         // and have the mirror rule trigger on that token only (thereby properly separating triggering, which
         // happens in the source env; and activating, which happens in the target env).
         //


### PR DESCRIPTION
### Issue # (if applicable)

N/A - Minor typo fixes

### Reason for this change

Fixed typos in code comments that had duplicate words ("the the").

### Description of changes

Corrected two instances of "the the" to "the" in:
- `packages/aws-cdk-lib/aws-events/lib/rule.ts` (line 225)
- `packages/aws-cdk-lib/aws-events-targets/lib/log-group.ts` (line 40)

### Describe any new or updated permissions being added

N/A - No permission changes

### Description of how you validated changes

Manual review of the changes. No functional code was modified, only comments.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
