### PR TITLE
fix(aws-amplify-alpha) Omit Prefix from SubDomainSettings when empty string is provided

### DIFF
--- a/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
@@ -200,7 +200,7 @@ export class Domain extends Resource {
   private renderSubDomainSettings() {
     return this.subDomains.map(s => ({
       branchName: s.branch.branchName,
-      prefix: s.prefix ?? s.branch.branchName,
+      ...(s.prefix !== '' ? { prefix: s.prefix ?? s.branch.branchName } : {}),
     }));
   }
 }

--- a/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
@@ -170,7 +170,6 @@ test('map a branch to the domain root', () => {
             'BranchName',
           ],
         },
-        Prefix: '',
       },
     ],
   });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #35958

### Reason for this change

After deploying a CDK stack containing an Amplify app with a custom domain that has a blank prefix, the underlying CloudFormation stack is immediately in "drifted" state.

### Description of changes

Per the suggestions in the issue, I updated the `renderSubDomainSettings` method to omit the `Prefix` method from the resulting map when the supplied prefix is set to `''`. 

The existing fallback logic is preserved for falling back to `branchName` if `prefix` is `null` or `undefined`.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Updated the corresponding test for mapping a branch to the domain root.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
