### PR TITLE
ci(mergify): revert skip integration deployment test

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,19 +26,6 @@ queue_rules:
       - or:
         - "-label~=pr/needs-integration-tests-deployment"
         - "check-success=Deploy integration test snapshots (requires `pr/needs-integration-tests-deployment` label)"
-    merge_conditions:
-      - -title~=(WIP|wip)
-      - -label~=(blocked|do-not-merge)
-      # Only if no-squash is set
-      - label~=no-squash
-      - -merged
-      - -closed
-      - "#approved-reviews-by>=1"
-      - -approved-reviews-by~=author
-      # This is important! It makes the PR Linter work.
-      - "#changes-requested-reviews-by=0"
-      - check-success=validate-pr
-      - check-success=build
     commit_message_template: |-
       {{ title }} (#{{ number }})
       {{ body }}
@@ -64,19 +51,6 @@ queue_rules:
       - or:
         - "-label~=pr/needs-integration-tests-deployment"
         - "check-success=Deploy integration test snapshots (requires `pr/needs-integration-tests-deployment` label)"
-    merge_conditions:
-      - base!=release
-      - -title~=(WIP|wip)
-      - -label~=(blocked|do-not-merge|no-squash)
-      - label~=priority-pr
-      - -merged
-      - -closed
-      - "#approved-reviews-by>=1"
-      - -approved-reviews-by~=author
-      # This is important! It makes the PR Linter work.
-      - "#changes-requested-reviews-by=0"
-      - check-success=validate-pr
-      - check-success=build
     commit_message_template: |-
       {{ title }} (#{{ number }})
       {{ body }}
@@ -101,18 +75,6 @@ queue_rules:
       - or:
         - "-label~=pr/needs-integration-tests-deployment"
         - "check-success=Deploy integration test snapshots (requires `pr/needs-integration-tests-deployment` label)"
-    merge_conditions:
-      - base!=release
-      - -title~=(WIP|wip)
-      - -label~=(blocked|do-not-merge|no-squash|priority-pr)
-      - -merged
-      - -closed
-      - "#approved-reviews-by>=1"
-      - -approved-reviews-by~=author
-      # This is important! It makes the PR Linter work.
-      - "#changes-requested-reviews-by=0"
-      - check-success=validate-pr
-      - check-success=build
     commit_message_template: |-
       {{ title }} (#{{ number }})
       {{ body }}


### PR DESCRIPTION
This reverts commit 77baea1692bd863f302ef61e6d6e0953e5979767.

### Reason for this change

The recent ci change is not compatible with branch protection settings of this repository. See https://github.com/aws/aws-cdk/pull/36588/checks?check_run_id=60891387085

### Description of changes

Reverts change.

### Describe any new or updated permissions being added

No permissions added.


### Description of how you validated changes

N/A

### Checklist
- [s] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
