### PR TITLE
chore(rds): aurora postgres add 17.6, 15.14, 14.19, and 13.22

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
@@ -1189,6 +1189,9 @@ export class AuroraPostgresEngineVersion {
   public static readonly VER_13_20 = AuroraPostgresEngineVersion.of('13.20', '13', { s3Import: true, s3Export: true });
   /** Version "13.21". */
   public static readonly VER_13_21 = AuroraPostgresEngineVersion.of('13.21', '13', { s3Import: true, s3Export: true });
+  /** Version "13.22". */
+  public static readonly VER_13_22 = AuroraPostgresEngineVersion.of('13.22', '13', { s3Import: true, s3Export: true });
+
   /**
    * Version "14.3".
    * @deprecated Version 14.3 is no longer supported by Amazon RDS.
@@ -1243,6 +1246,9 @@ export class AuroraPostgresEngineVersion {
   public static readonly VER_14_17 = AuroraPostgresEngineVersion.of('14.17', '14', { s3Import: true, s3Export: true });
   /** Version "14.18". */
   public static readonly VER_14_18 = AuroraPostgresEngineVersion.of('14.18', '14', { s3Import: true, s3Export: true });
+  /** Version "14.19". */
+  public static readonly VER_14_19 = AuroraPostgresEngineVersion.of('14.19', '14', { s3Import: true, s3Export: true });
+
   /**
    * Version "15.2".
    * @deprecated Version 15.2 is no longer supported by Amazon RDS.
@@ -1280,6 +1286,9 @@ export class AuroraPostgresEngineVersion {
   public static readonly VER_15_12 = AuroraPostgresEngineVersion.of('15.12', '15', { s3Import: true, s3Export: true });
   /** Version "15.13". */
   public static readonly VER_15_13 = AuroraPostgresEngineVersion.of('15.13', '15', { s3Import: true, s3Export: true });
+  /** Version "15.14". */
+  public static readonly VER_15_14 = AuroraPostgresEngineVersion.of('15.14', '15', { s3Import: true, s3Export: true });
+
   /**
    * Version "16.0"
    * @deprecated Version 16.0 is no longer supported by Amazon RDS.
@@ -1329,6 +1338,8 @@ export class AuroraPostgresEngineVersion {
   public static readonly VER_17_4 = AuroraPostgresEngineVersion.of('17.4', '17', { s3Import: true, s3Export: true });
   /** Version "17.5". */
   public static readonly VER_17_5 = AuroraPostgresEngineVersion.of('17.5', '17', { s3Import: true, s3Export: true });
+  /** Version "17.6". */
+  public static readonly VER_17_6 = AuroraPostgresEngineVersion.of('17.6', '17', { s3Import: true, s3Export: true });
 
   /**
    * Create a new AuroraPostgresEngineVersion with an arbitrary version.


### PR DESCRIPTION
### Reason for this change
https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-aurora-minor-versions-17.6-16.10-15.14-14.19-13.22/

### Description of changes
Aurora Postgres add 17.6, 15.14, 14.19, and 13.22

### Description of how you validated changes
```console
$ aws rds describe-db-engine-versions --engine aurora-postgresql --output table --query 'DBEngineVersions[*].{Engine:Engine,EngineVersion:EngineVersion}'

-----------------------------------------
|       DescribeDBEngineVersions        |
+--------------------+------------------+
|       Engine       |  EngineVersion   |
+--------------------+------------------+
...
|  aurora-postgresql |  13.22           |
...
|  aurora-postgresql |  14.19           |
...
|  aurora-postgresql |  15.14           |
...
|  aurora-postgresql |  17.6            |
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
