### PR TITLE
feat(synthetics): add syn-nodejs-3.0 runtime

### DIFF
--- a/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
+++ b/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
@@ -361,6 +361,17 @@ export class Runtime {
   public static readonly SYNTHETICS_NODEJS_PLAYWRIGHT_3_0 = new Runtime('syn-nodejs-playwright-3.0', RuntimeFamily.NODEJS);
 
   /**
+   * `syn-nodejs-3.0` includes the following:
+   * - Lambda runtime Node.js 20.x
+   *
+   * New Features:
+   * - **Multi-checks blueprint**: Supports the multi-checks blueprint for creating complex synthetic monitoring scenarios.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_Nodejs.html
+   */
+  public static readonly SYNTHETICS_NODEJS_3_0 = new Runtime('syn-nodejs-3.0', RuntimeFamily.NODEJS);
+
+  /**
    * `syn-python-selenium-1.0` includes the following:
    * - Lambda runtime Python 3.8
    * - Selenium version 3.141.0


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36648.

### Reason for this change

The Runtime class was missing the `syn-nodejs-3.0` runtime constant, forcing developers to manually instantiate it with `new Runtime('syn-nodejs-3.0', RuntimeFamily.NODEJS)` instead of using the standard static constant pattern.

### Description of changes

Added the `SYNTHETICS_NODEJS_3_0` static constant to the Runtime class following the existing pattern for runtime definitions. The constant includes:
- Lambda runtime Node.js 20.x
- Multi-checks blueprint support
- Proper JSDoc documentation with AWS documentation reference

### Describe any new or updated permissions being added

No new permissions required.

### Description of how you validated changes

**Environment:** macOS (arm64)  
**Runtime:** Node.js v24.11.1

Verified the change follows the established pattern by comparing against adjacent runtime definitions. The implementation matches the exact format used for other runtime constants including:
- Naming convention (SCREAMING_SNAKE_CASE)
- JSDoc structure and content
- Runtime family assignment
- Placement in the file

AWS documentation for syn-nodejs-3.0 verified at https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_Nodejs.html

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*