### PR TITLE
feat(ec2): add proper handling for VPC endpoint service name prefix eu.amazonaws for new region eusc-de-east-1 for ECR & API Gateway services

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ Shout out to our top contributors!
 - [peterwoodworth](https://github.com/peterwoodworth)
 - [phuhung273](https://github.com/phuhung273)
 - [GavinZZ](https://github.com/GavinZZ)
+- [salah1994-sys](https://github.com/salah1994-sys)
 
 
 _Last updated: Mon, 01 Dec 25 00:16:16 +0000_

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
@@ -848,12 +848,18 @@ export class InterfaceVpcEndpointAwsService implements IInterfaceVpcEndpointServ
         'redshift', 'redshift-data', 's3', 'sagemaker.api', 'sagemaker.featurestore-runtime', 'sagemaker.runtime', 'securityhub',
         'servicecatalog', 'sms', 'sqs', 'states', 'sts', 'sync-states', 'synthetics', 'transcribe', 'transcribestreaming', 'transfer',
         'workspaces', 'xray'],
+      'eusc-de-east-1': ['ecr.dkr', 'ecr.api', 'execute-api', 'securityhub'],
     };
     if (VPC_ENDPOINT_SERVICE_EXCEPTIONS[region]?.includes(name)) {
-      return 'cn.com.amazonaws';
-    } else {
-      return 'com.amazonaws';
+      switch (region) {
+        case 'eusc-de-east-1':
+          return 'eu.amazonaws';
+        case 'cn-north-1':
+        case 'cn-northwest-1':
+          return 'cn.com.amazonaws';
+      }
     }
+    return 'com.amazonaws';
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
@@ -840,6 +840,57 @@ describe('vpc endpoint', () => {
       });
     });
 
+    test('test vpc interface endpoint with eu.amazonaws prefix can be created correctly in eusc-de-east-1', () => {
+      // GIVEN
+      const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'eusc-de-east-1' } });
+      const vpc = new Vpc(stack, 'VPC');
+
+      // WHEN
+      vpc.addInterfaceEndpoint('ECR Endpoint', {
+        service: InterfaceVpcEndpointAwsService.ECR,
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        ServiceName: 'eu.amazonaws.eusc-de-east-1.ecr.api',
+      });
+    });
+
+    test('test vpc interface endpoint without eu.amazonaws prefix can be created correctly in eusc-de-east-1', () => {
+      // GIVEN
+      const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'eusc-de-east-1' } });
+      const vpc = new Vpc(stack, 'VPC');
+
+      // WHEN
+      vpc.addInterfaceEndpoint('ECS Endpoint', {
+        service: InterfaceVpcEndpointAwsService.ECS,
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        ServiceName: 'com.amazonaws.eusc-de-east-1.ecs',
+      });
+    });
+
+    test.each([
+      ['ecr.api', InterfaceVpcEndpointAwsService.ECR],
+      ['ecr.dkr', InterfaceVpcEndpointAwsService.ECR_DOCKER],
+      ['execute-api', InterfaceVpcEndpointAwsService.APIGATEWAY],
+      ['securityhub', InterfaceVpcEndpointAwsService.SECURITYHUB],
+    ])('test vpc interface endpoint for %s can be created correctly in eusc-de-east-1', (name: string, given: InterfaceVpcEndpointAwsService) => {
+      // GIVEN
+      const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'eusc-de-east-1' } });
+      const vpc = new Vpc(stack, 'VPC');
+
+      // WHEN
+      vpc.addInterfaceEndpoint('Endpoint', { service: given });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        ServiceName: `eu.amazonaws.eusc-de-east-1.${name}`,
+      });
+    });
+
     test('test codeartifact vpc interface endpoint in us-west-2', () => {
       // GIVEN
       const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'us-west-2' } });


### PR DESCRIPTION
Add proper handling for VPC endpoint service name prefix eu.amazonaws for new region eusc-de-east-1 for ECR & API Gateway services

### Reason for this change
For the new region `eusc-de-east-1` will be launched in [AWS European Sovereign Cloud](https://aws.amazon.com/blogs/security/introducing-the-overview-of-the-aws-european-sovereign-cloud-whitepaper/), services like 
- ECR
- API Gateway
- Security Hub

have their VPC endpoint service name starts with prefix `eu.amazonaws` rather than the default `com.amazonaws`.

This requires special handling similar to what's already implemented for China regions `cn-north-1` & `cn-northwest-1` otherwise, while deploying, CloudFormation stacks will hit the error "*The Vpc Endpoint Service `com.amazonaws.eusc-de-east-1.ecr.dkr` does not exist*"

<!--What is the bug or use case behind this change?-->

### Description of changes
In the file `packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts`, I am updating the method `getDefaultEndpointPrefix`, adding special handling for `eusc-de-east-1` when services are ['ecr.dkr', 'ecr.api', 'execute-api', 'securityhub'] to return `eu.amazonaws` instead of `com.amazonaws`. Similar to what's already existing for China regions. 


### Description of how you validated changes

I also updated `packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts` to cover unit tests and was confirmed tests are passed
````
maelnabi@c889f3aaec8b aws-cdk-lib % yarn test aws-ec2
yarn run v1.22.22
$ jest aws-ec2
 PASS  aws-ec2/test/volume.test.ts (13.106 s)
 PASS  aws-ec2/test/instance.test.ts (14.333 s)
 PASS  aws-ec2/test/vpc.test.ts (15.864 s)
 PASS  aws-ec2/test/vpc-endpoint.test.ts (17.116 s)
 PASS  aws-ec2/test/launch-template.test.ts
 PASS  aws-ec2/test/security-group.test.ts
 PASS  aws-ec2/test/vpc-flow-logs.test.ts
 PASS  aws-ec2/test/userdata.test.ts
 PASS  aws-ec2/test/cfn-init.test.ts
 PASS  aws-ec2/test/cfn-init-element.test.ts
 PASS  aws-ec2/test/machine-image.test.ts
 PASS  aws-ec2/test/ip-addresses.test.ts
 PASS  aws-ec2/test/vpc.from-lookup.test.ts
 PASS  aws-ec2/test/connections.test.ts
 PASS  aws-ec2/test/vpc-endpoint-service.test.ts
 PASS  aws-ec2/test/vpn.test.ts
 PASS  aws-ec2/test/client-vpn-endpoint.test.ts
 PASS  aws-ec2/test/prefix-list.test.ts
 PASS  aws-ec2/test/network-utils.test.ts
 PASS  aws-ec2/test/bastion-host.test.ts
 PASS  aws-ec2/test/aspects/require-imdsv2-aspect.test.ts
 PASS  aws-ec2/test/client-vpn-route.test.ts
 PASS  aws-ec2/test/key-pair.test.ts
 PASS  aws-ec2/test/client-vpn-authorization-rule.test.ts
 PASS  aws-ec2/test/placement-group.test.ts
 PASS  aws-ec2/test/cidr-splits.test.ts
 PASS  aws-ec2/test/instance-requirements.test.ts
 PASS  aws-ec2/test/l1.test.ts
 PASS  aws-ec2/test/instance-type.test.ts

=============================== Coverage summary ===============================
Statements   : 59.25% ( 12033/20308 )
Branches     : 41.58% ( 3168/7618 )
Functions    : 43.44% ( 1860/4281 )
Lines        : 60.55% ( 11632/19210 )
================================================================================

Test Suites: 29 passed, 29 total
Tests:       941 passed, 941 total
Snapshots:   0 total
Time:        29.278 s
Ran all test suites matching /aws-ec2/i.
✨  Done in 32.88s.
````

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
