### PR TITLE
feat: support VpcLinkV2 for REST API Gateway

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/README.md
+++ b/packages/aws-cdk-lib/aws-apigateway/README.md
@@ -1583,6 +1583,35 @@ const integration = new apigateway.Integration({
   },
 });
 ```
+```
+
+The following code sets up a private integration with a `VpcLinkV2` -
+
+```ts
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { VpcLink as VpcLinkV2 } from aws-cdk-lib/aws-apigatewayv2'; 
+
+const vpc = new ec2.Vpc(this, 'VPC');
+
+
+const alb = new elbv2.ApplicationLoadBalancer(this, 'ALB', {
+  vpc,
+});
+
+const vpcLink = new VpcLinkV2(this, 'VpcLink', {
+      vpc,
+    });
+
+const integration = new apigateway.Integration({
+  type: apigateway.IntegrationType.HTTP_PROXY,
+  integrationHttpMethod: 'ANY',
+  uri:  `http://${alb.loadBalancerDnsName}`,
+  options: {
+    connectionType: apigateway.ConnectionType.VPC_LINK,
+    vpcLink: link,
+  },
+});
+```
 
 The uri for the private integration, in the case of a VpcLink, will be set to the DNS name of
 the VPC Link's NLB. If the VPC Link has multiple NLBs or the VPC Link is imported or the DNS

--- a/packages/aws-cdk-lib/aws-apigateway/lib/integration.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/integration.ts
@@ -1,5 +1,6 @@
 import { Method } from './method';
 import { IVpcLink, VpcLink } from './vpc-link';
+import { IVpcLink as IVpcLinkV2 } from '../../aws-apigatewayv2'; 
 import * as iam from '../../aws-iam';
 import { Lazy, Duration } from '../../core';
 import { UnscopedValidationError, ValidationError } from '../../core/lib/errors';
@@ -114,7 +115,7 @@ export interface IntegrationOptions {
    * The VpcLink used for the integration.
    * Required if connectionType is VPC_LINK
    */
-  readonly vpcLink?: IVpcLink;
+  readonly vpcLink?: IVpcLink | IVpcLinkV2;
 }
 
 export interface IntegrationProps {


### PR DESCRIPTION
### Issue #36184

Closes #36184
### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

Add Support of IVpcLink aws-apigatewayv2 module in aws-apigateway module interface IntegrationOptions to support the new announced feature of supporting VPCLinkV2 for REST APIs

### Describe any new or updated permissions being added

None


### Description of how you validated changes

Test by hand successfully

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
