### PR TITLE
Support for ECS Event Capture in CDK - onEvent function added to cluster.ts

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ecs/test/integ.cluster-onevent.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ecs/test/integ.cluster-onevent.ts
@@ -1,0 +1,51 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as integ from '@aws-cdk/integ-tests-alpha';
+
+const app = new cdk.App({
+  postCliContext: {
+    '@aws-cdk/aws-lambda:useCdkManagedLogGroup': false,
+    '@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy': false,
+  },
+});
+
+const stack = new cdk.Stack(app, 'integ-ecs-cluster-onevent');
+
+// Create a new VPC instead of looking up existing one
+const vpc = new ec2.Vpc(stack, 'TestVpc', {
+  maxAzs: 2,
+  restrictDefaultSecurityGroup: false,
+});
+
+// Create cluster
+const cluster = new ecs.Cluster(stack, 'TestCluster', {
+  vpc,
+  clusterName: 'integ-test-cluster-onevent',
+});
+
+// Create log group with proper naming for event capture
+const logGroup = new logs.LogGroup(stack, 'EventCaptureLogGroup', {
+  logGroupName: `/aws/events/ecs-cluster/${cluster.clusterName}`,
+  retention: logs.RetentionDays.ONE_WEEK,
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
+});
+
+// Enable event capture using onEvent method with log group target
+cluster.onEvent('ClusterStateChangeRule', {
+  target: new targets.CloudWatchLogGroup(logGroup),
+  eventPattern: {
+    source: ['aws.ecs'],
+    detailType: ['ECS Cluster State Change'],
+    detail: {
+      clusterArn: [cluster.clusterArn],
+    },
+  },
+});
+
+// Create integration test - deployment success validates functionality
+new integ.IntegTest(app, 'ClusterOnEventTest', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -14,10 +14,12 @@ import * as autoscaling from '../../aws-autoscaling';
 import * as cloudwatch from '../../aws-cloudwatch';
 import { InstanceRequirementsConfig } from '../../aws-ec2';
 import * as ec2 from '../../aws-ec2';
+import * as events from '../../aws-events';
 import * as iam from '../../aws-iam';
 import { PolicyStatement, ServicePrincipal } from '../../aws-iam';
 import * as kms from '../../aws-kms';
 import { IKey, IKeyRef } from '../../aws-kms';
+import * as lambda from '../../aws-lambda';
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
 import * as cloudmap from '../../aws-servicediscovery';
@@ -36,10 +38,12 @@ import {
   ValidationError,
   Size,
   Lazy,
+  CustomResource,
 } from '../../core';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { mutatingAspectPrio32333 } from '../../core/lib/private/aspect-prio';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import * as cr from '../../custom-resources';
 
 const CLUSTER_SYMBOL = Symbol.for('@aws-cdk/aws-ecs/lib/cluster.Cluster');
 
@@ -784,6 +788,147 @@ export class Cluster extends Resource implements ICluster {
   @MethodMetadata()
   public grantTaskProtection(grantee: iam.IGrantable): iam.Grant {
     return this.grants.taskProtection(grantee);
+  }
+
+  /**
+   * Defines an EventBridge rule that enables ECS EventCapture for this cluster.
+   *
+   * The rule filters events from this cluster including task state changes, service actions, service deployment changes, and container instance state changes.
+   *
+   * **Cluster Usage**:
+   * - New cluster: Use onEvent() directly on a cluster being created in this stack
+   * - Existing cluster: First import using Cluster.fromClusterArn(), then call onEvent()
+   *
+   * **Log Group Usage**:
+   * - New log group: Create in this stack with format /aws/events/ecs/containerinsights/${clusterName}/performance
+   * - Replace ${clusterName} with the name of the cluster you want to create with Event Capture enabled.
+   * - Existing log group: Import using LogGroup.fromLogGroupName() or LogGroup.fromLogGroupArn()
+   *
+   * **EventCapture Requirements**:
+   * - Rule name format: EventsToLogs-{clusterPrefix}-{hash} (auto-generated if not provided)
+   * - Log group format: /aws/events/ecs/containerinsights/${clusterName}/performance
+   * - Both must follow these exact formats to enable ECS Event Capture
+   *
+   * @param id The construct id of the rule (must be unique within the construct scope)
+   * @param options Options for adding the rule
+   */
+  @MethodMetadata()
+  public onEvent(id: string, options: events.OnEventOptions = {}): events.Rule {
+    // Validate required id parameter
+    if (!id || id.trim() === '') {
+      throw new ValidationError('Rule ID cannot be empty', this);
+    }
+    if (!/^[a-zA-Z][a-zA-Z0-9._-]*$/.test(id)) {
+      throw new ValidationError('Rule ID must start with a letter and contain only alphanumeric characters, periods, hyphens, and underscores', this);
+    }
+    if (id.length > 255) {
+      throw new ValidationError('Rule ID cannot exceed 255 characters', this);
+    }
+
+    // Validate optional ruleName parameter
+    if (options.ruleName !== undefined) {
+      if (options.ruleName.trim() === '') {
+        throw new ValidationError('Rule name cannot be empty', this);
+      }
+      if (options.ruleName.length > 64) {
+        throw new ValidationError('Rule name cannot exceed 64 characters', this);
+      }
+      if (!/^[a-zA-Z0-9._-]+$/.test(options.ruleName)) {
+        throw new ValidationError('Rule name can only contain letters, numbers, periods, hyphens, and underscores', this);
+      }
+      if (options.ruleName.startsWith('aws-')) {
+        throw new ValidationError('Rule name cannot start with "aws-" (reserved prefix)', this);
+      }
+    }
+
+    // Validate other onEvent options
+    if (options.description && options.description.length > 512) {
+      throw new ValidationError('Rule description cannot exceed 512 characters', this);
+    }
+
+    // Generate rule name if not provided
+    const ruleOptions = { ...options };
+    if (!ruleOptions.ruleName) {
+      // Create Custom Resource to generate rule name at deployment time with actual values
+      const ruleNameGenerator = new lambda.Function(this, `${id}RuleNameGenerator`, {
+        runtime: lambda.Runtime.NODEJS_18_X,
+        handler: 'index.handler',
+        code: lambda.Code.fromInline(`
+          const crypto = require('crypto');
+          
+          exports.handler = async (event) => {
+            console.log('Event:', JSON.stringify(event, null, 2));
+            
+            if (event.RequestType === 'Delete') {
+              return { PhysicalResourceId: event.PhysicalResourceId };
+            }
+            
+            const clusterArn = event.ResourceProperties.ClusterArn;
+            const clusterName = event.ResourceProperties.ClusterName;
+            
+            // Calculate hash from actual resolved ARN
+            const quotedArn = '"' + clusterArn + '"';
+            const hash = crypto.createHash('sha256').update(quotedArn, 'utf8').digest();
+            const base58Hash = base58Encode(hash);
+            
+            const clusterPrefix = clusterName.substring(0, 6);
+            const ruleName = 'EventsToLogs-' + clusterPrefix + '-' + base58Hash;
+            
+            console.log('Generated rule name:', ruleName);
+            
+            return {
+              PhysicalResourceId: ruleName,
+              Data: { RuleName: ruleName }
+            };
+          };
+          
+          // Converts a buffer to Base58 encoding using Bitcoin's alphabet (excludes confusing characters: 0, O, I, l)
+          function base58Encode(buffer) {
+            const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+            let num = BigInt('0x' + buffer.toString('hex'));
+            let encoded = '';
+            while (num > BigInt(0)) {
+              encoded = alphabet[Number(num % BigInt(58))] + encoded;
+              num = num / BigInt(58);
+            }
+            for (let i = 0; i < buffer.length && buffer[i] === 0; i++) {
+              encoded = '1' + encoded;
+            }
+            return encoded || '1';
+          }
+        `),
+      });
+
+      // Creates a Custom Resource Provider that will execute the ruleNameGenerator function when CloudFormation lifecycle events occur (CREATE, UPDATE, DELETE)
+      const ruleNameProvider = new cr.Provider(this, `${id}RuleNameProvider`, {
+        onEventHandler: ruleNameGenerator,
+      });
+
+      // Creates the actual Custom Resource instance, linking it to the provider above. It passes the cluster ARN and name as properties that the ruleNameGenerator function can access.
+      const ruleNameResource = new CustomResource(this, `${id}RuleNameResource`, {
+        serviceToken: ruleNameProvider.serviceToken,
+        properties: {
+          ClusterArn: this.clusterArn,
+          ClusterName: this.clusterName,
+        },
+      });
+
+      // Sets the rule name by retrieving the 'RuleName' attribute returned by the custom resource (generated by the ruleNameGenerator function)
+      ruleOptions.ruleName = ruleNameResource.getAttString('RuleName');
+    }
+
+    // Creates an EventBridge rule using the options (including the dynamically generated rule name)
+    const rule = new events.Rule(this, id, ruleOptions);
+    rule.addEventPattern({
+      source: ['aws.ecs'],
+      detail: {
+        clusterArn: [this.clusterArn],
+      },
+    });
+    if (options.target) {
+      rule.addTarget(options.target);
+    }
+    return rule;
   }
 
   private configureWindowsAutoScalingGroup(autoScalingGroup: autoscaling.AutoScalingGroup, options: AddAutoScalingGroupCapacityOptions = {}) {

--- a/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
@@ -3,6 +3,8 @@ import { testDeprecated } from '@aws-cdk/cdk-build-tools';
 import { Match, Template } from '../../assertions';
 import * as autoscaling from '../../aws-autoscaling';
 import * as ec2 from '../../aws-ec2';
+import * as events from '../../aws-events';
+import * as targets from '../../aws-events-targets';
 import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
 import * as logs from '../../aws-logs';
@@ -4858,4 +4860,103 @@ test('throws when InstanceWarmupPeriod is greater than 10000', () => {
 
     cluster.addAsgCapacityProvider(capacityProviderAl2);
   }).toThrow(/InstanceWarmupPeriod must be between 0 and 10000 inclusive, got: 99999./);
+});
+
+describe('Cluster onEvent method', () => {
+  test('creates EventBridge rule with default options', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
+
+    // WHEN
+    cluster.onEvent('TestRule');
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+      EventPattern: {
+        source: ['aws.ecs'],
+        detail: {
+          clusterArn: [Match.anyValue()],
+        },
+      },
+      State: 'ENABLED',
+    });
+  });
+
+  test('creates EventBridge rule with custom event pattern', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
+
+    // WHEN
+    cluster.onEvent('TestRule', {
+      eventPattern: {
+        'source': ['aws.ecs'],
+        'detail-type': ['ECS Cluster State Change'],
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+      EventPattern: {
+        'source': ['aws.ecs'],
+        'detail-type': ['ECS Cluster State Change'],
+        'detail': {
+          clusterArn: [Match.anyValue()],
+        },
+      },
+      State: 'ENABLED',
+    });
+  });
+
+  test('creates EventBridge rule with target', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
+    const logGroup = new logs.LogGroup(stack, 'LogGroup');
+
+    // WHEN
+    cluster.onEvent('TestRule', {
+      target: new targets.CloudWatchLogGroup(logGroup),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+      EventPattern: {
+        source: ['aws.ecs'],
+        detail: {
+          clusterArn: [Match.anyValue()],
+        },
+      },
+      State: 'ENABLED',
+      Targets: [
+        {
+          Arn: Match.anyValue(),
+          Id: Match.anyValue(),
+        },
+      ],
+    });
+  });
+
+  test('creates Custom Resource when enableRuleNameGeneration is true', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const vpc = new ec2.Vpc(stack, 'Vpc');
+    const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
+
+    // WHEN
+    cluster.onEvent('TestRule', {
+      enableRuleNameGeneration: true,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::CloudFormation::CustomResource', {
+      ServiceToken: Match.anyValue(),
+      ClusterArn: Match.anyValue(),
+      ClusterName: Match.anyValue(),
+    });
+  });
 });


