### PR TITLE
chore(mixins-preview): redact third-party mixin FQNs in metadata

### DIFF
--- a/packages/@aws-cdk/mixins-preview/lib/core/private/metadata.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/core/private/metadata.ts
@@ -3,10 +3,20 @@ import { IMixin } from '../mixins';
 
 const MIXIN_METADATA_KEY = 'aws:cdk:analytics:mixin';
 const JSII_RUNTIME_SYMBOL = Symbol.for('jsii.rtti');
+const ALLOWED_FQN_PREFIXES: ReadonlyArray<string> = [
+  // SCOPES
+  '@aws-cdk/', '@aws-cdk-containers/', '@aws-solutions-konstruk/', '@aws-solutions-constructs/', '@amzn/', '@cdklabs/',
+  // PACKAGES
+  'aws-rfdk.', 'aws-cdk-lib.', 'cdk8s.',
+];
 
 export function addMetadata(construct: IConstruct, mixin: IMixin) {
   const fqn = Object.getPrototypeOf(mixin).constructor[JSII_RUNTIME_SYMBOL]?.fqn;
   if (fqn) {
-    construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: fqn });
+    if (ALLOWED_FQN_PREFIXES.find(prefix => fqn.startsWith(prefix))) {
+      construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: fqn });
+    } else {
+      construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: '*' });
+    }
   }
 }

--- a/packages/@aws-cdk/mixins-preview/test/core/metadata.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/core/metadata.test.ts
@@ -18,6 +18,13 @@ class MixinWithoutFqn extends Mixin {
   }
 }
 
+class ThirdPartyMixin extends Mixin {
+  static readonly [JSII_RUNTIME_SYMBOL] = { fqn: 'some-third-party.ThirdPartyMixin' };
+  applyTo(construct: any): any {
+    return construct;
+  }
+}
+
 describe('Mixin Metadata', () => {
   let app: App;
   let stack: Stack;
@@ -50,5 +57,14 @@ describe('Mixin Metadata', () => {
 
     const metadata = construct.node.metadata.filter(m => m.type === MIXIN_METADATA_KEY);
     expect(metadata.length).toBe(2);
+  });
+
+  test('redacts fqn for non-allowed prefixes', () => {
+    const construct = new Construct(stack, 'Test');
+    Mixins.of(construct).apply(new ThirdPartyMixin());
+
+    const metadata = construct.node.metadata.find(m => m.type === MIXIN_METADATA_KEY);
+    expect(metadata).toBeDefined();
+    expect(metadata?.data).toEqual({ mixin: '*' });
   });
 });


### PR DESCRIPTION
### Reason for this change

Mixin analytics metadata should only report the full FQN of any 1P  mixins, but not third-party mixins.

### Description of changes

Added an allowlist of FQN prefixes for AWS-owned packages. When a mixin's FQN matches one of these prefixes, the full FQN is reported in the metadata. For all other mixins (third-party), the FQN is redacted to `'*'` to preserve privacy while still tracking that a mixin was applied.

Allowed prefixes include:
- AWS CDK scopes: `@aws-cdk/`, `@aws-cdk-containers/`, `@aws-solutions-konstruk/`, `@aws-solutions-constructs/`, `@amzn/`, `@cdklabs/`
- AWS CDK packages: `aws-rfdk.`, `aws-cdk-lib.`, `cdk8s.`

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Added unit test to verify third-party mixin FQNs are redacted to `'*'`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
