### PR TITLE
feat(ecs): add forceNewDeployment support to BaseService

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ecs/test/ec2/integ.force-new-deployment.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ecs/test/ec2/integ.force-new-deployment.ts
@@ -1,0 +1,66 @@
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+
+const app = new cdk.App({
+  postCliContext: {
+    '@aws-cdk/aws-lambda:useCdkManagedLogGroup': false,
+    '@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy': false,
+  },
+});
+const stack = new cdk.Stack(app, 'integ-ec2-force-new-deployment');
+
+const vpc = new ec2.Vpc(stack, 'Vpc', { maxAzs: 2, restrictDefaultSecurityGroup: false });
+
+const cluster = new ecs.Cluster(stack, 'EC2CPCluster', {
+  vpc,
+  enableFargateCapacityProviders: true,
+});
+
+const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'TaskDef');
+
+taskDefinition.addContainer('web', {
+  image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+  memoryReservationMiB: 256,
+});
+
+const autoScalingGroup = new autoscaling.AutoScalingGroup(stack, 'ASG', {
+  vpc,
+  instanceType: new ec2.InstanceType('t3.medium'),
+  machineImage: ecs.EcsOptimizedImage.amazonLinux2023(ecs.AmiHardwareType.STANDARD),
+  minCapacity: 1,
+  maxCapacity: 5,
+});
+
+const cp = new ecs.AsgCapacityProvider(stack, 'EC2CapacityProvider', {
+  autoScalingGroup,
+  // This is to allow cdk destroy to work; otherwise deletion will hang bc ASG cannot be deleted
+  enableManagedTerminationProtection: false,
+  enableManagedDraining: true,
+});
+
+cluster.addAsgCapacityProvider(cp);
+
+// Service with capacity provider strategies and CODE_DEPLOY deployment controller
+// Using forceNewDeployment to allow changes to ASG instance types
+new ecs.Ec2Service(stack, 'EC2Service', {
+  cluster,
+  taskDefinition,
+  desiredCount: 1,
+  capacityProviderStrategies: [
+    {
+      capacityProvider: cp.capacityProviderName,
+      weight: 1,
+    },
+  ],
+  deploymentController: {
+    type: ecs.DeploymentControllerType.CODE_DEPLOY,
+  },
+  forceNewDeployment: {
+    enable: true,
+    nonce: 'test-nonce-123',
+  },
+});
+
+app.synth();

--- a/packages/aws-cdk-lib/aws-ecs/test/base-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/base-service.test.ts
@@ -514,4 +514,85 @@ describe('Blue/Green Deployment', () => {
     // THEN
     expect(service.isUsingECSDeploymentController()).toBe(false);
   });
+
+  test('can configure forceNewDeployment', () => {
+    // GIVEN
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+    const taskDefinition = new ecs.FargateTaskDefinition(stack, 'FargateTaskDef');
+    taskDefinition.addContainer('web', {
+      image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+    });
+
+    // WHEN
+    new ecs.FargateService(stack, 'FargateService', {
+      cluster,
+      taskDefinition,
+      forceNewDeployment: {
+        enable: true,
+        nonce: 'test-nonce-123',
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECS::Service', {
+      ForceNewDeployment: {
+        EnableForceNewDeployment: true,
+        ForceNewDeploymentNonce: 'test-nonce-123',
+      },
+    });
+  });
+
+  test('can configure forceNewDeployment with only enable flag', () => {
+    // GIVEN
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+    const taskDefinition = new ecs.FargateTaskDefinition(stack, 'FargateTaskDef');
+    taskDefinition.addContainer('web', {
+      image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+    });
+
+    // WHEN
+    new ecs.FargateService(stack, 'FargateService', {
+      cluster,
+      taskDefinition,
+      forceNewDeployment: {
+        enable: true,
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECS::Service', {
+      ForceNewDeployment: {
+        EnableForceNewDeployment: true,
+      },
+    });
+  });
+
+  test('can configure forceNewDeployment with default enable value', () => {
+    // GIVEN
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+    const taskDefinition = new ecs.FargateTaskDefinition(stack, 'FargateTaskDef');
+    taskDefinition.addContainer('web', {
+      image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+    });
+
+    // WHEN
+    new ecs.FargateService(stack, 'FargateService', {
+      cluster,
+      taskDefinition,
+      forceNewDeployment: {
+        nonce: 'test-nonce-456',
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECS::Service', {
+      ForceNewDeployment: {
+        EnableForceNewDeployment: true,
+        ForceNewDeploymentNonce: 'test-nonce-456',
+      },
+    });
+  });
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36563.

### Reason for this change

When using `Ec2Service` with `capacityProviderStrategies` and `CODE_DEPLOY` deployment controller, users are unable to deploy changes to the underlying Auto Scaling Group instance type. AWS ECS requires a force new deployment in these scenarios, but the CDK L2 constructs (`BaseService`, `Ec2Service`, `FargateService`) did not expose the `forceNewDeployment` property, forcing users to resort to escape hatches that don't work reliably.

This change adds first-class support for `forceNewDeployment` at the L2 construct level, allowing users to properly handle scenarios where AWS ECS requires a forced deployment (e.g., when switching from launch type to capacity provider strategy, or making changes to capacity provider strategy on an existing service).

### Description of changes

- Added `ForceNewDeployment` interface to `BaseServiceOptions` with `enable` and `nonce` properties
- Updated `BaseService` constructor to pass `forceNewDeployment` configuration to the underlying `CfnService`
- Added comprehensive unit tests covering various `forceNewDeployment` configurations
- Created integration test demonstrating `forceNewDeployment` with capacity provider strategies and CODE_DEPLOY deployment controller
- Updated README documentation with a new "Force new deployment" section explaining when and how to use this feature
- Added cross-reference note in the Capacity Provider section

These changes provide a clean, type-safe API for forcing new deployments without requiring escape hatches or workarounds.

No alternative approaches were considered, as this directly addresses the missing L2 property that users need for this common use case.

### Describe any new or updated permissions being added

None.

This change only adds a configuration property to existing ECS service constructs and does not introduce or modify any IAM permissions.

### Description of how you validated changes

- Added unit tests in `base-service.test.ts` covering:
  - `forceNewDeployment` with both `enable` and `nonce` properties
  - `forceNewDeployment` with only `enable` property
  - `forceNewDeployment` with only `nonce` property (defaults `enable` to `true`)
- Created integration test `integ.force-new-deployment.ts` demonstrating the feature with:
  - Capacity provider strategies
  - CODE_DEPLOY deployment controller
  - Force new deployment configuration
- Verified all linter checks pass
- Manually reviewed the implementation to ensure it correctly maps to CloudFormation `ForceNewDeployment` property structure
- Updated README documentation with examples and usage guidance

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
