### PR TITLE
fix: re-export of `ResourceEnvironment` is not an alias

### DIFF
--- a/packages/aws-cdk-lib/core/lib/environment.ts
+++ b/packages/aws-cdk-lib/core/lib/environment.ts
@@ -32,5 +32,7 @@ export interface Environment {
 }
 
 // For backwards compatibility with TypeScript users
+// (Note that `import { ... } from '...'; export { ... }` behaves differently in jsii
+// than `export { ... } from '...'`, and we need the former).
 import { IEnvironmentAware, ResourceEnvironment } from '../../interfaces/environment-aware';
 export type { IEnvironmentAware, ResourceEnvironment };

--- a/packages/aws-cdk-lib/core/lib/environment.ts
+++ b/packages/aws-cdk-lib/core/lib/environment.ts
@@ -32,4 +32,5 @@ export interface Environment {
 }
 
 // For backwards compatibility with TypeScript users
-export type { IEnvironmentAware, ResourceEnvironment } from '../../interfaces/environment-aware';
+import { IEnvironmentAware, ResourceEnvironment } from '../../interfaces/environment-aware';
+export type { IEnvironmentAware, ResourceEnvironment };


### PR DESCRIPTION
We changed the FQNs of interfaces in a recent PR in a non-backwards compatible way. By keeping aliases for the old types in TypeScript this should keep automatic backwards compatibility for TypeScript users, which translates to backwards compatibility of Java users of TypeScript-authored libraries.

However, we made a mistake in the aliasing. Originally, we wrote:

```ts
export type { IEnvironmentAware, ResourceEnvironment } from '...';
```

But `jsii` treats `export ... from` specially: it will take elements from the given file and export them *as if* they had been written in the current file (= current submodule).

This led to 2 equivalent but different definitions of `ResourceEnvironment`:

```
aws-cdk-lib.interfaces.ResourceEnvironment   (intended)
aws-cdk-lib.ResourceEnvironment              (unintended)
```

Change the syntax to:

```ts
import { IEnvironmentAware, ResourceEnvironment } from '...';
export type { IEnvironmentAware, ResourceEnvironment };
```

`export ...` is not the same as `export ... from`, so this now reduces us back to one definition with a TypeScript alias.

```
# Before
$ npx jsii-query --types . 'struct:name === "ResourceEnvironment"'
struct aws-cdk-lib.ResourceEnvironment
struct aws-cdk-lib.interfaces.ResourceEnvironment

# After
$ npx jsii-query --types . 'struct:name === "ResourceEnvironment"'
struct aws-cdk-lib.interfaces.ResourceEnvironment
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
