### PR TITLE
chore(codepipeline): reference interfaces

### DIFF
--- a/packages/aws-cdk-lib/aws-codepipeline-actions/lib/codepipeline/invoke-action.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline-actions/lib/codepipeline/invoke-action.ts
@@ -1,7 +1,9 @@
 import { Construct } from 'constructs';
 import * as codepipeline from '../../../aws-codepipeline';
+import { getPipelineArn } from '../../../aws-codepipeline/lib/private/ref-utils';
 import * as iam from '../../../aws-iam';
 import { Stack } from '../../../core';
+import { IPipelineRef } from '../../../interfaces/generated/aws-codepipeline-interfaces.generated';
 import { Action } from '../action';
 
 /**
@@ -12,7 +14,7 @@ export interface PipelineInvokeActionProps extends codepipeline.CommonAwsActionP
    * The pipeline that will, upon running, start the current target pipeline.
    * You must have already created the invoking pipeline.
    */
-  readonly targetPipeline: codepipeline.IPipeline;
+  readonly targetPipeline: IPipelineRef;
 
   /**
    * The source revisions that you want the target pipeline to use when it is started by the invoking pipeline.
@@ -111,14 +113,15 @@ export class PipelineInvokeAction extends Action {
 
   protected bound(scope: Construct, _stage: codepipeline.IStage, options: codepipeline.ActionBindOptions):
   codepipeline.ActionConfig {
+    const pipelineArn = getPipelineArn(this.props.targetPipeline);
     options.role.addToPolicy(new iam.PolicyStatement({
       actions: ['codepipeline:StartPipelineExecution'],
-      resources: [this.props.targetPipeline.pipelineArn],
+      resources: [pipelineArn],
     }));
 
     return {
       configuration: {
-        PipelineName: this.props.targetPipeline.pipelineName,
+        PipelineName: this.props.targetPipeline.pipelineRef.pipelineName,
         SourceRevisions: Stack.of(scope).toJsonString(this.props.sourceRevisions),
         Variables: Stack.of(scope).toJsonString(this.props.variables),
       },

--- a/packages/aws-cdk-lib/aws-codepipeline-actions/test/cloudformation/pipeline-actions.test.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline-actions/test/cloudformation/pipeline-actions.test.ts
@@ -383,6 +383,11 @@ class PipelineDouble extends cdk.Resource implements codepipeline.IPipeline {
   ): notifications.NotificationRuleSourceConfig {
     throw new Error('Method not implemented.');
   }
+  public get pipelineRef() {
+    return {
+      pipelineName: this.pipelineName,
+    };
+  }
 }
 
 class FullAction {

--- a/packages/aws-cdk-lib/aws-codepipeline/lib/action.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline/lib/action.ts
@@ -5,6 +5,7 @@ import * as events from '../../aws-events';
 import * as iam from '../../aws-iam';
 import * as s3 from '../../aws-s3';
 import { Duration, IResource, Lazy, UnscopedValidationError } from '../../core';
+import { IPipelineRef } from '../../interfaces/generated/aws-codepipeline-interfaces.generated';
 
 export enum ActionCategory {
   SOURCE = 'Source',
@@ -195,7 +196,7 @@ export interface IAction {
  * It extends `events.IRuleTarget`,
  * so this interface can be used as a Target for CloudWatch Events.
  */
