### PR TITLE
chore(rds): postgres add version 18

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -1944,6 +1944,11 @@ export class PostgresEngineVersion {
   /** Version "17.7". */
   public static readonly VER_17_7 = PostgresEngineVersion.of('17.7', '17', { s3Import: true, s3Export: true });
 
+  /** Version "18" (only a major version, without a specific minor version). */
+  public static readonly VER_18 = PostgresEngineVersion.of('18', '18', { s3Import: true, s3Export: true });
+  /** Version "18.1". */
+  public static readonly VER_18_1 = PostgresEngineVersion.of('18.1', '18', { s3Import: true, s3Export: true });
+
   /**
    * Create a new PostgresEngineVersion with an arbitrary version.
    *


### PR DESCRIPTION
### Reason for this change
https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-rds-postgresql-major-version-18/

### Description of changes
Postgres add version 18

### Description of how you validated changes
```console
$ aws rds describe-db-engine-versions --engine postgres --output table --query 'DBEngineVersions[*].{Engine:Engine,EngineVersion:EngineVersion}'

------------------------------------
|     DescribeDBEngineVersions     |
+-----------+----------------------+
|  Engine   |    EngineVersion     |
+-----------+----------------------+
...
|  postgres |  18.1                |
+-----------+----------------------+
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
