### PR TITLE
feat(dynamodb): `TableGrants` adds permission to `CfnTable` policy if necessary

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-grants.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-grants.ts
@@ -55,7 +55,9 @@ export class TableGrants {
     return new TableGrants({
       table,
       encryptedResource: (iam.GrantableResources.isEncryptedResource(table) ? table : undefined),
-      policyResource: (iam.GrantableResources.isResourceWithPolicy(table) ? table : undefined),
+      policyResource: GrantableResources.isResourceWithPolicy(table)
+        ? table
+        : CfnTable.isCfnTable(table) ? new CfnTableWithPolicy(table) : undefined,
     });
   }
 
@@ -67,9 +69,7 @@ export class TableGrants {
   constructor(props: TableGrantsProps) {
     this.table = props.table;
     this.encryptedResource = props.encryptedResource;
-    this.policyResource = GrantableResources.isResourceWithPolicy(this.table)
-      ? this.table
-      : CfnTable.isCfnTable(this.table) ? new CfnTableWithPolicy(this.table) : undefined;
+    this.policyResource = props.policyResource;
 
     const stack = Stack.of(this.table);
 


### PR DESCRIPTION
Analogous to https://github.com/aws/aws-cdk/pull/36802.

`TableGrants` can now generate policy resources even if the `ITableRef` passed to `TableGrants.fromTable` is an L1.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