### PR DESCRIPTION
### Support for ECS Event Capture in CDK - onEvent function added to cluster.ts

https://github.com/aws/aws-cdk/issues/36646
https://quip-amazon.com/Q3flAQJQAwLY/Event-Capture-L3-Construct-Low-Level-Design-Document

### Reason for this change

In October, our team (ecs-developer-platforms) received a request to support ECS Event Capture in CDK. The support for this feature will be implemented by adding an onEvent function to cluster.ts that customers can use to enable ECS Event Capture.

### Description of changes

The goal is to offer a simple way in which customers can enable ECS Event Capture in CDK. The onEvent function configures an Event Bridge rule that targets a log group that has been created by the customer. If the log group and the Event Bridge rule both follow the expected naming formats, ECS Event Capture will be enabled. 

### Description of how you validated changes

Unit Tests
- All ECS unit tests
- onEvent-specific unit tests

Code Quality Validations
- JSII validation
- ESLint validation
- TypeScript compilation

Integration Tests
- integ.cluster-enhanced-container-insights.js
- integ.cluster-grant-task-protection.js
- integ.cluster-amazonlinux2-neuron-ami.js
- integ.cluster.amazonlinux2023-ami.js
- integ.cluster-windows-server-ami.js
- integ.cluster-imported.js
- integ.cluster-bottlerocket-nvidia-ami.js
- integ.cluster-encrypt-ephemeral-storage.js
- integ.cluster-encrypt-storage.js
- integ.default-capacity-provider.js
- integ.fargate-with-efs.js
- integ.aws-custom-resource.js
- integ.sqs.js
- integ.event-ec2-task.js
- integ.core-custom-resources.js
- integ.cluster-onevent.js (my custom test)
