### PR TITLE
feat(appconfig): add typeAsString escape hatch for custom configurati…

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-appconfig/test/integ.configuration-type-as-string.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-appconfig/test/integ.configuration-type-as-string.ts
@@ -1,0 +1,33 @@
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+import { App, Stack } from 'aws-cdk-lib';
+import {
+  Application,
+  ConfigurationContent,
+  HostedConfiguration,
+} from 'aws-cdk-lib/aws-appconfig';
+
+const app = new App();
+const stack = new Stack(app, 'aws-appconfig-configuration-type-as-string');
+
+const appConfigApp = new Application(stack, 'MyAppConfig', {
+  applicationName: 'AppForTypeAsStringTest',
+});
+
+// Test typeAsString with existing enum value
+new HostedConfiguration(stack, 'MyConfigWithTypeAsString', {
+  application: appConfigApp,
+  name: 'TestConfigWithTypeAsString',
+  typeAsString: 'AWS.AppConfig.FeatureFlags',
+  content: ConfigurationContent.fromInlineText('This is my configuration content.'),
+});
+
+new IntegTest(app, 'appconfig-configuration-type-as-string', {
+  testCases: [stack],
+  cdkCommandOptions: {
+    destroy: {
+      args: {
+        force: true,
+      },
+    },
+  },
+});

--- a/packages/aws-cdk-lib/aws-appconfig/lib/configuration.ts
+++ b/packages/aws-cdk-lib/aws-appconfig/lib/configuration.ts
@@ -59,6 +59,16 @@ export interface ConfigurationOptions {
   readonly type?: ConfigurationType;
 
   /**
+   * The type of configuration as a string. Use this to specify custom configuration types
+   * that are not available in the ConfigurationType enum.
+   *
+   * This property takes precedence over the 'type' property if both are specified.
+   *
+   * @default - Uses the 'type' property value
+   */
+  readonly typeAsString?: string;
+
+  /**
    * The list of environments to deploy the configuration to.
    *
    * If this parameter is not specified, then there will be no
@@ -137,6 +147,11 @@ export interface IConfiguration extends IConstruct {
   readonly type?: ConfigurationType;
 
   /**
+   * The configuration type as a string.
+   */
+  readonly typeAsString?: string;
+
+  /**
    * The environments to deploy to.
    */
   readonly deployTo?: IEnvironment[];
@@ -187,6 +202,11 @@ abstract class ConfigurationBase extends Construct implements IConfiguration, IE
   public readonly type?: ConfigurationType;
 
   /**
+   * The configuration type as a string.
+   */
+  public readonly typeAsString?: string;
+
+  /**
    * The deployment key for the configuration.
    */
   public readonly deploymentKey?: kms.IKey;
@@ -210,6 +230,7 @@ abstract class ConfigurationBase extends Construct implements IConfiguration, IE
     this.application = props.application;
     this.applicationId = this.application.applicationId;
     this.type = props.type;
+    this.typeAsString = props.typeAsString;
     this.validators = props.validators;
     this.description = props.description;
     this.deployTo = props.deployTo;
@@ -349,6 +370,13 @@ abstract class ConfigurationBase extends Construct implements IConfiguration, IE
       environment.addDeployment(this);
     });
   }
+
+  /**
+   * Gets the effective configuration type, with typeAsString taking precedence over type.
+   */
+  protected effectiveType(): string | undefined {
+    return this.typeAsString || this.type;
+  }
 }
 
 /**
@@ -469,7 +497,7 @@ export class HostedConfiguration extends ConfigurationBase {
       locationUri: 'hosted',
       name: this.name!,
       description: this.description,
-      type: this.type,
+      type: this.effectiveType(),
       validators: this.validators,
       deletionProtectionCheck: this.deletionProtectionCheck,
       kmsKeyIdentifier: props.kmsKey?.keyRef.keyArn,
@@ -609,7 +637,7 @@ export class SourcedConfiguration extends ConfigurationBase {
       name: this.name!,
       description: this.description,
       retrievalRoleArn: this.retrievalRole?.roleArn,
-      type: this.type,
+      type: this.effectiveType(),
       validators: this.validators,
       deletionProtectionCheck: this.deletionProtectionCheck,
     });

--- a/packages/aws-cdk-lib/aws-appconfig/test/configuration.test.ts
+++ b/packages/aws-cdk-lib/aws-appconfig/test/configuration.test.ts
@@ -705,6 +705,58 @@ describe('configuration', () => {
     Template.fromStack(stack).resourceCountIs('AWS::AppConfig::Deployment', 0);
   });
 
+  test('configuration profile with typeAsString feature flags', () => {
+    const stack = new cdk.Stack();
+    const app = new Application(stack, 'MyAppConfig');
+    new HostedConfiguration(stack, 'MyConfigurationProfile', {
+      name: 'TestConfigProfile',
+      application: app,
+      typeAsString: 'AWS.AppConfig.FeatureFlags',
+      content: ConfigurationContent.fromInlineText('This is my content'),
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::AppConfig::ConfigurationProfile', {
+      Name: 'TestConfigProfile',
+      Type: 'AWS.AppConfig.FeatureFlags',
+      LocationUri: 'hosted',
+    });
+  });
+
+  test('configuration profile with typeAsString freeform', () => {
+    const stack = new cdk.Stack();
+    const app = new Application(stack, 'MyAppConfig');
+    new HostedConfiguration(stack, 'MyConfigurationProfile', {
+      name: 'TestConfigProfile',
+      application: app,
+      typeAsString: 'AWS.Freeform',
+      content: ConfigurationContent.fromInlineText('This is my content'),
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::AppConfig::ConfigurationProfile', {
+      Name: 'TestConfigProfile',
+      Type: 'AWS.Freeform',
+      LocationUri: 'hosted',
+    });
+  });
+
+  test('configuration profile typeAsString takes precedence over type', () => {
+    const stack = new cdk.Stack();
+    const app = new Application(stack, 'MyAppConfig');
+    new HostedConfiguration(stack, 'MyConfigurationProfile', {
+      name: 'TestConfigProfile',
+      application: app,
+      type: ConfigurationType.FEATURE_FLAGS,
+      typeAsString: 'AWS.Freeform',
+      content: ConfigurationContent.fromInlineText('This is my content'),
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::AppConfig::ConfigurationProfile', {
+      Name: 'TestConfigProfile',
+      Type: 'AWS.Freeform',
+      LocationUri: 'hosted',
+    });
+  });
+
   test('configuration profile with description', () => {
     const stack = new cdk.Stack();
     const app = new Application(stack, 'MyAppConfig');


### PR DESCRIPTION
…on types

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Allows customers to create custom configuration profile types not defined in the configuration profile enum.

### Description of changes
Added a typeAsString property to the AppConfig configuration interfaces as an escape hatch that allows specifying custom configuration types as strings.

<!--
What code changes did you make? 
- Added typeAsString?: string property to ConfigurationOptions and IConfiguration interfaces
- Added typeAsString property to ConfigurationBase class with precedence logic
- Created effectiveType() helper method that returns typeAsString if provided, otherwise falls back to type
- Added unit and integ tests.
Why do these changes address the issue?
- typeAsString takes precedence over type when both are provided.
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Yes

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
