### PR TITLE
fix(ecs): make securityGroups required in ManagedInstancesCapacityProvider

### DIFF
--- a/allowed-breaking-changes.txt
+++ b/allowed-breaking-changes.txt
@@ -4128,3 +4128,7 @@ removed:aws-cdk-lib.aws_apigatewayv2.IWebSocketStage.stageRef
 
 # This type must needs be weakened
 changed-type:aws-cdk-lib.aws_ses.EventDestination.bus
+
+# CloudFormation has always required SecurityGroups for ManagedInstancesCapacityProvider.
+# Making it required in TypeScript catches the error at compile time instead of deploy time.
+strengthened:aws-cdk-lib.aws_ecs.ManagedInstancesCapacityProviderProps

--- a/packages/aws-cdk-lib/aws-ecs/README.md
+++ b/packages/aws-cdk-lib/aws-ecs/README.md
@@ -1689,8 +1689,14 @@ declare const vpc: ec2.Vpc;
 
 const cluster = new ecs.Cluster(this, 'Cluster', { vpc });
 
+const securityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', {
+  vpc,
+  description: 'Security group for managed instances',
+});
+
 const miCapacityProvider = new ecs.ManagedInstancesCapacityProvider(this, 'MICapacityProvider', {
   subnets: vpc.privateSubnets,
+  securityGroups: [securityGroup],
   instanceRequirements: {
     vCpuCountMin: 1,
     memoryMin: Size.gibibytes(2),
@@ -1763,10 +1769,16 @@ customInfrastructureRole.addToPolicy(new iam.PolicyStatement({
   },
 }));
 
+const securityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', {
+  vpc,
+  description: 'Security group for managed instances',
+});
+
 const miCapacityProviderCustom = new ecs.ManagedInstancesCapacityProvider(this, 'MICapacityProviderCustomRoles', {
   infrastructureRole: customInfrastructureRole,
   ec2InstanceProfile: customInstanceProfile,
   subnets: vpc.privateSubnets,
+  securityGroups: [securityGroup],
 });
 
 // Add the capacity provider to the cluster
