### PR TITLE
fix(lambda): calculateLayersHash includes all stack layers

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.function-hash.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.function-hash.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { STANDARD_NODEJS_RUNTIME } from '../../config';
+
+const app = new cdk.App();
+
+const stack = new cdk.Stack(app, 'aws-cdk-lambda-function-hash');
+
+const layer = new lambda.LayerVersion(stack, 'MyLayer', {
+    code: lambda.Code.fromAsset(path.join(__dirname, 'layer-code'), { exclude: ['*.ts'] }),
+    compatibleRuntimes: [STANDARD_NODEJS_RUNTIME],
+});
+
+new lambda.Function(stack, 'MyFunction', {
+    code: new lambda.InlineCode('foo'),
+    handler: 'index.handler',
+    runtime: STANDARD_NODEJS_RUNTIME,
+    layers: [layer],
+});
+
+// Adding an unattached layer should not change the function hash
+// with the feature flag enabled (which is default in new projects)
+new lambda.LayerVersion(stack, 'UnattachedLayer', {
+    code: lambda.Code.fromAsset(path.join(__dirname, 'layer-code'), { exclude: ['*.ts'] }),
+    compatibleRuntimes: [STANDARD_NODEJS_RUNTIME],
+});
+
+app.synth();

--- a/packages/aws-cdk-lib/aws-lambda/lib/function-hash.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function-hash.ts
@@ -22,7 +22,13 @@ export function calculateFunctionHash(fn: LambdaFunction, additional: string = '
   }
 
   if (FeatureFlags.of(fn).isEnabled(LAMBDA_RECOGNIZE_LAYER_VERSION)) {
-    stringifiedConfig = stringifiedConfig + calculateLayersHash(fn._layers);
+    const layerArns = properties.Layers || [];
+    const relevantLayers = fn._layers.filter(layer => {
+      const resolvedLayerArn = stack.resolve(layer.layerVersionArn);
+      return layerArns.some((arn: any) => JSON.stringify(arn) === JSON.stringify(resolvedLayerArn));
+    });
+
+    stringifiedConfig = stringifiedConfig + calculateLayersHash(relevantLayers);
   }
 
   return md5hash(stringifiedConfig + additional);
@@ -102,7 +108,7 @@ function filterUsefulKeys(properties: any, fn: LambdaFunction) {
 }
 
 function calculateLayersHash(layers: ILayerVersion[]): string {
-  const layerConfig: {[key: string]: any } = {};
+  const layerConfig: { [key: string]: any } = {};
   for (const layer of layers) {
     const stack = Stack.of(layer);
     const layerResource = layer.node.defaultChild as CfnResource;

--- a/packages/aws-cdk-lib/aws-lambda/test/function-hash.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function-hash.test.ts
@@ -278,6 +278,30 @@ describe('function hash', () => {
 
       expect(calculateFunctionHash(fn1)).not.toEqual(calculateFunctionHash(fn2));
     });
+
+    test('adding unattached layer to the stack does not impact hash', () => {
+      const app = new App({ context: { [cxapi.LAMBDA_RECOGNIZE_LAYER_VERSION]: true } });
+      const stack = new Stack(app, 'stack');
+
+      const fn = new lambda.Function(stack, 'MyFunction', {
+        runtime: THE_RUNTIME,
+        code: lambda.Code.fromInline('foo'),
+        handler: 'index.handler',
+        layers: [layer1],
+      });
+
+      const hashBefore = calculateFunctionHash(fn);
+
+      // Create another layer in the stack but don't attach it to the function
+      new lambda.LayerVersion(stack, 'UnattachedLayer', {
+        code: lambda.Code.fromAsset(path.join(__dirname, 'layer-code')),
+        compatibleRuntimes: [THE_RUNTIME],
+      });
+
+      const hashAfter = calculateFunctionHash(fn);
+
+      expect(hashAfter).toEqual(hashBefore);
+    });
   });
 
   describe('impact of env variables order on hash', () => {


### PR DESCRIPTION
Description
-----------
Fixes #36713

When calculateFunctionHash computes the hash for a function, it currently includes the hash of all layers in the stack (fn._layers), regardless of whether they are attached to the function. This causes unnecessary function updates when unrelated layers in the same stack are modified.

This PR modifies the logic to filter fn._layers and only include those that are actually present in the function's CloudFormation properties (properties.Layers).

Validation
----------
- [ ] Manual verification via code review
- [ ] (Pending) Integration tests