### PR TITLE
chore(interfaces): submodule names for interface submodules are incorrect

### DIFF
--- a/packages/aws-cdk-lib/interfaces/.jsiirc.json
+++ b/packages/aws-cdk-lib/interfaces/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.interfaces"
+    },
+    "go": {
+      "packageName": "interfaces"
     }
   }
 }

--- a/tools/@aws-cdk/spec2cdk/lib/util/jsii.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/util/jsii.ts
@@ -1,3 +1,4 @@
+import type { ModuleDefinition } from '@aws-cdk/pkglint';
 import * as naming from '../naming';
 
 export interface PackageBaseNames {
@@ -21,15 +22,16 @@ export const AWS_CDK_LIB_BASE_NAMES: PackageBaseNames = {
  * @param bases - provide different package base names and overwrite jsii targets
  * @returns the module definition
  */
-export function namespaceToModuleDefinition(namespace: string, bases: PackageBaseNames = AWS_CDK_LIB_BASE_NAMES) {
+export function namespaceToModuleDefinition(namespace: string, bases: PackageBaseNames = AWS_CDK_LIB_BASE_NAMES): ModuleDefinition {
+  // [aws-s3, AWS, S3]
   const { moduleName, moduleFamily, moduleBaseName } = naming.modulePartsFromNamespace(namespace);
-  const submoduleName = moduleName.replace('-', '_');
+  const submoduleName = moduleName.replace('-', '_'); // aws_s3
 
-  const lowcaseModuleName = moduleBaseName.toLocaleLowerCase();
-  const packageName = `${bases.javascript}/${moduleName}`;
+  const lowcaseModuleName = moduleBaseName.toLocaleLowerCase(); // s3
+  const packageName = `${bases.javascript}/${moduleName}`; // aws-cdk-lib/aws-s3
 
   // dotnet names
-  const dotnetPackage = `${bases.dotnet}.${moduleFamily}.${moduleBaseName}`;
+  const dotnetPackage = `${bases.dotnet}.${moduleFamily}.${moduleBaseName}`; // Amazon.CDK.AWS.S3
 
   // java names
   const javaGroupId = bases.java;
@@ -41,8 +43,8 @@ export function namespaceToModuleDefinition(namespace: string, bases: PackageBas
     moduleFamily === 'AWS' ? lowcaseModuleName : `${moduleFamily.toLocaleLowerCase()}-${lowcaseModuleName}`;
 
   // python names
-  const pythonDistName = `${bases.python}.${moduleName}`;
-  const pythonModuleName = pythonDistName.replace(/-/g, '_');
+  const pythonDistName = `${bases.python}.${moduleName}`; // aws-cdk.aws-s3
+  const pythonModuleName = pythonDistName.replace(/-/g, '_'); // aws_cdk.aws_s3
 
   return {
     namespace,


### PR DESCRIPTION
### Reason for this change

Go packaging was failing with

```
#STDERR> awsimagebuilder/internal/types.go:4:2: "github.com/aws/aws-cdk-go/awscdk/interfaces/awsimagebuilder" imported and not used
#STDERR> awsimagebuilder/internal/types.go:8:28: undefined: IComponentRef
```

However as it turns out the generated `jsiirc` were using the wrong path. They were missing the required `.` (fullstop) prefix, thus the written package names were not being considered by jsii at all.

For go, we also need to update the interfaces package name to a unique name:

Before:

```
package awsimagebuilder
```

After:

```
package interfacesawsimagebuilder
```

### Description of changes

Use the correct `jsiirc` filename.
Ensure a unique package name for go is used.

### Describe any new or updated permissions being added

n/a

### Description of how you validated changes

Test pipeline is passing. Manually tested go packaging.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
