### PR TITLE
fix(apigatewayv2): use custom domain name instead of regional domain name when importing domain name via fromDomainNameAttributes

### DIFF
--- a/packages/aws-cdk-lib/aws-apigatewayv2/lib/common/domain-name.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/lib/common/domain-name.ts
@@ -180,12 +180,12 @@ export class DomainName extends Resource implements IDomainName {
       public readonly regionalHostedZoneId = attrs.regionalHostedZoneId;
       public readonly name = attrs.name;
       public readonly domainNameRef: DomainNameReference = {
-        domainName: attrs.regionalDomainName,
+        domainName: attrs.name,
         domainNameArn: Stack.of(this).formatArn({
           service: 'apigateway',
           arnFormat: ArnFormat.SLASH_RESOURCE_SLASH_RESOURCE_NAME,
           resource: 'domainnames',
-          resourceName: attrs.regionalDomainName,
+          resourceName: attrs.name,
         }),
       };
     }


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-cdk/issues/36708

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
