### PR TITLE
chore(cloudwatch): reference interfaces

### DIFF
--- a/packages/aws-cdk-lib/aws-appconfig/lib/environment.ts
+++ b/packages/aws-cdk-lib/aws-appconfig/lib/environment.ts
@@ -5,11 +5,11 @@ import { IConfiguration } from './configuration';
 import { ActionPoint, IEventDestination, ExtensionOptions, IExtension, IExtensible, ExtensibleBase } from './extension';
 import { getHash } from './private/hash';
 import { DeletionProtectionCheck } from './util';
-import * as cloudwatch from '../../aws-cloudwatch';
 import * as iam from '../../aws-iam';
 import { Resource, IResource, Stack, ArnFormat, PhysicalName, Names, ValidationError, UnscopedValidationError } from '../../core';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import { IAlarmRef } from '../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 
 /**
  * Attributes of an existing AWS AppConfig environment to import it.
@@ -403,9 +403,9 @@ export abstract class Monitor {
    * @param alarm The Amazon CloudWatch alarm.
    * @param alarmRole The IAM role for AWS AppConfig to view the alarm state.
    */
-  public static fromCloudWatchAlarm(alarm: cloudwatch.IAlarm, alarmRole?: iam.IRoleRef): Monitor {
+  public static fromCloudWatchAlarm(alarm: IAlarmRef, alarmRole?: iam.IRoleRef): Monitor {
     return {
-      alarmArn: alarm.alarmArn,
+      alarmArn: alarm.alarmRef.alarmArn,
       alarmRoleArn: alarmRole?.roleRef.roleArn,
       monitorType: MonitorType.CLOUDWATCH,
     };

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-base.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-base.ts
@@ -1,5 +1,6 @@
 import { IAlarmAction } from './alarm-action';
 import { IResource, Resource } from '../../core';
+import { IAlarmRef } from '../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 
 /**
  * Interface for Alarm Rule.
@@ -16,7 +17,7 @@ export interface IAlarmRule {
 /**
  * Represents a CloudWatch Alarm
  */
-export interface IAlarm extends IAlarmRule, IResource {
+export interface IAlarm extends IAlarmRule, IResource, IAlarmRef {
   /**
    * Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo)
    *
@@ -45,6 +46,13 @@ export abstract class AlarmBase extends Resource implements IAlarm {
   protected alarmActionArns?: string[];
   protected insufficientDataActionArns?: string[];
   protected okActionArns?: string[];
+
+  public get alarmRef() {
+    return {
+      alarmName: this.alarmName,
+      alarmArn: this.alarmArn,
+    };
+  }
 
   /**
    * AlarmRule indicating ALARM state for Alarm.

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-status-widget.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-status-widget.ts
@@ -1,6 +1,6 @@
-import { IAlarm } from './alarm-base';
 import { AlarmState } from './alarm-rule';
 import { ConcreteWidget } from './widget';
+import { IAlarmRef } from '../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 
 /**
  * The sort possibilities for AlarmStatusWidgets
@@ -34,7 +34,7 @@ export interface AlarmStatusWidgetProps {
   /**
    * CloudWatch Alarms to show in widget
    */
-  readonly alarms: IAlarm[];
+  readonly alarms: IAlarmRef[];
   /**
    * The title of the widget
    *
@@ -99,7 +99,7 @@ export class AlarmStatusWidget extends ConcreteWidget {
         y: this.y,
         properties: {
           title: this.props.title ? this.props.title : 'Alarm Status',
-          alarms: this.props.alarms.map((alarm) => alarm.alarmArn),
+          alarms: this.props.alarms.map((alarm) => alarm.alarmRef.alarmArn),
           states: this.props.states,
           sortBy: this.props.sortBy,
         },

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/composite-alarm.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/composite-alarm.ts
@@ -4,6 +4,7 @@ import { CfnCompositeAlarm } from './cloudwatch.generated';
 import { ArnFormat, Lazy, Names, Stack, Duration, ValidationError } from '../../core';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import { IAlarmRef } from '../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 
 /**
  * Properties for creating a Composite Alarm
@@ -41,7 +42,7 @@ export interface CompositeAlarmProps {
    *
    * @default - alarm will not be suppressed.
    */
-  readonly actionsSuppressor?: IAlarm;
+  readonly actionsSuppressor?: IAlarmRef;
 
   /**
    * The maximum duration that the composite alarm waits after suppressor alarm goes out of the ALARM state.
@@ -149,7 +150,7 @@ export class CompositeAlarm extends AlarmBase {
       alarmActions: Lazy.list({ produce: () => this.alarmActionArns }),
       insufficientDataActions: Lazy.list({ produce: (() => this.insufficientDataActionArns) }),
       okActions: Lazy.list({ produce: () => this.okActionArns }),
-      actionsSuppressor: props.actionsSuppressor?.alarmArn,
+      actionsSuppressor: props.actionsSuppressor?.alarmRef.alarmArn,
       actionsSuppressorExtensionPeriod: extensionPeriod?.toSeconds(),
       actionsSuppressorWaitPeriod: waitPeriod?.toSeconds(),
     });

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
@@ -1,8 +1,8 @@
-import { IAlarm } from './alarm-base';
 import { IMetric } from './metric-types';
 import { allMetricsGraphJson } from './private/rendering';
 import { ConcreteWidget } from './widget';
 import * as cdk from '../../core';
+import { IAlarmRef } from '../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 
 /**
  * Basic properties for widgets that display metrics
@@ -92,7 +92,7 @@ export interface AlarmWidgetProps extends MetricWidgetProps {
   /**
    * The alarm to show
    */
-  readonly alarm: IAlarm;
+  readonly alarm: IAlarmRef;
 
   /**
    * Left Y axis
@@ -125,7 +125,7 @@ export class AlarmWidget extends ConcreteWidget {
         title: this.props.title,
         region: this.props.region || cdk.Aws.REGION,
         annotations: {
-          alarms: [this.props.alarm.alarmArn],
+          alarms: [this.props.alarm.alarmRef.alarmArn],
         },
         yAxis: {
           left: this.props.leftYAxis ?? undefined,

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/ecs/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/ecs/deployment-group.ts
@@ -1,7 +1,6 @@
 import { Construct } from 'constructs';
 import { IEcsApplication, EcsApplication } from './application';
 import { EcsDeploymentConfig, IEcsDeploymentConfig } from './deployment-config';
-import * as cloudwatch from '../../../aws-cloudwatch';
 import * as ecs from '../../../aws-ecs';
 import * as elbv2 from '../../../aws-elasticloadbalancingv2';
 import * as iam from '../../../aws-iam';
@@ -10,6 +9,7 @@ import { ValidationError } from '../../../core';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
 import { CODEDEPLOY_REMOVE_ALARMS_FROM_DEPLOYMENT_GROUP } from '../../../cx-api';
+import { IAlarmRef } from '../../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 import { CfnDeploymentGroup } from '../codedeploy.generated';
 import { ImportedDeploymentGroupBase, DeploymentGroupBase } from '../private/base-deployment-group';
 import { renderAlarmConfiguration, renderAutoRollbackConfiguration } from '../private/utils';
@@ -149,7 +149,7 @@ export interface EcsDeploymentGroupProps {
    * @default []
    * @see https://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-create-alarms.html
    */
-  readonly alarms?: cloudwatch.IAlarm[];
+  readonly alarms?: IAlarmRef[];
 
   /**
    * The service Role of this Deployment Group.
@@ -223,7 +223,7 @@ export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeplo
    */
   public readonly role: iam.IRole;
 
-  private readonly alarms: cloudwatch.IAlarm[];
+  private readonly alarms: IAlarmRef[];
 
   constructor(scope: Construct, id: string, props: EcsDeploymentGroupProps) {
     super(scope, id, {
@@ -298,7 +298,7 @@ export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeplo
    * @param alarm the alarm to associate with this Deployment Group
    */
   @MethodMetadata()
-  public addAlarm(alarm: cloudwatch.IAlarm): void {
+  public addAlarm(alarm: IAlarmRef): void {
     this.alarms.push(alarm);
   }
 

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
@@ -1,13 +1,13 @@
 import { Construct } from 'constructs';
 import { ILambdaApplication, LambdaApplication } from './application';
 import { ILambdaDeploymentConfig, LambdaDeploymentConfig } from './deployment-config';
-import * as cloudwatch from '../../../aws-cloudwatch';
 import * as iam from '../../../aws-iam';
 import * as lambda from '../../../aws-lambda';
 import * as cdk from '../../../core';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
 import { CODEDEPLOY_REMOVE_ALARMS_FROM_DEPLOYMENT_GROUP } from '../../../cx-api';
+import { IAlarmRef } from '../../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 import { CfnDeploymentGroup } from '../codedeploy.generated';
 import { ImportedDeploymentGroupBase, DeploymentGroupBase } from '../private/base-deployment-group';
 import { renderAlarmConfiguration, renderAutoRollbackConfiguration } from '../private/utils';
@@ -75,7 +75,7 @@ export interface LambdaDeploymentGroupProps {
    * @default []
    * @see https://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-create-alarms.html
    */
-  readonly alarms?: cloudwatch.IAlarm[];
+  readonly alarms?: IAlarmRef[];
 
   /**
    * The service Role of this Deployment Group.
@@ -160,7 +160,7 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
    */
   public readonly role: iam.IRole;
 
-  private readonly alarms: cloudwatch.IAlarm[];
+  private readonly alarms: IAlarmRef[];
   private preHook?: lambda.IFunction;
   private postHook?: lambda.IFunction;
 
@@ -233,7 +233,7 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
    * @param alarm the alarm to associate with this Deployment Group
    */
   @MethodMetadata()
-  public addAlarm(alarm: cloudwatch.IAlarm): void {
+  public addAlarm(alarm: IAlarmRef): void {
     this.alarms.push(alarm);
   }
 

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/private/utils.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/private/utils.ts
@@ -1,7 +1,7 @@
 import { Construct } from 'constructs';
 import { IPredefinedDeploymentConfig } from './predefined-deployment-config';
-import * as cloudwatch from '../../../aws-cloudwatch';
 import { Token, Stack, ArnFormat, Arn, Fn, Aws, IResource, ValidationError } from '../../../core';
+import { IAlarmRef } from '../../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 import { IBaseDeploymentConfig } from '../base-deployment-config';
 import { CfnDeploymentGroup } from '../codedeploy.generated';
 import { AutoRollbackConfig } from '../rollback-config';
@@ -36,7 +36,7 @@ export interface renderAlarmConfigProps {
   /**
    * Array of Cloudwatch alarms
    */
-  readonly alarms: cloudwatch.IAlarm[];
+  readonly alarms: IAlarmRef[];
 
   /**
    * Whether to ignore failure to fetch the status of alarms from CloudWatch
@@ -64,7 +64,7 @@ export function renderAlarmConfiguration(props: renderAlarmConfigProps): CfnDepl
   const removeAlarms = props.removeAlarms ?? true;
   if (removeAlarms) {
     return {
-      alarms: props.alarms.length > 0 ? props.alarms.map(a => ({ name: a.alarmName })) : undefined,
+      alarms: props.alarms.length > 0 ? props.alarms.map(a => ({ name: a.alarmRef.alarmName })) : undefined,
       enabled: !ignoreAlarmConfiguration && props.alarms.length > 0,
       ignorePollAlarmFailure: props.ignorePollAlarmFailure,
     };
@@ -73,7 +73,7 @@ export function renderAlarmConfiguration(props: renderAlarmConfigProps): CfnDepl
   return props.alarms.length === 0
     ? undefined
     : {
-      alarms: props.alarms.map(a => ({ name: a.alarmName })),
+      alarms: props.alarms.map(a => ({ name: a.alarmRef.alarmName })),
       enabled: !ignoreAlarmConfiguration,
       ignorePollAlarmFailure: props.ignorePollAlarmFailure,
     };
@@ -96,7 +96,7 @@ enum AutoRollbackEvent {
   DEPLOYMENT_STOP_ON_REQUEST = 'DEPLOYMENT_STOP_ON_REQUEST',
 }
 
-export function renderAutoRollbackConfiguration(scope: Construct, alarms: cloudwatch.IAlarm[], autoRollbackConfig: AutoRollbackConfig = {}):
+export function renderAutoRollbackConfiguration(scope: Construct, alarms: IAlarmRef[], autoRollbackConfig: AutoRollbackConfig = {}):
 CfnDeploymentGroup.AutoRollbackConfigurationProperty | undefined {
   const events = new Array<string>();
 

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
@@ -3,7 +3,6 @@ import { IServerApplication, ServerApplication } from './application';
 import { IServerDeploymentConfig, ServerDeploymentConfig } from './deployment-config';
 import { LoadBalancer, LoadBalancerGeneration } from './load-balancer';
 import * as autoscaling from '../../../aws-autoscaling';
-import * as cloudwatch from '../../../aws-cloudwatch';
 import * as ec2 from '../../../aws-ec2';
 import * as iam from '../../../aws-iam';
 import * as s3 from '../../../aws-s3';
@@ -11,6 +10,7 @@ import * as cdk from '../../../core';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
 import { CODEDEPLOY_REMOVE_ALARMS_FROM_DEPLOYMENT_GROUP } from '../../../cx-api';
+import { IAlarmRef } from '../../../interfaces/generated/aws-cloudwatch-interfaces.generated';
 import { CfnDeploymentGroup } from '../codedeploy.generated';
 import { ImportedDeploymentGroupBase, DeploymentGroupBase } from '../private/base-deployment-group';
 import { renderAlarmConfiguration, renderAutoRollbackConfiguration } from '../private/utils';
@@ -211,7 +211,7 @@ export interface ServerDeploymentGroupProps {
    * @default []
    * @see https://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-create-alarms.html
    */
-  readonly alarms?: cloudwatch.IAlarm[];
+  readonly alarms?: IAlarmRef[];
 
   /**
    * Whether to continue a deployment even if fetching the alarm status from CloudWatch failed.
@@ -279,7 +279,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
   private readonly _autoScalingGroups: autoscaling.IAutoScalingGroup[];
   private readonly installAgent: boolean;
   private readonly codeDeployBucket: s3.IBucket;
-  private readonly alarms: cloudwatch.IAlarm[];
+  private readonly alarms: IAlarmRef[];
   private readonly loadBalancers?: LoadBalancer[];
 
   constructor(scope: Construct, id: string, props: ServerDeploymentGroupProps = {}) {
@@ -364,7 +364,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
    * @param alarm the alarm to associate with this Deployment Group
    */
   @MethodMetadata()
-  public addAlarm(alarm: cloudwatch.IAlarm): void {
+  public addAlarm(alarm: IAlarmRef): void {
     this.alarms.push(alarm);
   }
 


### PR DESCRIPTION

Reference interfaces for L2s, like https://github.com/aws/aws-cdk/pull/35271.

"chore" because I plan to make a lot of these PRs and they're not adding value to the changelog.

(Generated with AI)