@@ -1804,8 +1816,14 @@ You can specify detailed instance requirements to control which types of instanc
 ```ts
 declare const vpc: ec2.Vpc;
 
+const securityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', {
+  vpc,
+  description: 'Security group for managed instances',
+});
+
 const miCapacityProvider = new ecs.ManagedInstancesCapacityProvider(this, 'MICapacityProvider', {
   subnets: vpc.privateSubnets,
+  securityGroups: [securityGroup],
   instanceRequirements: {
     // Required: CPU and memory constraints
     vCpuCountMin: 2,

--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -1647,6 +1647,10 @@ export class ManagedInstancesCapacityProvider extends Construct implements ec2.I
       throw new ValidationError('Subnets are required and should be non-empty.', this);
     }
 
+    if (props.securityGroups.length === 0) {
+      throw new ValidationError('Security groups cannot be an empty array. Provide at least one security group.', this);
+    }
+
     // Create or use provided infrastructure role
     const roleId = `${id}Role`;
     this.infrastructureRole = props.infrastructureRole ?? new iam.Role(this, roleId, {

--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -1546,11 +1546,8 @@ export interface ManagedInstancesCapacityProviderProps {
   /**
    * The security groups to associate with the launched EC2 instances.
    * These security groups control the network traffic allowed to and from the instances.
-   * If not specified, the default security group of the VPC containing the subnets will be used.
-   *
-   * @default - default security group of the VPC
    */
-  readonly securityGroups?: ec2.ISecurityGroup[];
+  readonly securityGroups: ec2.ISecurityGroup[];
 
   /**
    * The size of the task volume storage attached to each instance.

--- a/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
@@ -2620,10 +2620,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       // THEN
@@ -2678,11 +2684,17 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         capacityProviderName: 'my-managed-instances-cp',
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       // THEN
@@ -2805,10 +2817,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         taskVolumeStorage: cdk.Size.gibibytes(100),
       });
 
@@ -2867,10 +2885,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         monitoring: ecs.InstanceMonitoring.DETAILED,
       });
 
@@ -2927,10 +2951,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       // THEN
@@ -2985,10 +3015,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         instanceRequirements: {
           vCpuCountMin: 2,
           vCpuCountMax: 8,
@@ -3061,10 +3097,16 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         propagateTags: ecs.PropagateManagedInstancesTags.CAPACITY_PROVIDER,
       });
 
@@ -3100,6 +3142,7 @@ describe('cluster', () => {
       // GIVEN
       const app = new cdk.App();
       const stack = new cdk.Stack(app, 'test');
+      const vpc = new ec2.Vpc(stack, 'Vpc');
 
       const infrastructureRole = new iam.Role(stack, 'InfrastructureRole', {
         assumedBy: new iam.ServicePrincipal('ecs.amazonaws.com'),
@@ -3119,12 +3162,18 @@ describe('cluster', () => {
         role: instanceRole,
       });
 
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
+
       // THEN
       expect(() => {
         new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: [],
+          securityGroups: [securityGroup],
         });
       }).toThrow('Subnets are required and should be non-empty.');
     });
@@ -3154,11 +3203,17 @@ describe('cluster', () => {
       });
 
       // THEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       expect(() => {
         new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: vpc.privateSubnets,
+          securityGroups: [securityGroup],
           instanceRequirements: {
             vCpuCountMin: 2,
             memoryMin: cdk.Size.gibibytes(4),
@@ -3194,11 +3249,17 @@ describe('cluster', () => {
       });
 
       // THEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       expect(() => {
         new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: vpc.privateSubnets,
+          securityGroups: [securityGroup],
           instanceRequirements: {
             vCpuCountMin: 2,
             memoryMin: cdk.Size.gibibytes(4),
@@ -3233,6 +3294,11 @@ describe('cluster', () => {
         role: instanceRole,
       });
 
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
+
       // THEN
       expect(() => {
         new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
@@ -3240,6 +3306,7 @@ describe('cluster', () => {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: vpc.privateSubnets,
+          securityGroups: [securityGroup],
         });
       }).toThrow(/Invalid Capacity Provider Name: awscp, If a name is specified, it cannot start with aws, ecs, or fargate./);
 
@@ -3249,6 +3316,7 @@ describe('cluster', () => {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: vpc.privateSubnets,
+          securityGroups: [securityGroup],
         });
       }).toThrow(/Invalid Capacity Provider Name: ecscp, If a name is specified, it cannot start with aws, ecs, or fargate./);
 
@@ -3258,6 +3326,7 @@ describe('cluster', () => {
           infrastructureRole,
           ec2InstanceProfile: instanceProfile,
           subnets: vpc.privateSubnets,
+          securityGroups: [securityGroup],
         });
       }).toThrow(/Invalid Capacity Provider Name: fargatecp, If a name is specified, it cannot start with aws, ecs, or fargate./);
     });
@@ -3323,8 +3392,14 @@ describe('cluster', () => {
       const cluster = new ecs.Cluster(stack, 'EcsCluster');
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3507,9 +3582,15 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       // THEN
@@ -3538,8 +3619,14 @@ describe('cluster', () => {
       const cluster = new ecs.Cluster(stack, 'EcsCluster');
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3592,9 +3679,15 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole: customInfrastructureRole,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3623,8 +3716,14 @@ describe('cluster', () => {
       const cluster = new ecs.Cluster(stack, 'EcsCluster');
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3644,8 +3743,14 @@ describe('cluster', () => {
       const cluster = new ecs.Cluster(stack, 'EcsCluster');
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3688,9 +3793,15 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.enableFargateCapacityProviders();
@@ -3745,9 +3856,15 @@ describe('cluster', () => {
       });
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       const capacityProvider = new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
       });
 
       cluster.addManagedInstancesCapacityProvider(capacityProvider);
@@ -3786,10 +3903,16 @@ describe('cluster', () => {
       };
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         instanceRequirements: config,
       });
 
@@ -3864,10 +3987,16 @@ describe('cluster', () => {
       };
 
       // WHEN
+
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
       new ecs.ManagedInstancesCapacityProvider(stack, 'provider', {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         instanceRequirements: config,
       });
 
@@ -3936,6 +4065,11 @@ describe('cluster', () => {
         role: instanceRole,
       });
 
+      const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description: 'Test security group',
+      });
+
       const config: ec2.InstanceRequirementsConfig = {
         acceleratorCountMin: 1,
         acceleratorCountMax: 4,
@@ -3975,6 +4109,7 @@ describe('cluster', () => {
         infrastructureRole,
         ec2InstanceProfile: instanceProfile,
         subnets: vpc.privateSubnets,
+        securityGroups: [securityGroup],
         instanceRequirements: config,
       });
 


### PR DESCRIPTION
### Issue # (if applicable)

### Reason for this change

The `ManagedInstancesCapacityProvider` L2 construct has `securityGroups` as optional, but CloudFormation requires it. This causes deployment failures when users don't provide security groups with the error:

```
Resource handler returned message: "Model validation failed (#/ManagedInstancesProvider/InstanceLaunchTemplate/NetworkConfiguration: required key [SecurityGroups] not found)"
```

### Description of changes

- Made `securityGroups` required in `ManagedInstancesCapacityProviderProps` interface (removed the `?` optional marker)
- Removed misleading JSDoc comment that claimed it would default to the VPC's default security group (no such default behavior existed in the code)
- Updated all unit tests to provide `securityGroups` parameter

The CloudFormation schema for `AWS::ECS::CapacityProvider` requires `SecurityGroups` in `ManagedInstancesNetworkConfiguration`. The CDK implementation used conditional spreading that simply omitted the field when not provided, causing CloudFormation validation errors at deployment time.

### Describe any new or updated permissions being added

No new or updated IAM permissions are needed.

### Description of how you validated changes

- All 136 unit tests in `cluster.test.ts` pass
- All 3 integration tests already had `securityGroups` specified and continue to work
- TypeScript compilation now correctly fails when `securityGroups` is not provided

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

BREAKING CHANGE: `securityGroups` is now required in `ManagedInstancesCapacityProviderProps`. CloudFormation has always required this field, so any code that omitted it would have failed at deployment time with a validation error. This change catches the error at compile time instead, improving the developer experience. If your code previously omitted `securityGroups`, you must now explicitly provide at least one security group.
