### PR TITLE
fix(region-info): standalone use of `@aws-cdk/region-info` throws an `Cannot find module 'aws-cdk-lib/core/lib/errors'` error

### DIFF
--- a/packages/aws-cdk-lib/eslint.config.mjs
+++ b/packages/aws-cdk-lib/eslint.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from 'eslint/config';
 export default defineConfig(
   makeConfig('tsconfig.json'),
   {
-    files: ['region-info/lib/**/*.ts'],
+    files: ['region-info/lib/**'],
     rules: {
       'no-restricted-imports': ['error', {
         patterns: [{

--- a/packages/aws-cdk-lib/eslint.config.mjs
+++ b/packages/aws-cdk-lib/eslint.config.mjs
@@ -1,3 +1,17 @@
 import { makeConfig } from '@aws-cdk/eslint-config';
+import { defineConfig } from 'eslint/config';
 
-export default makeConfig('tsconfig.json');
+export default defineConfig(
+  makeConfig('tsconfig.json'),
+  {
+    files: ['region-info/lib/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['../../*'],
+          message: '@aws-cdk/region-info must work standalone without aws-cdk-lib imports',
+        }],
+      }],
+    },
+  },
+);


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36399.

### Reason for this change

The `@aws-cdk/region-info` package imports `UnscopedValidationError` from an internal `aws-cdk-lib` path (`aws-cdk-lib/core/lib/errors`). Since `aws-cdk-lib` is only a devDependency, users installing `@aws-cdk/region-info` standalone get a "Cannot find module" error when using the package.

### Description of changes

Introduce a local `RegionFactError` class that:
- Extends `Error` and uses `CONSTRUCT_ERROR_SYMBOL` for typed error detection via `Errors.isConstructError()`
- Sets `name` to `'RegionFactError'` for consistent error presentation to users
- Removes the dependency on the internal `aws-cdk-lib/core/lib/errors` import

Also adds an ESLint rule to `region-info/lib/` that prevents imports from `../../*` paths, ensuring this issue cannot regress.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

- Built `aws-cdk-lib` successfully
- Ran `region-info` tests in both `aws-cdk-lib` and `@aws-cdk/region-info` packages
- Verified ESLint rule catches violations

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
