### PR TITLE
fix(ecs-patterns): add feature flag to keep ECSPrivate target group ID (under feature flag)

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/application-load-balanced-service-base.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/application-load-balanced-service-base.ts
@@ -15,7 +15,7 @@ import { IRole } from '../../../aws-iam';
 import { ARecord, IHostedZone, RecordTarget, CnameRecord } from '../../../aws-route53';
 import { LoadBalancerTarget } from '../../../aws-route53-targets';
 import { CfnOutput, Duration, FeatureFlags, Stack, Token, ValidationError } from '../../../core';
-import { ECS_PATTERNS_SEC_GROUPS_DISABLES_IMPLICIT_OPEN_LISTENER, ECS_PATTERNS_UNIQUE_TARGET_GROUP_ID } from '../../../cx-api';
+import { ALBS_KEEP_ECSPRIVATE_TARGET_GROUP_NAME, ECS_PATTERNS_SEC_GROUPS_DISABLES_IMPLICIT_OPEN_LISTENER, ECS_PATTERNS_UNIQUE_TARGET_GROUP_ID } from '../../../cx-api';
 
 /**
  * Describes the type of DNS record the service should create
@@ -525,6 +525,8 @@ export abstract class ApplicationLoadBalancedServiceBase extends Construct {
     if (FeatureFlags.of(this).isEnabled(ECS_PATTERNS_UNIQUE_TARGET_GROUP_ID)) {
       // Include both internetFacing and loadBalancerName in target group ID
       targetGroupId = `ECS${props.loadBalancerName ?? ''}${internetFacing ? '' : 'Private'}`;
+    } else if ( FeatureFlags.of(this).isEnabled(ALBS_KEEP_ECSPRIVATE_TARGET_GROUP_NAME) && !internetFacing ) {
+      targetGroupId = 'ECSPrivate';
     } else {
       // Legacy behavior
       targetGroupId = 'ECS';

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -815,3 +815,23 @@ _cdk.json_
   }
 }
 ```
+
+* `@aws-cdk/ecs-patterns:albsKeepEcsPrivateTargetGroupName`
+
+When this feature flag is enabled, ALB patterns will use keep the target group name 'ECSPrivate' for
+non-public ApplicationLoadBalancedEc2 and ApplicationLoadBalancedFargateService constructs.
+
+This should only be used if you are migrating from versions of CDK prior to v2.221.0 and v2229.1 AND
+use either a ApplicationLoadBalancedEc2Service or ApplicationLoadBalancedFargateService construct with
+the publicLoadBalancer property set to off. As this will prevent the target group name from changing and
+forcing a replacement during deployment.
+
+_cdk.json_
+
+```json
+{
+  "context": {
+    "@aws-cdk/ecs-patterns:albsKeepEcsPrivateTargetGroupName": true
+  }
+}
+```

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -1780,7 +1780,7 @@ export const FLAGS: Record<string, FlagInfo> = {
       the publicLoadBalancer property set to off. As this will prevent the target group name from changing and
       forcing a replacement during deployment.
     `,
-    introducedIn: { v2: 'V2_NEXT' },
+    introducedIn: { v2: 'V2NEXT' },
     recommendedValue: false,
   },
 };

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -148,6 +148,7 @@ export const S3_PUBLIC_ACCESS_BLOCKED_BY_DEFAULT = '@aws-cdk/aws-s3:publicAccess
 export const USE_CDK_MANAGED_LAMBDA_LOGGROUP = '@aws-cdk/aws-lambda:useCdkManagedLogGroup';
 export const NETWORK_LOAD_BALANCER_WITH_SECURITY_GROUP_BY_DEFAULT = '@aws-cdk/aws-elasticloadbalancingv2:networkLoadBalancerWithSecurityGroupByDefault';
 export const STEPFUNCTIONS_TASKS_HTTPINVOKE_DYNAMIC_JSONPATH_ENDPOINT = '@aws-cdk/aws-stepfunctions-tasks:httpInvokeDynamicJsonPathEndpoint';
+export const ALBS_KEEP_ECSPRIVATE_TARGET_GROUP_NAME = '@aws-cdk/ecs-patterns:albsKeepEcsPrivateTargetGroupName';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1765,6 +1766,22 @@ export const FLAGS: Record<string, FlagInfo> = {
     `,
     introducedIn: { v2: '2.221.0' },
     recommendedValue: true,
+  },
+  //////////////////////////////////////////////////////////////////////
+  [ALBS_KEEP_ECSPRIVATE_TARGET_GROUP_NAME]: {
+    type: FlagType.BugFix,
+    summary: 'When enabled, ALB patterns will use the legacy target group name format.',
+    detailsMd: `
+      When this feature flag is enabled, ALB patterns will use keep the target group name 'ECSPrivate' for
+      non-public ApplicationLoadBalancedEc2 and ApplicationLoadBalancedFargateService constructs.
+
+      This should only be used if you are migrating from versions of CDK prior to v2.221.0 and v2229.1 AND
+      use either a ApplicationLoadBalancedEc2Service or ApplicationLoadBalancedFargateService construct with
+      the publicLoadBalancer property set to off. As this will prevent the target group name from changing and
+      forcing a replacement during deployment.
+    `,
+    introducedIn: { v2: 'V2_NEXT' },
+    recommendedValue: false,
   },
 };
 


### PR DESCRIPTION
### Reason for this change

A breaking change was introduced in CDK v2.221.0 (fixed in v2.230.0) that modified the target group naming convention for `ApplicationLoadBalancedEc2Service` and `ApplicationLoadBalancedFargateService` constructs when publicLoadBalancer is set to false. This caused the target group name to change from `ECS` to `ECSPrivate`, forcing resource replacement during deployment for existing stacks, which could cause service disruption.

For users who use versions between v2.221.0 and v2.229.1, upgrading to v2.230.0+ will cause another ID change back to the legacy behavior (`ECSPrivate` to `ECS`), which may cause service disruption when the upgrade is deployed.

### Description of changes

- Added a new feature flag `ALBS_KEEP_ECSPRIVATE_TARGET_GROUP_NAME` in cx-api/lib/features.ts

- Modified the target group ID logic in `application-load-balanced-service-base.ts` to check for the new feature flag

### Describe any new or updated permissions being added

No new permissions are added.

### Description of how you validated changes

Unit tests.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
