### PR TITLE
fix(lambda-nodejs): copy .npmrc for pnpm to enable private registry authentication

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/bundling.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/bundling.ts
@@ -286,13 +286,16 @@ export class Bundling implements cdk.BundlingOptions {
       const isPnpm = this.packageManager.lockFile === LockFile.PNPM;
       const isBun = this.packageManager.lockFile === LockFile.BUN_LOCK || this.packageManager.lockFile === LockFile.BUN;
 
-      // Find .npmrc file in project root for pnpm to inherit registry authentication
+      // Find .npmrc file for pnpm to inherit registry authentication
+      // Only use it if it's within projectRoot (not outside, which would be inaccessible in Docker)
       const npmrcFilePath = isPnpm ? findUp('.npmrc', this.projectRoot) : undefined;
+      const relativeNpmrcPath = npmrcFilePath ? path.relative(this.projectRoot, npmrcFilePath) : undefined;
+      const npmrcInProjectRoot = relativeNpmrcPath && !relativeNpmrcPath.startsWith('..');
 
       // Create dummy package.json, copy lock file if any and then install
       depsCommand = chain([
         isPnpm ? osCommand.write(pathJoin(options.outputDir, 'pnpm-workspace.yaml'), ''): '', // Ensure node_modules directory is installed locally by creating local 'pnpm-workspace.yaml' file
-        isPnpm && npmrcFilePath ? osCommand.copy(pathJoin(options.inputDir, path.relative(this.projectRoot, npmrcFilePath)), pathJoin(options.outputDir, '.npmrc')) : '', // Copy .npmrc for pnpm to inherit registry authentication
+        npmrcInProjectRoot ? osCommand.copy(pathJoin(options.inputDir, relativeNpmrcPath!), pathJoin(options.outputDir, '.npmrc')) : '', // Copy .npmrc for pnpm to inherit registry authentication
         osCommand.writeJson(pathJoin(options.outputDir, 'package.json'), { dependencies }),
         osCommand.copy(lockFilePath, pathJoin(options.outputDir, this.packageManager.lockFile)),
         osCommand.changeDirectory(options.outputDir),

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/.testnpmrc
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/.testnpmrc
@@ -1,0 +1,1 @@
+@myorg:registry=https://registry.example.com/

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/bundling.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/bundling.test.ts
@@ -635,9 +635,21 @@ test('pnpm with nodeModules writes .npmrc using base64 for private registry auth
   });
 });
 
-test('pnpm with nodeModules writes .npmrc using base64 for private registry authentication on win32', () => {
+test('Local bundling pnpm with .npmrc uses PowerShell base64 on win32', () => {
+  // Simulate Windows environment
   const osPlatformMock = jest.spyOn(os, 'platform').mockReturnValue('win32');
-  const pnpmLock = 'C:\\project\\pnpm-lock.yaml';
+
+  // Mock spawnSync to capture the command that tryBundle() executes
+  const spawnSyncMock = jest.spyOn(child_process, 'spawnSync').mockReturnValue({
+    status: 0,
+    stderr: Buffer.from('stderr'),
+    stdout: Buffer.from('stdout'),
+    pid: 123,
+    output: ['stdout', 'stderr'],
+    signal: null,
+  });
+
+  const pnpmLock = path.join(__dirname, '..', 'pnpm-lock.yaml');
   const npmrcFixture = path.join(__dirname, '.testnpmrc');
   const npmrcBase64 = Buffer.from(fs.readFileSync(npmrcFixture, 'utf-8')).toString('base64');
 
@@ -645,12 +657,44 @@ test('pnpm with nodeModules writes .npmrc using base64 for private registry auth
   jest.spyOn(util, 'findUp').mockImplementation((name, dir) =>
     name === '.npmrc' ? npmrcFixture : originalFindUp(name, dir),
   );
-  jest.spyOn(path, 'basename').mockReturnValueOnce('pnpm-lock.yaml');
-  jest.spyOn(path, 'relative').mockReturnValueOnce('test\\bundling.test.ts').mockReturnValueOnce('pnpm-lock.yaml');
+
+  const bundler = new Bundling(stack, {
+    entry: __filename,
+    projectRoot: path.dirname(pnpmLock),
+    depsLockFilePath: pnpmLock,
+    runtime: STANDARD_RUNTIME,
+    architecture: Architecture.X86_64,
+    nodeModules: ['delay'],
+  });
+
+  // Call tryBundle() directly to test local bundling.
+  // Local bundling uses os.platform() to determine the shell (cmd on win32, bash on Linux).
+  // This is different from Docker bundling (forceDockerBundling: true) which always uses bash.
+  bundler.local?.tryBundle('/outdir', { image: STANDARD_RUNTIME.bundlingImage });
+
+  // Verify the command uses PowerShell to decode base64 on Windows
+  expect(spawnSyncMock).toHaveBeenCalledWith(
+    'cmd',
+    ['/c', expect.stringContaining(`[System.Convert]::FromBase64String('${npmrcBase64}')`)],
+    expect.anything(),
+  );
+
+  osPlatformMock.mockRestore();
+  spawnSyncMock.mockRestore();
+});
+
+test('pnpm with nodeModules does not write .npmrc when none exists', () => {
+  const pnpmLock = '/project/pnpm-lock.yaml';
+
+  // Mock findUp to return undefined for .npmrc (simulating no .npmrc file found)
+  const originalFindUp = util.findUp;
+  jest.spyOn(util, 'findUp').mockImplementation((name, dir) =>
+    name === '.npmrc' ? undefined : originalFindUp(name, dir),
+  );
 
   Bundling.bundle(stack, {
     entry: __filename,
-    projectRoot: 'C:\\project',
+    projectRoot,
     depsLockFilePath: pnpmLock,
     runtime: STANDARD_RUNTIME,
     architecture: Architecture.X86_64,
@@ -658,16 +702,14 @@ test('pnpm with nodeModules writes .npmrc using base64 for private registry auth
     forceDockerBundling: true,
   });
 
-  expect(Code.fromAsset).toHaveBeenCalledWith(expect.any(String), {
-    assetHashType: AssetHashType.OUTPUT,
-    bundling: expect.objectContaining({
-      command: expect.arrayContaining([
-        expect.stringContaining(`echo '${npmrcBase64}' | base64 -d`),
-      ]),
-    }),
-  });
+  // Verify the bundling command was generated
+  expect(Code.fromAsset).toHaveBeenCalledWith(path.dirname(pnpmLock), expect.anything());
 
-  osPlatformMock.mockRestore();
+  // Extract the command and verify it does NOT contain base64 decoding for .npmrc
+  const call = (Code.fromAsset as jest.Mock).mock.calls[0];
+  const bundlingCommand = call[1].bundling.command[2]; // The shell command string
+  expect(bundlingCommand).not.toContain('base64 -d');
+  expect(bundlingCommand).not.toContain('.npmrc');
 });
 
 test('Detects bun.lockb', () => {


### PR DESCRIPTION
### Issue # 36567

Closes #36567

### Reason for this change

When using nodeModules with pnpm, CDK creates a `pnpm-workspace.yaml` in the bundling directory (added in #21911). This causes pnpm to treat the bundling directory as a standalone workspace root, which prevents it from inheriting .npmrc configuration from parent directories. This breaks authentication for packages from private registries.

### Description of changes

When pnpm is detected and `nodeModules` is specified, copy the project's `.npmrc` (if it exists) to the bundling directory alongside `pnpm-workspace.yaml`. This allows pnpm to find auth tokens for private registries.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

- Added unit test 'pnpm with nodeModules copies .npmrc for private registry authentication'
- All existing tests pass (120/120)

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
