### PR TITLE
fix(iam): `IEncryptedResource` extends `IEnvironmentAware` instead of `IResource`

### DIFF
--- a/allowed-breaking-changes.txt
+++ b/allowed-breaking-changes.txt
@@ -4142,3 +4142,12 @@ changed-type:aws-cdk-lib.aws_ses.EventDestination.bus
 # CloudFormation has always required SecurityGroups for ManagedInstancesCapacityProvider.
 # Making it required in TypeScript catches the error at compile time instead of deploy time.
 strengthened:aws-cdk-lib.aws_ecs.ManagedInstancesCapacityProviderProps
+
+# IEncryptedResource was too strongly typed for practical use.
+# We need to weaken it and align with other traits.
+# See: https://github.com/aws/aws-cdk/pull/36787
+incompatible-argument:aws-cdk-lib.aws_iam.GrantableResources.isEncryptedResource
+base-types:aws-cdk-lib.aws_iam.IEncryptedResource
+removed:aws-cdk-lib.aws_iam.IEncryptedResource.applyRemovalPolicy
+removed:aws-cdk-lib.aws_iam.IEncryptedResource.node
+removed:aws-cdk-lib.aws_iam.IEncryptedResource.stack

--- a/packages/aws-cdk-lib/aws-iam/lib/grant.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/grant.ts
@@ -433,11 +433,9 @@ export interface GrantOnKeyResult {
 }
 
 /**
- * A resource that contains data that can be encrypted, using a KMS key.
- *
- * [awslint:interface-extends-ref]
+ * A resource that contains data that can be encrypted, using a KMS key.s
  */
-export interface IEncryptedResource extends cdk.IResource {
+export interface IEncryptedResource extends IEnvironmentAware {
   /**
    * Gives permissions to a grantable entity to perform actions on the encryption key.
    */
@@ -468,7 +466,7 @@ export class GrantableResources {
   /**
    * Whether this resource holds data that can be encrypted using a KMS key.
    */
-  static isEncryptedResource(resource: IConstruct): resource is iam.IEncryptedResource {
+  static isEncryptedResource(resource: IEnvironmentAware): resource is iam.IEncryptedResource {
     return (resource as unknown as iam.IEncryptedResource).grantOnKey !== undefined;
   }
 }


### PR DESCRIPTION
### Reason for this change

The `IEncryptedResource` interface currently extends `IResource`, which requires implementations to be full CDK resources. By changing it to extend `IEnvironmentAware` instead, we allow for more flexible implementations that only need environment information to function correctly with encryption grants.

This change also aligns the `GrantableResources.isEncryptedResource()` type guard to accept `IEnvironmentAware` instead of `IConstruct`, making the API more consistent with the interface it guards.

Today, all AWS vended constructs that implement `IEncryptedResource` already implement `IResource` directly.

### Description of changes

- Changed `IEncryptedResource` to extend `IEnvironmentAware` instead of `cdk.IResource`
- Updated `GrantableResources.isEncryptedResource()` parameter type from `IConstruct` to `IEnvironmentAware`
- Removed the `[awslint:interface-extends-ref]` directive as it's no longer applicable

BREAKING CHANGE: Receivers of `IEncryptedResource` objects now have fewer guarantees about the shape of the object. If you still require an `IResource`, change the type to `IEncryptedResource & IResource` and/or add a type guard check using `Resource.isResource()`. Implementations of `IEncryptedResource` no longer need to implement `IResource` but must continue to implement `IEnvironmentAware`. Since `IResource` extends `IEnvironmentAware`, there is no change for implementors. Calls to `GrantableResources.isEncryptedResource()` now require an `IEnvironmentAware` argument instead of `IConstruct`.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
