### PR TITLE
fix: `getEnv()` incompatibility with Java bindings of old CDK packages

### DIFF
--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
@@ -4,7 +4,7 @@ import { Attributes, renderAttributes } from './util';
 import * as ec2 from '../../../aws-ec2';
 import * as cdk from '../../../core';
 import { ValidationError } from '../../../core/lib/errors';
-import { aws_elasticloadbalancingv2 } from '../../../interfaces';
+import { aws_elasticloadbalancingv2, ResourceEnvironment } from '../../../interfaces';
 import { CfnTargetGroup } from '../elasticloadbalancingv2.generated';
 
 /**
@@ -249,7 +249,7 @@ export abstract class TargetGroupBase extends Construct implements ITargetGroup 
   /**
    * The environment this resource belongs to
    */
-  public get env(): cdk.ResourceEnvironment {
+  public get env(): ResourceEnvironment {
     return cdk.Stack.of(this).env;
   }
 

--- a/packages/aws-cdk-lib/core/lib/cfn-resource.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-resource.ts
@@ -15,7 +15,7 @@ import { FeatureFlags } from './feature-flags';
 import { ResolutionTypeHint } from './type-hints';
 import * as cxapi from '../../cx-api';
 import { AssumptionError, ValidationError } from './errors';
-import { ResourceEnvironment } from './environment';
+import { ResourceEnvironment } from '../../interfaces/environment-aware';
 
 export interface CfnResourceProps {
   /**

--- a/packages/aws-cdk-lib/core/lib/environment.ts
+++ b/packages/aws-cdk-lib/core/lib/environment.ts
@@ -1,5 +1,8 @@
 /**
  * The deployment environment for a stack.
+ *
+ * This is an input type: it is used to specify a deployment environment when
+ * instantiating `Stack` or `Stage`.
  */
 export interface Environment {
   /**
@@ -34,5 +37,5 @@ export interface Environment {
 // For backwards compatibility with TypeScript users
 // (Note that `import { ... } from '...'; export { ... }` behaves differently in jsii
 // than `export { ... } from '...'`, and we need the former).
-import { IEnvironmentAware, ResourceEnvironment } from '../../interfaces/environment-aware';
-export type { IEnvironmentAware, ResourceEnvironment };
+import { IEnvironmentAware } from '../../interfaces/environment-aware';
+export type { IEnvironmentAware };

--- a/packages/aws-cdk-lib/core/lib/index.ts
+++ b/packages/aws-cdk-lib/core/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './aspect';
 export * from './tag-aspect';
+export * from './resource-environment';
 
 export * from './token';
 export * from './resolvable';

--- a/packages/aws-cdk-lib/core/lib/private/detached-construct.ts
+++ b/packages/aws-cdk-lib/core/lib/private/detached-construct.ts
@@ -1,5 +1,5 @@
 import { Construct, IConstruct } from 'constructs';
-import type { ResourceEnvironment } from '../environment';
+import { ResourceEnvironment } from '../../../interfaces/environment-aware';
 import { UnscopedValidationError } from '../errors';
 
 const CONSTRUCT_SYM = Symbol.for('constructs.Construct');

--- a/packages/aws-cdk-lib/core/lib/stack.ts
+++ b/packages/aws-cdk-lib/core/lib/stack.ts
@@ -11,7 +11,7 @@ import { Fn } from './cfn-fn';
 import { Aws, ScopedAws } from './cfn-pseudo';
 import { CfnResource, TagType } from './cfn-resource';
 import { ContextProvider } from './context-provider';
-import { Environment, ResourceEnvironment } from './environment';
+import { Environment } from './environment';
 import { FeatureFlags } from './feature-flags';
 import { PermissionsBoundary, PERMISSIONS_BOUNDARY_CONTEXT_KEY } from './permissions-boundary';
 import { CLOUDFORMATION_TOKEN_RESOLVER, CloudFormationLang } from './private/cloudformation-lang';
@@ -1887,4 +1887,5 @@ import { PRIVATE_CONTEXT_DEFAULT_STACK_SYNTHESIZER } from './private/private-con
 import { Intrinsic } from './private/intrinsic';
 import { mutatingAspectPrio32333 } from './private/aspect-prio';
 import { AssumptionError, ValidationError } from './errors';
+import { ResourceEnvironment } from '../../interfaces/environment-aware';
 /* eslint-enable import/order */

--- a/packages/aws-cdk-lib/interfaces/environment-aware.ts
+++ b/packages/aws-cdk-lib/interfaces/environment-aware.ts
@@ -1,3 +1,4 @@
+import { ResourceEnvironment as CoreResourceEnvironment } from '../core/lib/resource-environment';
 /**
  * Used to indicate that a particular construct has an resource environment
  */
@@ -19,25 +20,10 @@ export interface IEnvironmentAware {
 /**
  * Represents the environment a given resource lives in.
  *
+ * This extends the old definition of `ResourceEnvironment` for backwards
+ * compatibility with Java bindings generated from old CDK library versions.
+ *
  * Used as the return value for the `IEnvironmentAware.env` property.
  */
-export interface ResourceEnvironment {
-  /**
-   * The AWS Account ID that this resource belongs to.
-   *
-   * Since this can be a Token (for example, when the account is
-   * CloudFormation's `AWS::AccountId` intrinsic), make sure to use
-   * `Token.compareStrings()` instead of comparing the values with direct
-   * string equality.
-   */
-  readonly account: string;
-
-  /**
-   * The AWS Region that this resource belongs to.
-   *
-   * Since this can be a Token (for example, when the region is CloudFormation's
-   * `AWS::Region` intrinsic), make sure to use `Token.compareStrings()` instead
-   * of comparing the values with direct string equality.
-   */
-  readonly region: string;
+export interface ResourceEnvironment extends CoreResourceEnvironment {
 }


### PR DESCRIPTION
We moved the FQN of `ResourceEnvironment`, which means that Java packages generated against an old version of `aws-cdk-lib` don't compile against a newer version of the official CDK Java bindings (because the `aws-cdk-lib.ResourceEnvironment` class no longer exists).

Instead, add the old class back and make the new class a subclass of the old one. This works because `ResourceEnvironment` is only ever a return type, never a parameter type.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
