### PR TITLE
chore(cdk-build-tools): rosetta: snippet merging prevents effective caching

### DIFF
--- a/scripts/run-rosetta.sh
+++ b/scripts/run-rosetta.sh
@@ -54,6 +54,7 @@ if [[ "${jsii_pkgs_file}" = "" ]]; then
     jsii_pkgs_file=$TMPDIR/jsii.txt
 fi
 
+mkdir -p $HOME/.s3buildcache
 rosetta_cache_file=$HOME/.s3buildcache/rosetta-cache.tabl.json
 extract_opts=""
 if $infuse; then

--- a/tools/@aws-cdk/cdk-build-tools/package.json
+++ b/tools/@aws-cdk/cdk-build-tools/package.json
@@ -54,7 +54,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^13.2.0",
     "jsii": "~5.9.18",
-    "jsii-rosetta": "~5.9.21",
+    "jsii-rosetta": "~5.9.22",
     "jsii-pacmak": "1.121.0",
     "jsii-reflect": "1.121.0",
     "markdownlint-cli": "^0.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10118,10 +10118,10 @@ jsii-reflect@1.121.0, jsii-reflect@^1.120.0, jsii-reflect@^1.121.0:
     oo-ascii-tree "^1.121.0"
     yargs "^17.7.2"
 
-jsii-rosetta@~5.9.21:
-  version "5.9.21"
-  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.21.tgz#dbf798490e2317dcf4d3dcd22a0aaec842c7bbfa"
-  integrity sha512-oexuS+gKmlLUhotMKiAndRXYnapDvLdUtWkWFt6afGRJJBPL3aPL54aHJmyMOIC43lUhU+az/8N8ewgPls2wQg==
+jsii-rosetta@~5.9.22:
+  version "5.9.22"
+  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.22.tgz#c9f9b9f958573744775448143cb857348375069d"
+  integrity sha512-FcZRHybS+0CSJxfRfIXlG+5lNMC4T1SkF/zW5FJfj+f9D3vtg3Ju0JEpjM9yoxSV4CPdSAxxbFo4GKgY6a4A9Q==
   dependencies:
     "@jsii/check-node" "^1.121.0"
     "@jsii/spec" "^1.121.0"


### PR DESCRIPTION
### Reason for this change

Update jsii-rosetta to get this fix in: https://github.com/aws/jsii-rosetta/pull/3488

### Description of changes

Bumps jsii-rosetta from 5.9.21 to 5.9.22 in cdk-build-tools.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A - dependency bump only.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
