### PR TITLE
docs(contributing): add section explaining PR review process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Any code that you submit will be released under that license.
   - [Step 2: Design (optional)](#step-2-design)
   - [Step 3: Work your Magic](#step-3-work-your-magic)
   - [Step 4: Pull Request](#step-4-pull-request)
+  - [What Happens After You Submit Your PR](#what-happens-after-you-submit-your-pr)
   - [Step 5: Merge](#step-5-merge)
 - [Breaking Changes](#breaking-changes)
 - [Documentation](#documentation)
@@ -820,6 +821,45 @@ To disable coverage of specific lines, you can use:
 /* istanbul ignore next */
 console.log('This cannot be covered')
 ```
+
+### What Happens After You Submit Your PR
+
+After you submit your pull request, here's what to expect:
+
+#### 1. CodeBuild CI Validation
+
+Your PR will automatically trigger a CodeBuild CI pipeline that runs tests and validation checks. You are responsible for ensuring these checks pass:
+
+* **Monitor the build status** - Check the PR status checks to see if CodeBuild passes or fails.
+* **If the build fails** - You need to:
+  1. Click on the "Details" link next to the failed CodeBuild check to view the build logs
+  2. Identify the error message in the build log
+  3. Address the issue locally in your development environment
+  4. Commit and push the fixes to your PR branch
+  5. Repeat until the CodeBuild CI passes successfully
+
+> [!IMPORTANT]
+> Your PR cannot proceed to review until the CodeBuild CI check passes. If your build is failing without any work on it, your PR will be subject to closure for staleness.
+
+* **Resolve merge conflicts** - After CI passes, check if your PR has any merge conflicts with the base branch. If conflicts exist, you must resolve them either:
+  - From the GitHub web UI using the conflict resolution tool, or
+  - Locally in your IDE by pulling the latest changes from the base branch and resolving conflicts manually
+
+#### 2. Community Review Queue
+
+Once your PR passes all CI checks with no conflicts:
+
+* Your PR will be added to the [pending-community-review](https://github.com/aws/aws-cdk/pulls?q=is%3Apr+is%3Aopen+label%3Apr%2Fneeds-community-review) queue
+* [Eligible community reviewers](https://github.com/aws/aws-cdk/wiki/CDK-Community-PR-Reviews) can review and provide feedback on your changes
+* **One approving community review** is required before your PR moves forward
+
+#### 3. Maintainer Review Queue
+
+After receiving community approval:
+
+* Your PR will be promoted to the [pending-maintainer-review](https://github.com/aws/aws-cdk/pulls?q=is%3Apr+is%3Aopen+label%3Apr%2Fneeds-maintainer-review) queue
+* A CDK maintainer will perform a final review
+* The maintainer may request additional changes or approve your PR for merge
 
 ### Step 5: Merge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -851,7 +851,7 @@ Once your PR passes all CI checks with no conflicts:
 
 * Your PR will be added to the [pending-community-review](https://github.com/aws/aws-cdk/pulls?q=is%3Apr+is%3Aopen+label%3Apr%2Fneeds-community-review) queue
 * [Eligible community reviewers](https://github.com/aws/aws-cdk/wiki/CDK-Community-PR-Reviews) can review and provide feedback on your changes
-* **One approving community review** is required before your PR moves forward
+* **One approving community review** will immediately bump your PR to the pending maintainer review queue
 
 #### 3. Maintainer Review Queue
 


### PR DESCRIPTION
We have seen many requests from the contributors asking for what's next to move forward the PR review such as

https://github.com/aws/aws-cdk/pull/35933#issuecomment-3521777683
https://github.com/aws/aws-cdk/pull/35819#issuecomment-3470977273
https://github.com/aws/aws-cdk/pull/35812#issuecomment-3470978238
https://github.com/aws/aws-cdk/pull/35773#issuecomment-3470980022
https://github.com/aws/aws-cdk/pull/35766#issuecomment-3459527745
https://github.com/aws/aws-cdk/pull/34202#issuecomment-2855199827

We need to add a section in the contributing guide about "what should we do/expect after the PR submission".

This PR essentially:

- Add new section "What Happens After You Submit Your PR" to CONTRIBUTING.md
- Describe CodeBuild CI validation process and steps for resolving build failures
- Explain community review queue and requirements for community review
- Detail maintainer review process and progression of PR through review stages
- Provide guidance on monitoring PR status and addressing potential issues
- Improve documentation to help contributors understand the PR submission workflow

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

To improve the contributing experience.


### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
