### PR TITLE
fix (bedrock): Adding Canada regions to cross-region inference profiles

### DIFF
--- a/packages/@aws-cdk/aws-bedrock-alpha/bedrock/inference-profiles/cross-region-inference-profile.ts
+++ b/packages/@aws-cdk/aws-bedrock-alpha/bedrock/inference-profiles/cross-region-inference-profile.ts
@@ -84,6 +84,13 @@ export enum CrossRegionInferenceProfileRegion {
    * - Melbourne (`ap-southeast-4`)
    */
   AU = 'au',
+  /**
+   * Cross-region Inference Identifier for the Canada area.
+   * According to the model chosen, this might include:
+   * - Canada Central (`ca-central-1`)
+   * - Calgary (`ca-west-1)
+   */
+  CA = 'ca',
 }
 
 /**
@@ -107,6 +114,10 @@ export const REGION_TO_GEO_AREA: { [key: string]: CrossRegionInferenceProfileReg
   'ap-south-1': CrossRegionInferenceProfileRegion.APAC, // Mumbai
   'ap-southeast-1': CrossRegionInferenceProfileRegion.APAC, // Singapore
   'ap-southeast-2': CrossRegionInferenceProfileRegion.APAC, // Sydney
+
+  // Canada Regions
+  'ca-central-1': CrossRegionInferenceProfileRegion.CA, // Canada Central
+  'ca-west-1': CrossRegionInferenceProfileRegion.CA, // Calgary
 };
 
 /******************************************************************************


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Adding support for Canadian Cross-Region Inference Profiles, to support Nova Lite models.

### Description of changes

Minor change to add to cross-region-inference-profile list to match documentation -https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

### Describe any new or updated permissions being added

None


### Description of how you validated changes

No additional tests added.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
