### PR TITLE
chore(spec2cdk): add explicit return type to loadPatchedSpec

### DIFF
--- a/tools/@aws-cdk/spec2cdk/lib/generate.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/generate.ts
@@ -105,7 +105,7 @@ export async function generate(modules: GenerateModuleMap, options: GenerateOpti
 /**
  * Load the service spec with patched schema files.
  */
-export async function loadPatchedSpec() {
+export async function loadPatchedSpec(): Promise<SpecDatabase> {
   const db = await loadAwsServiceSpec();
 
   // Load additional schema files


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The `loadPatchedSpec` function was missing an explicit return type annotation, which caused the integration test PRs in https://github.com/cdklabs/awscdk-service-spec to fail ([example](https://github.com/cdklabs/awscdk-service-spec/actions/runs/19285484055/job/55145432926?pr=2203#step:10:73)).

This is a fairly obscure scenario and doesn't happen that often. But I don't really have a good way to prevent this kind of issue in future. For now, let's stop the bleeding.

### Description of changes

Added explicit `Promise<SpecDatabase>` return type annotation to the `loadPatchedSpec` function in `tools/@aws-cdk/spec2cdk/lib/generate.ts`.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Type-only change, verified manually with linked `awscdk-service-spec` packages.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
