### PR TITLE
chore: update readme metrics collection link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ environment and submit code.
 
 This solution collects anonymous operational metrics to help AWS improve the
 quality and features of the CDK. For more information, including how to disable
-this capability, please see the [developer guide](https://docs.aws.amazon.com/cdk/latest/guide/cli.html#version_reporting).
+this capability, please see the [developer guide](https://docs.aws.amazon.com/cdk/v2/guide/cdktelemetry.html).
 
 ## More Resources
 


### PR DESCRIPTION
current [link](https://docs.aws.amazon.com/cdk/latest/guide/cli.html#version_reporting) is not working. should be https://docs.aws.amazon.com/cdk/v2/guide/cli.html#version-reporting

however im linking to https://docs.aws.amazon.com/cdk/v2/guide/cdktelemetry.html instead, as we recently also introduced cli telemetry.