### PR TITLE
Fix URI in documentations

### DIFF
--- a/packages/@aws-cdk/aws-s3tables-alpha/lib/table.ts
+++ b/packages/@aws-cdk/aws-s3tables-alpha/lib/table.ts
@@ -312,7 +312,7 @@ export interface SchemaFieldProperty {
   /**
    * The field type.
    *
-   * S3 Tables supports all Apache Iceberg primitive types. For more information, see the [Apache Iceberg documentation](https://docs.aws.amazon.com/https://iceberg.apache.org/spec/#primitive-types).
+   * S3 Tables supports all Apache Iceberg primitive types. For more information, see the [Apache Iceberg documentation](https://iceberg.apache.org/spec/#primitive-types).
    */
   readonly type: string;
 }

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/lib/record-format/input.ts
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/lib/record-format/input.ts
@@ -90,7 +90,7 @@ export class TimestampParser {
    * Creates a TimestampParser from the given format string.
    *
    * The format string should be a valid Joda Time pattern string.
-   * See [Class DateTimeFormat](https://docs.aws.amazon.com/https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html) for more details
+   * See [Class DateTimeFormat](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html) for more details
    *
    * @param format the Joda Time format string
    */


### PR DESCRIPTION
### Reason for this change

Current documentation redirects to incorrect URIs.

### Description of changes
Fix the links in documentation.

### Describe any new or updated permissions being added
NA


### Description of how you validated changes
Its just typescript documentation change. No need for validations.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
