### PR TITLE
chore(mixins-preview): do not extend event metadata

### DIFF
--- a/packages/@aws-cdk/mixins-preview/scripts/spec2eventbridge/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2eventbridge/builder.ts
@@ -179,6 +179,7 @@ class EventBridgeEventsClass extends ClassType {
     eventNsName,
     event,
     typeDef,
+    addMetadata,
   }: {
     /** The interface or struct to add properties to */
     target: InterfaceType | StructType;
@@ -194,6 +195,7 @@ class EventBridgeEventsClass extends ClassType {
     event: Event;
     /** Type definition for resource field identification */
     typeDef: TypeDefinition;
+    addMetadata: boolean;
   }): FreeFunction {
     const propertyMappings = new Map<string, { original: string; type: Type; resolver?: Expression }>();
     const module = Module.of(this);
@@ -225,6 +227,18 @@ class EventBridgeEventsClass extends ClassType {
           summary: propSpec.documentation || `${propName} property`,
           remarks: `Specify an array of string values to match this event if the actual value of ${propName} is one of the values in the array. Use one of the constructors on the \`aws_events.Match\`  for more advanced matching options.`,
           default: defaultDoc,
+        },
+      });
+    }
+    if (addMetadata) {
+      target.addProperty({
+        name: 'eventMetadata',
+        type: CDK_CORE.AWSEventMetadataProps,
+        optional: true,
+        immutable: true,
+        docs: {
+          summary: 'EventBridge event metadata',
+          default: '-',
         },
       });
     }
@@ -329,6 +343,7 @@ class EventBridgeEventsClass extends ClassType {
               eventNsName,
               event,
               typeDef,
+              addMetadata: false,
             });
           }
         };
@@ -364,10 +379,10 @@ class EventBridgeEventsClass extends ClassType {
 
         // Create detail interface with event properties
         const detailInterface = new InterfaceType(eventNamespace, {
-          name: `${namespaceName}Detail`,
+          name: `${namespaceName}Props`,
           export: true,
           docs: {
-            summary: `Detail type for ${this.resource.name} ${event.name} event`,
+            summary: `Props type for ${this.resource.name} ${event.name} event`,
           },
         });
 
@@ -380,26 +395,7 @@ class EventBridgeEventsClass extends ClassType {
           eventNsName: namespaceName,
           event,
           typeDef: rootProperty,
-        });
-
-        // Create pattern props interface extending detail with metadata
-        const propInterface = new InterfaceType(eventNamespace, {
-          name: 'PatternProps',
-          export: true,
-          extends: [detailInterface.type],
-          docs: {
-            summary: `Properties for ${this.resource.name} ${event.name} event pattern`,
-          },
-        });
-        propInterface.addProperty({
-          name: 'eventMetadata',
-          type: CDK_CORE.AWSEventMetadataProps,
-          optional: true,
-          immutable: true,
-          docs: {
-            summary: 'EventBridge event metadata',
-            default: '-',
-          },
+          addMetadata: true,
         });
 
         // Create event pattern method that returns events.EventPattern
@@ -411,27 +407,21 @@ class EventBridgeEventsClass extends ClassType {
             summary: `EventBridge event pattern for ${this.resource.name} ${event.detailType}`,
           },
         });
-        const eventPatternMethodParam = eventPatternMethod.addParameter({
+        eventPatternMethod.addParameter({
           name: 'options',
-          type: propInterface.type,
+          type: detailInterface.type,
           optional: true,
         });
 
-        const eventMetadata = expr.ident('eventMetadata');
-
         eventPatternMethod.addBody(
-          stmt.constVar(
-            expr.destructuringObject(eventMetadata, expr.directCode('...obj')),
-            expr.binOp(expr.ident(eventPatternMethodParam.spec.name), '||', expr.lit({})),
-          ),
           stmt.ret(
             expr.object({
               source: expr.list([expr.lit(event.source)]),
               detailType: expr.list([expr.lit(event.detailType)]),
-              detail: expr.ident(converterFunction.name).call(expr.ident('obj'), expr.this_().prop(this.referenceName)),
-              version: expr.directCode('eventMetadata?.version'),
-              resources: expr.directCode('eventMetadata?.resources'),
-              region: expr.directCode('eventMetadata?.region'),
+              detail: expr.ident(converterFunction.name).call(expr.ident('options'), expr.this_().prop(this.referenceName)),
+              version: expr.directCode('options?.eventMetadata?.version'),
+              resources: expr.directCode('options?.eventMetadata?.resources'),
+              region: expr.directCode('options?.eventMetadata?.region'),
             }),
           ),
         );

--- a/packages/@aws-cdk/mixins-preview/test/events/l1-l2.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/events/l1-l2.test.ts
@@ -153,6 +153,36 @@ describe.each([
       },
     });
   });
+
+  test('should always have a bucketRef when empty props is passed', () => {
+    // GIVEN
+    const bucketEvents = BucketEvents.fromBucket(new class extends Construct {
+      public readonly bucketRef = {
+        bucketArn: 'arn',
+        bucketName: 'the-bucket',
+      };
+      public readonly env = { account: '11111111111', region: 'us-east-1' };
+    }(stack, 'Bucket'));
+
+    // WHEN
+    newRule(stack, bucketEvents.objectCreatedPattern({
+      eventMetadata: {
+        region: ['my-region'],
+      },
+    }));
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+      EventPattern: {
+        'detail-type': ['Object Created'],
+        'source': ['aws.s3'],
+        'detail': {
+          bucket: { name: ['the-bucket'] },
+        },
+        'region': ['my-region'],
+      },
+    });
+  });
 });
 
 test('creates multiple rules for different event types', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Remove the detail interface that was extending the `cdk.AWSEventMetadataProps` as extending creates problems in python.

### Description of changes
Before 
```
    export interface ObjectCreatedDetail {
      readonly bucket?: BucketEvents.ObjectCreated.Bucket;
      ...otherfields
     }  
  
    export interface PatternProps extends BucketEvents.ObjectCreated.ObjectCreatedDetail {
      readonly eventMetadata?: cdk.AWSEventMetadataProps;
    }
```

After this change:
```
    export interface ObjectCreatedProps {
      readonly eventMetadata?: cdk.AWSEventMetadataProps;

      readonly bucket?: BucketEvents.ObjectCreated.Bucket;
      ...otherfields
    }
```

The Pattern functions have been updated to:
```
  public workSpacesAccessPattern(options?: WorkspaceEvents.WorkSpacesAccess.WorkSpacesAccessProps): events.EventPattern {
    return {
      source: ["aws.workspaces"],
      detailType: ["WorkSpaces Access"],
      detail: convertWorkSpacesAccessDetailToEventPattern(options, this.workspaceRef),
      version: options?.eventMetadata?.version,
      resources: options?.eventMetadata?.resources,
      region: options?.eventMetadata?.region
    };
  }
```
And the `convertWorkSpacesAccessDetailToEventPattern` functions ignore the `eventMetadata` property.
### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Added unit test to ensure that the metadata was still being passed to the `EventPattern`
### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