-export interface IPipeline extends IResource, notifications.INotificationRuleSource {
+export interface IPipeline extends IResource, notifications.INotificationRuleSource, IPipelineRef {
   /**
    * The name of the Pipeline.
    *

--- a/packages/aws-cdk-lib/aws-codepipeline/lib/pipeline.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline/lib/pipeline.ts
@@ -41,6 +41,7 @@ import {
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import * as cxapi from '../../cx-api';
+import { PipelineReference } from '../../interfaces/generated/aws-codepipeline-interfaces.generated';
 
 /**
  * Allows you to control where to place a new Stage when it's added to the Pipeline.
@@ -388,6 +389,12 @@ export interface PipelineProps {
 abstract class PipelineBase extends Resource implements IPipeline {
   public abstract readonly pipelineName: string;
   public abstract readonly pipelineArn: string;
+
+  public get pipelineRef(): PipelineReference {
+    return {
+      pipelineName: this.pipelineName,
+    };
+  }
 
   /**
    * Defines an event rule triggered by this CodePipeline.

--- a/packages/aws-cdk-lib/aws-codepipeline/lib/private/ref-utils.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline/lib/private/ref-utils.ts
@@ -1,0 +1,25 @@
+import { IPipelineRef } from '../../../interfaces/generated/aws-codepipeline-interfaces.generated';
+import { CfnPipeline } from '../codepipeline.generated';
+import { IPipeline } from '../action';
+
+/**
+ * Get the pipeline ARN from an IPipelineRef.
+ * If the object is actually an IPipeline with a concrete pipelineArn, use that.
+ * Otherwise, construct the ARN from the pipeline name.
+ */
+export function getPipelineArn(pipeline: IPipelineRef): string {
+  // Check if this is actually an IPipeline with a pipelineArn property
+  if (isIPipeline(pipeline)) {
+    return pipeline.pipelineArn;
+  }
+  
+  // Fall back to constructing the ARN
+  return CfnPipeline.arnForPipeline(pipeline);
+}
+
+/**
+ * Type guard to check if an IPipelineRef is actually an IPipeline
+ */
+function isIPipeline(pipeline: IPipelineRef): pipeline is IPipeline {
+  return 'pipelineArn' in pipeline && typeof (pipeline as any).pipelineArn === 'string';
+}

--- a/packages/aws-cdk-lib/aws-codepipeline/lib/private/rich-action.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline/lib/private/rich-action.ts
@@ -1,7 +1,8 @@
 import { Construct } from 'constructs';
 import * as events from '../../../aws-events';
 import { ResourceEnvironment, Stack, Token, TokenComparison } from '../../../core';
-import { ActionBindOptions, ActionConfig, ActionProperties, IAction, IPipeline, IStage } from '../action';
+import { IPipelineRef } from '../../../interfaces/generated/aws-codepipeline-interfaces.generated';
+import { ActionBindOptions, ActionConfig, ActionProperties, IAction, IStage } from '../action';
 
 /**
  * Helper routines to work with Actions
@@ -19,7 +20,7 @@ import { ActionBindOptions, ActionConfig, ActionProperties, IAction, IPipeline, 
 export class RichAction implements IAction {
   public readonly actionProperties: ActionProperties;
 
-  constructor(private readonly action: IAction, private readonly pipeline: IPipeline) {
+  constructor(private readonly action: IAction, private readonly pipeline: IPipelineRef) {
     this.actionProperties = action.actionProperties;
   }
 

--- a/packages/aws-cdk-lib/aws-events-targets/lib/codepipeline.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/lib/codepipeline.ts
@@ -1,7 +1,8 @@
 import { bindBaseTargetConfig, singletonEventRole, TargetBaseProps } from './util';
-import * as codepipeline from '../../aws-codepipeline';
+import { getPipelineArn } from '../../aws-codepipeline/lib/private/ref-utils';
 import * as events from '../../aws-events';
 import * as iam from '../../aws-iam';
+import { IPipelineRef } from '../../interfaces/generated/aws-codepipeline-interfaces.generated';
 
 /**
  * Customization options when creating a `CodePipeline` event target.
@@ -21,21 +22,22 @@ export interface CodePipelineTargetOptions extends TargetBaseProps {
  */
 export class CodePipeline implements events.IRuleTarget {
   constructor(
-    private readonly pipeline: codepipeline.IPipeline,
+    private readonly pipeline: IPipelineRef,
     private readonly options: CodePipelineTargetOptions = {}) {
   }
 
   public bind(_rule: events.IRule, _id?: string): events.RuleTargetConfig {
     const role = this.options.eventRole || singletonEventRole(this.pipeline);
+    const pipelineArn = getPipelineArn(this.pipeline);
     role.addToPrincipalPolicy(new iam.PolicyStatement({
-      resources: [this.pipeline.pipelineArn],
+      resources: [pipelineArn],
       actions: ['codepipeline:StartPipelineExecution'],
     }));
 
     return {
       ...bindBaseTargetConfig(this.options),
       id: '',
-      arn: this.pipeline.pipelineArn,
+      arn: pipelineArn,
       role,
       targetResource: this.pipeline,
     };

--- a/packages/aws-cdk-lib/aws-scheduler-targets/lib/codepipeline-start-pipeline-execution.ts
+++ b/packages/aws-cdk-lib/aws-scheduler-targets/lib/codepipeline-start-pipeline-execution.ts
@@ -1,23 +1,24 @@
 import { ScheduleTargetBase, ScheduleTargetBaseProps } from './target';
-import { IPipeline } from '../../aws-codepipeline';
+import { getPipelineArn } from '../../aws-codepipeline/lib/private/ref-utils';
 import { IRole, PolicyStatement } from '../../aws-iam';
 import { IScheduleTarget } from '../../aws-scheduler';
+import { IPipelineRef } from '../../interfaces/generated/aws-codepipeline-interfaces.generated';
 
 /**
  * Use an AWS CodePipeline pipeline as a target for AWS EventBridge Scheduler.
  */
 export class CodePipelineStartPipelineExecution extends ScheduleTargetBase implements IScheduleTarget {
   constructor(
-    private readonly pipeline: IPipeline,
+    private readonly pipeline: IPipelineRef,
     props: ScheduleTargetBaseProps = {},
   ) {
-    super(props, pipeline.pipelineArn);
+    super(props, getPipelineArn(pipeline));
   }
 
   protected addTargetActionToRole(role: IRole): void {
     role.addToPrincipalPolicy(new PolicyStatement({
       actions: ['codepipeline:StartPipelineExecution'],
-      resources: [this.pipeline.pipelineArn],
+      resources: [getPipelineArn(this.pipeline)],
     }));
   }
 }


### PR DESCRIPTION
Reference interfaces for L2s, like https://github.com/aws/aws-cdk/pull/35271.

"chore" because I plan to make a lot of these PRs and they're not adding value to the changelog.

(Generated with AI)
