### PR TITLE
chore(core): add parseAnalytics function for debugging

### DIFF
--- a/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
+++ b/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
@@ -2,7 +2,7 @@ import * as zlib from 'zlib';
 import { Construct } from 'constructs';
 import { ENABLE_ADDITIONAL_METADATA_COLLECTION } from '../../cx-api';
 import { App, Stack, IPolicyValidationPluginBeta1, IPolicyValidationContextBeta1, Stage, PolicyValidationPluginReportBeta1, FeatureFlags, Duration } from '../lib';
-import { formatAnalytics } from '../lib/private/metadata-resource';
+import { formatAnalytics, parseAnalytics } from '../lib/private/metadata-resource';
 import { ConstructInfo } from '../lib/private/runtime-info';
 
 describe('MetadataResource', () => {
@@ -220,6 +220,43 @@ describe('formatAnalytics', () => {
   function expectAnalytics(constructs: ConstructInfo[], expectedPlaintext: string) {
     expect(plaintextConstructsFromAnalytics(formatAnalytics(constructs))).toEqual(expectedPlaintext);
   }
+});
+
+describe('parseAnalytics', () => {
+  test('parseAnalytics is the inverse of formatAnalytics for single construct', () => {
+    const constructInfo = [{ fqn: 'aws-cdk-lib.Construct', version: '1.2.3' }];
+    const analytics = formatAnalytics(constructInfo);
+    expect(parseAnalytics(analytics)).toEqual(constructInfo);
+  });
+
+  test('parseAnalytics is the inverse of formatAnalytics for multiple constructs', () => {
+    const constructInfo = [
+      { fqn: 'aws-cdk-lib.Construct', version: '1.2.3' },
+      { fqn: 'aws-cdk-lib.CfnResource', version: '1.2.3' },
+      { fqn: 'aws-cdk-lib.Stack', version: '1.2.3' },
+    ];
+    const analytics = formatAnalytics(constructInfo);
+    expect(parseAnalytics(analytics)).toEqual(constructInfo);
+  });
+
+  test('parseAnalytics is the inverse of formatAnalytics for nested modules', () => {
+    const constructInfo = [
+      { fqn: 'aws-cdk-lib.Construct', version: '1.2.3' },
+      { fqn: 'aws-cdk-lib.aws_servicefoo.CoolResource', version: '1.2.3' },
+      { fqn: 'aws-cdk-lib.aws_servicefoo.OtherResource', version: '1.2.3' },
+    ];
+    const analytics = formatAnalytics(constructInfo);
+    expect(parseAnalytics(analytics)).toEqual(constructInfo);
+  });
+
+  test('parseAnalytics is the inverse of formatAnalytics for different versions', () => {
+    const constructInfo = [
+      { fqn: 'aws-cdk-lib.Construct', version: '1.2.3' },
+      { fqn: 'aws-cdk-lib.CoolResource', version: '0.1.2' },
+    ];
+    const analytics = formatAnalytics(constructInfo);
+    expect(parseAnalytics(analytics)).toEqual(constructInfo);
+  });
 });
 
 function plaintextConstructsFromAnalytics(analytics: string) {


### PR DESCRIPTION
### Reason for this change

It always bothered me that we don't have an easy way of converting a template analytics string back for debugging.
This PR adds a debugging utility to decode analytics strings back into readable ConstructInfo objects.

### Description of changes

- Added `parseAnalytics()` function that reverses the `formatAnalytics()` encoding
- Added `parsePrefixEncodedList()` helper to decode the trie structure
- Added `trieToConstructInfos()` to convert trie back to ConstructInfo array
- Added comprehensive tests verifying parseAnalytics is the inverse of formatAnalytics

The implementation handles the v2:deflate64 format by base64 decoding, gunzipping, and parsing the prefix-encoded trie structure.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Added unit tests covering:
- Single construct parsing
- Multiple constructs with same version
- Nested module constructs
- Different versions

All tests verify that `parseAnalytics(formatAnalytics(x)) === x`

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
