### PR TITLE
fix(apigatewayv2): imported HttpApi validation fails without apiEndpoint

### DIFF
--- a/packages/aws-cdk-lib/aws-apigatewayv2/lib/http/api.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/lib/http/api.ts
@@ -568,7 +568,7 @@ export class HttpApi extends HttpApiBase {
 
 export function toIHttpApi(x: IHttpApiRef): IHttpApi {
   const ret = x as IHttpApi;
-  if (!!ret.addVpcLink && !!ret.apiEndpoint && !!ret.apiId && !!ret.arnForExecuteApi && !!ret.metricClientError) {
+  if (!!ret.addVpcLink && 'apiEndpoint' in ret && !!ret.apiId && !!ret.arnForExecuteApi && !!ret.metricClientError) {
     return ret;
   }
   throw new UnscopedValidationError(`Input HttpApi ${x.constructor.name} does not implement IHttpApi`);

--- a/packages/aws-cdk-lib/aws-apigatewayv2/test/http/api.test.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/test/http/api.test.ts
@@ -40,6 +40,15 @@ describe('HttpApi', () => {
     expect(imported.apiEndpoint).toEqual('api-endpoint');
   });
 
+  test('import without apiEndpoint', () => {
+    // Verifies that an HttpApi can be imported with only httpApiId and that accessing apiEndpoint correctly throws a descriptive error, but the import itself succeeds.
+    const stack = new Stack();
+    const imported = HttpApi.fromHttpApiAttributes(stack, 'imported', { httpApiId: 'http-1234' });
+
+    expect(imported.apiId).toEqual('http-1234');
+    expect(() => imported.apiEndpoint).toThrow('apiEndpoint is not configured on the imported HttpApi.');
+  });
+
   test('unsetting createDefaultStage', () => {
     const stack = new Stack();
     const api = new HttpApi(stack, 'api', {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36621.

### Reason for this change

When importing an `HttpApi` using `fromHttpApiAttributes` without providing an `apiEndpoint`, the validation logic in `toIHttpApi` incorrectly accessed `apiEndpoint` directly. This access triggered the property getter, which is designed to throw an error if `apiEndpoint` is unconfigured. This caused the import to crash even though `apiEndpoint` is technically optional for many operations (like creating routes).

### Description of changes

I updated the validation logic in `packages/aws-cdk-lib/aws-apigatewayv2/lib/http/api.ts`.
Instead of checking `!!ret.apiEndpoint`, which invokes the getter, I changed it to check `'apiEndpoint' in ret`. This successfully verifies that the object conforms to the interface structure (i.e., it has the property key) without evaluating the value and triggering the error.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

I added a new unit test case `'import without apiEndpoint'` to `packages/aws-cdk-lib/aws-apigatewayv2/test/http/api.test.ts`. This test:
1. Imports an `HttpApi` providing only the `httpApiId`.
2. Verifies the import succeeds (no crash on validation).
3. Verifies that accessing `.apiEndpoint` on the imported object still correctly throws the expected "not configured" error.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license### Issue # (if applicable)
