### PR TITLE
feat(kms): make `trustAccountIdentities` optional in `KeyGrants`

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/lib/key-grants.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/key-grants.ts
@@ -7,7 +7,7 @@ import { IKeyRef } from '../../interfaces/generated/aws-kms-interfaces.generated
 
 interface KeyGrantsProps {
   readonly resource: IKeyRef;
-  readonly trustAccountIdentities: boolean;
+  readonly trustAccountIdentities?: boolean;
 }
 
 /**
@@ -17,17 +17,17 @@ export class KeyGrants {
   /**
    * Creates grants for an IKeyRef
    */
-  public static fromKey(resource: IKeyRef, trustAccountIdentities: boolean): KeyGrants {
+  public static fromKey(resource: IKeyRef, trustAccountIdentities?: boolean): KeyGrants {
     return new KeyGrants({ resource, trustAccountIdentities });
   }
 
   protected readonly resource: IKeyRef;
-  private readonly trustAccountIdentities: boolean;
+  private readonly trustAccountIdentities?: boolean;
   private readonly policyResource?: iam.IResourceWithPolicyV2;
 
   private constructor(props: KeyGrantsProps) {
     this.resource = props.resource;
-    this.trustAccountIdentities = props.trustAccountIdentities;
+    this.trustAccountIdentities = props.trustAccountIdentities ?? FeatureFlags.of(this.resource).isEnabled(cxapi.KMS_DEFAULT_KEY_POLICIES);
     this.policyResource = (iam.GrantableResources.isResourceWithPolicy(this.resource) ? this.resource : undefined);
   }
 

--- a/packages/aws-cdk-lib/aws-kms/test/key.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/key.test.ts
@@ -233,7 +233,7 @@ describe('key policies', () => {
     const user = new iam.User(stack, 'User');
 
     // WHEN
-    KeyGrants.fromKey(key, false).decrypt(user);
+    KeyGrants.fromKey(key).decrypt(user);
 
     // THEN
     // Key policy should be unmodified by the grant.

--- a/packages/aws-cdk-lib/aws-kms/test/key.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/key.test.ts
@@ -183,7 +183,7 @@ describe('key policies', () => {
     const user = new iam.User(stack, 'User');
 
     // WHEN
-    key.grants.decrypt(user);
+    KeyGrants.fromKey(key).decrypt(user);
 
     // THEN
     // Key policy should be unmodified by the grant.
@@ -201,6 +201,31 @@ describe('key policies', () => {
       },
     });
 
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'kms:Decrypt',
+            Effect: 'Allow',
+            Resource: { 'Fn::GetAtt': ['Key961B73FD', 'Arn'] },
+          },
+        ],
+        Version: '2012-10-17',
+      },
+    });
+  });
+
+  test('decrypt with trustAccountIdentities false', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const key = new kms.Key(stack, 'Key');
+    const user = new iam.User(stack, 'User');
+
+    // WHEN
+    KeyGrants.fromKey(key, false).decrypt(user);
+
+    // THEN
+    // Only the principal's policy is modified by the grant.
     Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [


### PR DESCRIPTION
### Reason for this change

The `KeyGrants.fromKey()` method requires the user to decide whether they want to add permission to both the principal and the resource or just the principal. This is hard to reason about and most of the time customers just want a sensible default.

### Description of changes

The parameter `trustAccountIdentities` to `KeyGrants.fromKey()` is being made optional, and defaults to the value of the `@aws-cdk/aws-kms:defaultKeyPolicies` feature flag.


### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
