### PR TITLE
feat(stepfunctions): add support for JSONata expressions to Map maxConcurrency

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions/README.md
@@ -861,6 +861,19 @@ const map = new sfn.Map(this, 'Map State', {
 });
 ```
 
+When using `JSONata`, you can also specify the `maxConcurrency` dynamically using a JSONata expression with the `jsonataMaxConcurrency` property. This allows you to determine the concurrency limit based on state input or other runtime values:
+
+```ts
+const map = new sfn.Map(this, 'Map State', {
+  jsonataMaxConcurrency: '{% $states.input.maxConcurrency %}',
+  itemSelector: {
+    item: '{% $states.context.Map.Item.Value %}',
+  }
+});
+```
+
+Note that `jsonataMaxConcurrency` is mutually exclusive with `maxConcurrency` and `maxConcurrencyPath`.
+
 To define a distributed `Map` state set `itemProcessors` mode to `ProcessorMode.DISTRIBUTED`.
 An `executionType` must be specified for the distributed `Map` workflow.
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36274 

### Reason for this change

In the current implementation, the Map state's maxConcurrency property only accepts numeric values.
However, according to the Amazon States Language specification, maxConcurrency can also be defined using a JSONata expression.

This limitation prevents users from dynamically controlling concurrency based on input data and causes a mismatch between CDK and the underlying Step Functions / CloudFormation capabilities.

This change updates the implementation to allow JSONata expressions for Map maxConcurrency, aligning CDK behavior with the Step Functions specification.

### Description of changes

This PR updates the Map state to support JSONata expressions for the maxConcurrency property.

A new option is introduced to allow maxConcurrency to be specified as a JSONata expression, in addition to a static numeric value.
This option is mutually exclusive with the existing numeric maxConcurrency configuration.

During synthesis, when a JSONata expression is provided, it is rendered directly into the CloudFormation template as the Map state's maxConcurrency value.

An alternative approach, such as introducing a new class or restructuring the existing API, was considered.
However, this was avoided to prevent breaking changes for existing users.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Added Unittest

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
