### PR TITLE
revert: ci(mergify): update PRs via rebase by default instead of merge commit"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ queue_rules:
   - name: default-merge
     # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
     batch_size: 1
-    update_method: rebase
+    update_method: merge
     merge_method: merge
     queue_conditions:
       - -title~=(WIP|wip)
@@ -33,7 +33,7 @@ queue_rules:
   - name: priority-squash
     # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
     batch_size: 1
-    update_method: rebase
+    update_method: merge
     merge_method: squash
     queue_conditions:
       - base!=release
@@ -58,7 +58,7 @@ queue_rules:
   - name: default-squash
     # batch_size: 1 enables in-place checks (no draft PRs created for testing merges)
     batch_size: 1
-    update_method: rebase
+    update_method: merge
     merge_method: squash
     queue_conditions:
       - base!=release


### PR DESCRIPTION
Reverts aws/aws-cdk#35894 as it is causing issues with auto approve PRs, as they would require impersonation. 

The rebase strategy was added because whenever someone updates a workflow file, the merge commit update fails because of a Github security feature that prevents Github apps (Mergify) from updating workflow files unless they have the workflows permission. 

We reverted it because it is causing more issues than it solves, all auto approve PRs are not being merged anymore and the case of updating workflows is not very frequent to be worth the change.