### PR TITLE
fix(mixins-preview): cannot use string literal types for `S3LogsDeliveryProps.permissionsVersion`

### DIFF
--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
@@ -42,6 +42,20 @@ export interface ILogsDelivery {
 }
 
 /**
+ * S3 Vended Logs Permissions version.
+ */
+export enum S3LogsDeliveryPermissionsVersion {
+  /**
+   * V1
+   */
+  V1 = 'V1',
+  /**
+   * V2
+   */
+  V2 = 'V2',
+}
+
+/**
  * Props for S3LogsDelivery
  */
 export interface S3LogsDeliveryProps {
@@ -51,7 +65,7 @@ export interface S3LogsDeliveryProps {
    *
    * @default "V2
    */
-  readonly permissionsVersion?: 'V1' | 'V2';
+  readonly permissionsVersion?: S3LogsDeliveryPermissionsVersion;
 }
 
 /**

--- a/packages/@aws-cdk/mixins-preview/test/services/aws-logs/logs-delivery.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/services/aws-logs/logs-delivery.test.ts
@@ -5,7 +5,7 @@ import { AccountRootPrincipal, Effect, PolicyDocument, PolicyStatement, Role, Se
 import { DeliveryStream, S3Bucket } from 'aws-cdk-lib/aws-kinesisfirehose';
 import { CfnDeliverySource, LogGroup, ResourcePolicy, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
-import { FirehoseLogsDelivery, LogGroupLogsDelivery, S3LogsDelivery, XRayLogsDelivery } from '../../../lib/services/aws-logs';
+import { FirehoseLogsDelivery, LogGroupLogsDelivery, S3LogsDelivery, S3LogsDeliveryPermissionsVersion, XRayLogsDelivery } from '../../../lib/services/aws-logs';
 
 // at the time of creating this test file S3 does not support Vended Logs on Buckets but this test pretends they do to make writing tests easier
 describe('S3 Delivery', () => {
@@ -77,7 +77,7 @@ describe('S3 Delivery', () => {
     });
 
     const s3Logs1 = new S3LogsDelivery(bucket, {
-      permissionsVersion: 'V2',
+      permissionsVersion: S3LogsDeliveryPermissionsVersion.V2,
     });
     s3Logs1.bind(source1, deliverySource1, source1.bucketArn);
 
@@ -89,7 +89,7 @@ describe('S3 Delivery', () => {
   test('creates policy with V1 permissions if specified', () => {
     const bucket = new Bucket(stack, 'Destination');
     const s3Logs = new S3LogsDelivery(bucket, {
-      permissionsVersion: 'V1',
+      permissionsVersion: S3LogsDeliveryPermissionsVersion.V1,
     });
     s3Logs.bind(source, deliverySource, source.bucketArn);
 
@@ -207,7 +207,7 @@ describe('S3 Delivery', () => {
   test('creates policy with V2 permissions if specified', () => {
     const bucket = new Bucket(stack, 'Destination');
     const s3Logs = new S3LogsDelivery(bucket, {
-      permissionsVersion: 'V2',
+      permissionsVersion: S3LogsDeliveryPermissionsVersion.V2,
     });
     s3Logs.bind(source, deliverySource, source.bucketArn);
 


### PR DESCRIPTION
### Issue # (if applicable)

```
@aws-cdk.mixins-preview.aws_logs.S3LogsDelivery-example.ts:19:3 - error TS2322: Type '"permissionsVersion"' is not assignable to type '"V1" | "V2" | undefined'.

19   permissionsVersion: 'permissionsVersion',
     ~~~~~~~~~~~~~~~~~~
@aws-cdk.mixins-preview.aws_logs.S3LogsDeliveryProps-example.ts:16:3 - error TS2322: Type '"permissionsVersion"' is not assignable to type '"V1" | "V2" | undefined'.

16   permissionsVersion: 'permissionsVersion',
     ~~~~~~~~~~~~~~~~~~

  /codebuild/output/src37859859/src/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts:54:12
    54   readonly permissionsVersion?: 'V1' | 'V2';
                  ~~~~~~~~~~~~~~~~~~
    The expected type comes from property 'permissionsVersion' which is declared here on type 'S3LogsDeliveryProps'
[jsii-rosetta] [WARN] 2 diagnostics from assemblies with 'strict' mode on (and 368 more non-strict diagnostics)
```

### Reason for this change

String literal types are not allowed in our pipeline.

### Description of changes

Replaced the string literal type with an enum.

### Describe any new or updated permissions being added

n/a

### Description of how you validated changes

Existing tests.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
