### PR TITLE
fix(cloudwatch): skip MathExpression validation when prop is a token

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/metric.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/metric.ts
@@ -838,7 +838,7 @@ export class MathExpression implements IMetric {
       warnings['CloudWatch:Math:MetricsPeriodsOverridden'] = `Periods of metrics in 'usingMetrics' for Math expression '${this.expression}' have been overridden to ${this.period.toSeconds()} seconds.`;
     }
 
-    const invalidVariableNames = Object.keys(this.usingMetrics).filter(x => !validVariableName(x));
+    const invalidVariableNames = Object.keys(this.usingMetrics).filter(x => !cdk.Token.isUnresolved(x) && !validVariableName(x));
     if (invalidVariableNames.length > 0) {
       throw new cdk.UnscopedValidationError(`Invalid variable names in expression: ${invalidVariableNames}. Must start with lowercase letter and only contain alphanumerics.`);
     }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

`MathExpression` class has multiple props that needs to be alphanumeric, that check for this is already there, but the problem is the checker doesn't check first if it's token or not. so for any tokens it always throw an error since it has `$` even if the resolve of this token is alphanumeric string.

### Description of changes

I'm checking if it's token or not, and if it's i'm passing the alphanumeric checker, since in this case u can't check it.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
