### PR TITLE
fix(eks): security group specified by the implementer is correctly applied to the Lambda Handler

### DIFF
--- a/packages/@aws-cdk/aws-eks-v2-alpha/lib/cluster.ts
+++ b/packages/@aws-cdk/aws-eks-v2-alpha/lib/cluster.ts
@@ -1291,6 +1291,7 @@ export class Cluster extends ClusterBase {
         environment: this._kubectlProviderOptions?.environment,
         memory: this._kubectlProviderOptions?.memory,
         privateSubnets: kubectlSubnets,
+        securityGroup: this._kubectlProviderOptions?.securityGroup,
       });
 
       // give the handler role admin access to the cluster

--- a/packages/@aws-cdk/aws-eks-v2-alpha/lib/kubectl-provider.ts
+++ b/packages/@aws-cdk/aws-eks-v2-alpha/lib/kubectl-provider.ts
@@ -36,8 +36,8 @@ export interface KubectlProviderOptions {
   /**
    * A security group to use for `kubectl` execution.
    *
-   * @default - If not specified, the k8s endpoint is expected to be accessible
-   * publicly.
+   * @default - The cluster security group is used if `privateSubnets` are specified.
+   * Otherwise, no security group is assigned.
    */
   readonly securityGroup?: ec2.ISecurityGroup;
 
@@ -152,7 +152,9 @@ export class KubectlProvider extends Construct implements IKubectlProvider {
 
     const vpc = props.privateSubnets ? props.cluster.vpc : undefined;
     let securityGroups;
-    if (props.privateSubnets && props.cluster.clusterSecurityGroup) {
+    if (props.privateSubnets && props.securityGroup) {
+      securityGroups = [props.securityGroup];
+    } else if (props.privateSubnets && props.cluster.clusterSecurityGroup) {
       securityGroups = [props.cluster.clusterSecurityGroup];
     }
     const privateSubnets = props.privateSubnets ? { subnets: props.privateSubnets } : undefined;


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36653 .

### Reason for this change

Despite specifying a SecurityGroup in KubectlProviderOptions,
the EKS Cluster's SecurityGroup is being applied to the Kubectl Handler (Lambda) instead.

### Description of changes
- Modified to ensure the security group specified by the implementer is correctly applied to the Lambda Handler.
- If no security group is specified, the cluster security group is used, maintaining consistency with the original specification.

### Describe any new or updated permissions being added
There are no changes related to IAM permissions.

### Description of how you validated changes
- [x] add unit test
- [ ] add integration test

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
