### PR TITLE
fix(aws-cdk-lib): make grants factory methods public

### DIFF
--- a/packages/aws-cdk-lib/aws-s3/lib/bucket-grants.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket-grants.ts
@@ -22,10 +22,8 @@ interface IPubliclyAccessibleBucket extends IBucketRef {
 export class BucketGrants {
   /**
    * Creates grants for an IBucketRef
-   *
-   * @internal
    */
-  public static _fromBucket(bucket: IBucketRef): BucketGrants {
+  public static fromBucket(bucket: IBucketRef): BucketGrants {
     return new BucketGrants(
       bucket,
       iam.GrantableResources.isEncryptedResource(bucket) ? bucket : undefined,

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -623,7 +623,7 @@ export abstract class BucketBase extends Resource implements IBucket, IEncrypted
   /**
    * Collection of grant methods for a Bucket
    */
-  public grants = BucketGrants._fromBucket(this);
+  public grants = BucketGrants.fromBucket(this);
 
   constructor(scope: Construct, id: string, props: ResourceProps = {}) {
     super(scope, id, props);

--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine-grants.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine-grants.ts
@@ -18,10 +18,8 @@ export interface StateMachineGrantsProps {
 export class StateMachineGrants {
   /**
    * Creates grants for StateMachineGrants
-   *
-   * @internal
    */
-  public static _fromStateMachine(resource: stepfunctions.IStateMachineRef): StateMachineGrants {
+  public static fromStateMachine(resource: stepfunctions.IStateMachineRef): StateMachineGrants {
     return new StateMachineGrants({
       resource: resource,
     });

--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
@@ -219,7 +219,7 @@ abstract class StateMachineBase extends Resource implements IStateMachine {
   /**
    * Collection of grant methods for a StateMachine
    */
-  public grants = StateMachineGrants._fromStateMachine(this);
+  public grants = StateMachineGrants.fromStateMachine(this);
 
   public get stateMachineRef(): StateMachineReference {
     return {


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The grants factory methods `BucketGrants.fromBucket()` and `StateMachineGrants.fromStateMachine()` were marked as internal but are useful for construct authors who want to create custom grant patterns or extend existing grant functionality.

### Description of changes

- Removed `@internal` JSDoc markers from factory methods
- Renamed methods from `_fromBucket` to `fromBucket` and `_fromStateMachine` to `fromStateMachine` to follow public API naming conventions
- Updated all internal usages to use the new public method names

This change makes it possible for construct authors to create grants objects for custom resources that implement `IBucketRef` or `IStateMachineRef`.

### Describe any new or updated permissions being added

No new or updated IAM permissions are being added. This change only exposes existing grant functionality through a public API.

### Description of how you validated changes

Existing unit tests continue to pass with the renamed methods.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
