### PR TITLE
Update aws gateway domain name security policy

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/restapi.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/restapi.ts
@@ -196,6 +196,11 @@ export interface RestApiBaseProps {
   readonly endpointExportName?: string;
 
   /**
+   * The Endpoint Access Mode needs to be set when using the enhanced security policies with SecurityPolicy_
+   */
+  readonly endpointAccessMode?: EndpointAccessMode
+
+  /**
    * A list of the endpoint types of the API. Use this property when creating
    * an API.
    *
@@ -1132,6 +1137,11 @@ export enum ApiKeySourceType {
    * To read the API key from the `UsageIdentifierKey` from a custom authorizer.
    */
   AUTHORIZER = 'AUTHORIZER',
+}
+
+export enum EndpointAccessMode {
+  BASIC = 'BASIC',
+  STRICT = 'STRICT',
 }
 
 export enum EndpointType {

--- a/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
@@ -3,7 +3,6 @@ import * as acm from '../../aws-certificatemanager';
 import { Bucket } from '../../aws-s3';
 import { Stack } from '../../core';
 import * as apigw from '../lib';
-import { EndpointAccessMode } from '../lib';
 
 /* eslint-disable @stylistic/quote-props */
 

--- a/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
@@ -1,9 +1,9 @@
-import {Match, Template} from '../../assertions';
+import { Match, Template } from '../../assertions';
 import * as acm from '../../aws-certificatemanager';
-import {Bucket} from '../../aws-s3';
-import {Stack} from '../../core';
+import { Bucket } from '../../aws-s3';
+import { Stack } from '../../core';
 import * as apigw from '../lib';
-import {EndpointAccessMode} from '../lib';
+import { EndpointAccessMode } from '../lib';
 
 /* eslint-disable @stylistic/quote-props */
 
@@ -93,7 +93,7 @@ describe('domains', () => {
       'DomainName': 'old.example.com',
       'EndpointConfiguration': { 'Types': ['REGIONAL'] },
       'RegionalCertificateArn': { 'Ref': 'Cert5C9FAEC1' },
-      'SecurityPolicy': 'SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09',
+      'SecurityPolicy': 'TLS_1_2',
     });
 
     Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::DomainName', {

--- a/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/test/domains.test.ts
@@ -1,8 +1,9 @@
-import { Match, Template } from '../../assertions';
+import {Match, Template} from '../../assertions';
 import * as acm from '../../aws-certificatemanager';
-import { Bucket } from '../../aws-s3';
-import { Stack } from '../../core';
+import {Bucket} from '../../aws-s3';
+import {Stack} from '../../core';
 import * as apigw from '../lib';
+import {EndpointAccessMode} from '../lib';
 
 /* eslint-disable @stylistic/quote-props */
 
@@ -72,13 +73,14 @@ describe('domains', () => {
     new apigw.DomainName(stack, 'my-domain', {
       domainName: 'old.example.com',
       certificate: cert,
-      securityPolicy: apigw.SecurityPolicy.TLS_1_0,
+      securityPolicy: apigw.SecurityPolicy.TLS_1_2,
     });
 
     new apigw.DomainName(stack, 'your-domain', {
       domainName: 'new.example.com',
       certificate: cert,
-      securityPolicy: apigw.SecurityPolicy.TLS_1_2,
+      securityPolicy: apigw.SecurityPolicy.SecurityPolicy_TLS13_1_3_2025_09,
+      endpointAccessMode: EndpointAccessMode.STRICT
     });
 
     new apigw.DomainName(stack, 'default-domain', {
@@ -91,14 +93,14 @@ describe('domains', () => {
       'DomainName': 'old.example.com',
       'EndpointConfiguration': { 'Types': ['REGIONAL'] },
       'RegionalCertificateArn': { 'Ref': 'Cert5C9FAEC1' },
-      'SecurityPolicy': 'TLS_1_0',
+      'SecurityPolicy': 'SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09',
     });
 
     Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::DomainName', {
       'DomainName': 'new.example.com',
       'EndpointConfiguration': { 'Types': ['REGIONAL'] },
       'RegionalCertificateArn': { 'Ref': 'Cert5C9FAEC1' },
-      'SecurityPolicy': 'TLS_1_2',
+      'SecurityPolicy': 'SecurityPolicy_TLS13_1_3_2025_09',
     });
 
     Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::DomainName', {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->
The TLS_1_2 security policies are legacy. The policies starting with SecurityPolicy should be preferred this introduces the possibility to do this via CDK.

### Description of changes

- Add the Security Policies to the Enum
- Make the endpointAccessMode configurable as required by the new policies

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
