### PR TITLE
feat(batch): add tag support to ManagedEc2EcsComputeEnvironment

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-batch/test/integ.compute-environment-tags.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-batch/test/integ.compute-environment-tags.ts
@@ -1,0 +1,22 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { App, Stack } from 'aws-cdk-lib';
+import * as integ from '@aws-cdk/integ-tests-alpha';
+import { ManagedEc2EcsComputeEnvironment } from 'aws-cdk-lib/aws-batch';
+
+const app = new App();
+const stack = new Stack(app, 'batch-compute-environment-tags-stack');
+const vpc = new ec2.Vpc(stack, 'vpc', { restrictDefaultSecurityGroup: false });
+
+new ManagedEc2EcsComputeEnvironment(stack, 'TaggedComputeEnv', {
+  vpc,
+  tags: {
+    Environment: 'test',
+    Application: 'myapp',
+  },
+});
+
+new integ.IntegTest(app, 'BatchComputeEnvironmentTagsTest', {
+  testCases: [stack],
+});
+
+app.synth();

--- a/packages/aws-cdk-lib/aws-batch/README.md
+++ b/packages/aws-cdk-lib/aws-batch/README.md
@@ -241,7 +241,7 @@ const tagCE = new batch.ManagedEc2EcsComputeEnvironment(this, 'CEThatMakesTagged
 Tags.of(tagCE).add('super', 'salamander');
 ```
 
-You can also tag the ComputeEnvironment resource directly:
+Tags can be applied directly to the underlying ComputeEnvironment resource.:
 
 ```ts
 declare const vpc: ec2.IVpc;

--- a/packages/aws-cdk-lib/aws-batch/README.md
+++ b/packages/aws-cdk-lib/aws-batch/README.md
@@ -241,6 +241,20 @@ const tagCE = new batch.ManagedEc2EcsComputeEnvironment(this, 'CEThatMakesTagged
 Tags.of(tagCE).add('super', 'salamander');
 ```
 
+You can also tag the ComputeEnvironment resource directly:
+
+```ts
+declare const vpc: ec2.IVpc;
+
+new batch.ManagedEc2EcsComputeEnvironment(this, 'myTaggedComputeEnv', {
+  vpc,
+  tags: {
+    Environment: 'production',
+    Application: 'my-app',
+  },
+});
+```
+
 Unmanaged `ComputeEnvironment`s do not support `maxvCpus` or `minvCpus` because you must provision and manage the instances yourself;
 that is, Batch will not scale them up and down as needed.
 

--- a/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
@@ -624,6 +624,13 @@ export interface ManagedEc2EcsComputeEnvironmentProps extends ManagedComputeEnvi
    * @default - no placement group
    */
   readonly placementGroup?: ec2.IPlacementGroupRef;
+
+  /**
+   * Key-value pairs to associate with the compute environment.
+   *
+   * @default - no tags
+   */
+  readonly tags?: { [key: string]: string };
 }
 
 /**
@@ -731,6 +738,7 @@ export class ManagedEc2EcsComputeEnvironment extends ManagedComputeEnvironmentBa
     const resource = new CfnComputeEnvironment(this, 'Resource', {
       ...baseManagedResourceProperties(this, subnetIds),
       computeEnvironmentName: props.computeEnvironmentName,
+      tags: props.tags as any,
       computeResources: {
         ...baseManagedResourceProperties(this, subnetIds).computeResources as CfnComputeEnvironment.ComputeResourcesProperty,
         minvCpus: this.minvCpus,
@@ -752,7 +760,6 @@ export class ManagedEc2EcsComputeEnvironment extends ManagedComputeEnvironmentBa
           };
         }),
         placementGroup: props.placementGroup?.placementGroupRef.groupName,
-        tags: this.tags.renderedTags as any,
       },
     });
 

--- a/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
+++ b/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
@@ -1126,6 +1126,35 @@ describe('ManagedEc2EksComputeEnvironment', () => {
   });
 });
 
+describe('ManagedEc2EcsComputeEnvironment tags', () => {
+  let stack: Stack;
+  let vpc: ec2.Vpc;
+
+  beforeEach(() => {
+    stack = new Stack();
+    vpc = new ec2.Vpc(stack, 'vpc');
+  });
+
+  test('tags are rendered in CloudFormation', () => {
+    // WHEN
+    new ManagedEc2EcsComputeEnvironment(stack, 'MyCE', {
+      vpc,
+      tags: {
+        Environment: 'test',
+        Application: 'myapp',
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+      Tags: {
+        Environment: 'test',
+        Application: 'myapp',
+      },
+    });
+  });
+});
+
 describe('FargateComputeEnvironment', () => {
   beforeEach(() => {
     stack = new Stack();


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36615.

---

### Reason for this change

The `ManagedEc2EcsComputeEnvironment` L2 construct does not currently expose
support for tagging the underlying AWS Batch compute environment, even though
`AWS::Batch::ComputeEnvironment` supports tags in CloudFormation. This prevents
users from applying standard governance, cost allocation, and operational tags
without relying on escape hatches.

---

### Description of changes

This change introduces an optional `tags` property on
`ManagedEc2EcsComputeEnvironmentProps` and passes it directly to the underlying
`AWS::Batch::ComputeEnvironment` CloudFormation resource.

The implementation follows existing CDK L2 conventions by explicitly wiring a
supported CloudFormation property rather than relying on construct-level tag
propagation.

No breaking changes are introduced, and existing behavior remains unchanged
when `tags` is not provided.

---

### Describe any new or updated permissions being added

None.  
This change does not introduce any new or modified IAM permissions.

---

### Description of how you validated changes

A focused unit test was added to assert that user-provided tags are rendered as
top-level `Tags` on the synthesized `AWS::Batch::ComputeEnvironment` resource.
Existing tests continue to pass, and no behavioral changes occur when tags are
not specified.

---

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

