### PR TITLE
fix: update custom resource runtime fallback from nodejs18.x to nodej…

### DIFF
--- a/packages/aws-cdk-lib/core/lib/custom-resource-provider/custom-resource-provider.ts
+++ b/packages/aws-cdk-lib/core/lib/custom-resource-provider/custom-resource-provider.ts
@@ -155,5 +155,5 @@ function customResourceProviderRuntimeToString(x: CustomResourceProviderRuntime)
  * The name of the latest Lambda node runtime available by AWS region.
  */
 export function determineLatestNodeRuntimeName(scope: Construct): string {
-  return Stack.of(scope).regionalFact(FactName.LATEST_NODE_RUNTIME, 'nodejs18.x');
+  return Stack.of(scope).regionalFact(FactName.LATEST_NODE_RUNTIME, 'nodejs22.x');
 }


### PR DESCRIPTION
### Reason for this change

In some special regions, this fallback value was used, creating node18 functions. According to [Lambda runtimes documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), node18 is not supported anymore, which is why this needs updating.

### Description of changes

Updated the fallback value to node22, which matches NODEJS_LATEST and as such should be available in all regions.

### Describe any new or updated permissions being added

No updated or new permissions.

### Description of how you validated changes

Verified that updating the code in my package in my node_modules resolves this issue and now creates node22 functions instead of node18 functions as before.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
