### PR TITLE
Refactor VPC subnet properties in template

### DIFF
--- a/packages/@aws-cdk/aws-elasticache-alpha/test/integ.serverless-cache.js.snapshot/aws-cdk-serverless-cache.template.json
+++ b/packages/@aws-cdk/aws-elasticache-alpha/test/integ.serverless-cache.js.snapshot/aws-cdk-serverless-cache.template.json
@@ -19,10 +19,6 @@
    "Type": "AWS::EC2::Subnet",
    "Properties": {
     "AvailabilityZone": {
-     "Fn::Select": [
-      0,
-      {
-       "Fn::GetAZs": ""
       }
      ]
     },


### PR DESCRIPTION
Removed Fn::Select function from VPCPublicSubnet1SubnetB4246D30 properties.

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
