### PR TITLE
chore: enable rosetta performance debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ read*lock
 # Nx cache
 .nx/
 
+# jsii-rosetta files
+type-fingerprints.txt

--- a/scripts/run-rosetta.sh
+++ b/scripts/run-rosetta.sh
@@ -61,6 +61,12 @@ if $infuse; then
 fi
 
 #----------------------------------------------------------------------
+# Rosetta Debug settings
+
+export TIMING="1"
+export DEBUG_TYPE_FINGERPRINTS=$HOME/.s3buildcache/type-fingerprints.txt
+
+#----------------------------------------------------------------------
 
 echo "💎 Extracting code samples" >&2
 time $ROSETTA extract \

--- a/tools/@aws-cdk/cdk-build-tools/package.json
+++ b/tools/@aws-cdk/cdk-build-tools/package.json
@@ -54,7 +54,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^13.2.0",
     "jsii": "~5.9.18",
-    "jsii-rosetta": "~5.9.15",
+    "jsii-rosetta": "~5.9.21",
     "jsii-pacmak": "1.121.0",
     "jsii-reflect": "1.121.0",
     "markdownlint-cli": "^0.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,15 +3580,7 @@
     chalk "^4.1.2"
     semver "^7.7.2"
 
-"@jsii/check-node@1.121.0", "@jsii/check-node@^1.118.0":
-  version "1.121.0"
-  resolved "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.121.0.tgz#cfb32df36b38c308deb8e64f0406d73a55aaa8f1"
-  integrity sha512-0mPTsD9PDx/+Kvi6xNfOMzcxWW/nzo74rp96vN5qVg8pZThtzHqR14X0z4E/SqfYVs6Tv+Xiu4ctRRFmwe4xtQ==
-  dependencies:
-    chalk "^4.1.2"
-    semver "^7.7.2"
-
-"@jsii/check-node@1.121.0":
+"@jsii/check-node@1.121.0", "@jsii/check-node@^1.121.0":
   version "1.121.0"
   resolved "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.121.0.tgz#cfb32df36b38c308deb8e64f0406d73a55aaa8f1"
   integrity sha512-0mPTsD9PDx/+Kvi6xNfOMzcxWW/nzo74rp96vN5qVg8pZThtzHqR14X0z4E/SqfYVs6Tv+Xiu4ctRRFmwe4xtQ==
@@ -3603,14 +3595,7 @@
   dependencies:
     ajv "^8.17.1"
 
-"@jsii/spec@1.121.0", "@jsii/spec@^1.118.0", "@jsii/spec@^1.120.0":
-  version "1.121.0"
-  resolved "https://registry.npmjs.org/@jsii/spec/-/spec-1.121.0.tgz#43eeee50904151cebd1a68b2e93e35f104e24ee5"
-  integrity sha512-TDDUKTSRgRB0j2Yti+LOgUzjka8D+NdJm9vzYu1DOGu8Oje8cl9hRYZUmGoW8dWQLnF1dcouUP0n9PLvVKzu5w==
-  dependencies:
-    ajv "^8.17.1"
-
-"@jsii/spec@1.121.0":
+"@jsii/spec@1.121.0", "@jsii/spec@^1.120.0", "@jsii/spec@^1.121.0":
   version "1.121.0"
   resolved "https://registry.npmjs.org/@jsii/spec/-/spec-1.121.0.tgz#43eeee50904151cebd1a68b2e93e35f104e24ee5"
   integrity sha512-TDDUKTSRgRB0j2Yti+LOgUzjka8D+NdJm9vzYu1DOGu8Oje8cl9hRYZUmGoW8dWQLnF1dcouUP0n9PLvVKzu5w==
@@ -10140,13 +10125,13 @@ jsii-reflect@1.121.0, jsii-reflect@^1.120.0, jsii-reflect@^1.121.0:
     oo-ascii-tree "^1.121.0"
     yargs "^17.7.2"
 
-jsii-rosetta@~5.9.15:
-  version "5.9.15"
-  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.15.tgz#92d1cbab0a4f5f6b0fae89e1b7f673ddea506082"
-  integrity sha512-ruY+YQURrNIyEVZRTA2/v2jT3sDgS/0NFDIWfSvy0uzGV/IH2MqNRQHxD/u5k0ZlwIct3SjTAsqSpJ6ah3vT2Q==
+jsii-rosetta@~5.9.21:
+  version "5.9.21"
+  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.21.tgz#dbf798490e2317dcf4d3dcd22a0aaec842c7bbfa"
+  integrity sha512-oexuS+gKmlLUhotMKiAndRXYnapDvLdUtWkWFt6afGRJJBPL3aPL54aHJmyMOIC43lUhU+az/8N8ewgPls2wQg==
   dependencies:
-    "@jsii/check-node" "^1.118.0"
-    "@jsii/spec" "^1.118.0"
+    "@jsii/check-node" "^1.121.0"
+    "@jsii/spec" "^1.121.0"
     "@xmldom/xmldom" "^0.9.8"
     chalk "^4"
     commonmark "^0.31.2"


### PR DESCRIPTION
### Reason for this change

jsii-rosetta 5.9.21 includes performance improvements and bug fixes that help with translating code samples more reliably. The debug settings enable timing analysis and type fingerprint tracking to identify bottlenecks in the rosetta extraction process.

### Description of changes

The new debug environment variables (`TIMING` and `DEBUG_TYPE_FINGERPRINTS`) provide visibility into rosetta's performance characteristics, which is useful for diagnosing slow builds and optimizing the code sample translation pipeline.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A - dependency bump

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
