### PR TITLE
fix (aws-opensearchservice/domain): r8gd not usable

### DIFF
--- a/packages/aws-cdk-lib/aws-opensearchservice/lib/domain.ts
+++ b/packages/aws-cdk-lib/aws-opensearchservice/lib/domain.ts
@@ -1651,6 +1651,7 @@ export class Domain extends DomainBase implements IDomain, ec2.IConnectable {
       ec2.InstanceClass.I8G,
       ec2.InstanceClass.IM4GN,
       ec2.InstanceClass.R7GD,
+      ec2.InstanceClass.R8GD,
     ];
 
     const supportInstanceStorageInstanceType = [


### PR DESCRIPTION
### Issue #36056
Closes #36056.

### Reason for this change

AWS announced Graviton4-based R8GD instance support for OpenSearch Service in October 2025, but the CDK validation logic hasn't been updated yet to recognize this new instance family. Like R6GD and R7GD, R8GD instances have built-in NVMe SSD storage and shouldn't require EBS volumes.

Root Cause:
The issue is in the [unSupportEbsInstanceType array](https://github.com/aws/aws-cdk/blob/61360ea5d27a3da232f7612fcd9a7512f20967df/packages/aws-cdk-lib/aws-opensearchservice/lib/domain.ts#L1619-L1627) in the OpenSearch Domain construct. R8GD needs to be added to this list alongside R6GD and R7GD.

### Description of changes

Add ec2.InstanceClass.R8GD to the unSupportEbsInstanceType array in packages/aws-cdk-lib/aws-opensearchservice/lib/domain.ts (around line 1654).

### Describe any new or updated permissions being added

No


### Description of how you validated changes

Instance class is available in Opensearch Console as per https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-opensearch-service-supports-graviton4-based-instances/

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
