### PR TITLE
chore: update cdk-generate-synthetic-examples to use latest

### DIFF
--- a/scripts/run-rosetta.sh
+++ b/scripts/run-rosetta.sh
@@ -73,7 +73,7 @@ time $ROSETTA extract \
 
 if $infuse; then
     echo "💎 Generating synthetic examples for the remainder" >&2
-    time npx cdk-generate-synthetic-examples@^0.1.292 \
+    time npx cdk-generate-synthetic-examples@^0.2 \
         $(cat $jsii_pkgs_file)
 
     time $ROSETTA extract \

--- a/scripts/run-rosetta.sh
+++ b/scripts/run-rosetta.sh
@@ -73,7 +73,7 @@ time $ROSETTA extract \
 
 if $infuse; then
     echo "💎 Generating synthetic examples for the remainder" >&2
-    time npx cdk-generate-synthetic-examples@^0.2 \
+    time npx cdk-generate-synthetic-examples@latest \
         $(cat $jsii_pkgs_file)
 
     time $ROSETTA extract \


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Update the `cdk-generate-synthetic-examples` package to use the latest tag so we always get the latest features and improvements.

### Description of changes

Updated the version constraint in `scripts/run-rosetta.sh` from `^0.1.292` to `latest` for the `cdk-generate-synthetic-examples` package.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

This is a dependency version update. The script will use the latest version of the package when generating synthetic examples.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
