### PR TITLE
feat(mixins-preview): align Mixins API with latest RFC proposal

### DIFF
--- a/packages/@aws-cdk/mixins-preview/README.md
+++ b/packages/@aws-cdk/mixins-preview/README.md
@@ -54,7 +54,7 @@ For convenience, you can use the `.with()` method for a more fluent syntax:
 import '@aws-cdk/mixins-preview/with';
 
 const bucket = new s3.CfnBucket(scope, "MyBucket")
-  .with(new EnableVersioning())
+  .with(new BucketVersioning())
   .with(new AutoDeleteObjects());
 ```
 
@@ -127,11 +127,11 @@ const bucket = new s3.CfnBucket(scope, "Bucket");
 Mixins.of(bucket).apply(new AutoDeleteObjects());
 ```
 
-**EnableVersioning**: Enables versioning on S3 buckets
+**BucketVersioning**: Enables versioning on S3 buckets
 
 ```typescript
 const bucket = new s3.CfnBucket(scope, "Bucket");
-Mixins.of(bucket).apply(new EnableVersioning());
+Mixins.of(bucket).apply(new BucketVersioning());
 ```
 
 **BucketPolicyStatementsMixin**: Adds IAM policy statements to a bucket policy
@@ -231,7 +231,8 @@ Mixins.of(scope)
 
 // Strict application that requires all constructs to match
 Mixins.of(scope)
-  .mustApply(new EncryptionAtRest()); // Throws if no constructs support the mixin
+  .requireAll() // Throws if no constructs support the mixin
+  .apply(new EncryptionAtRest());
 ```
 
 ---

--- a/packages/@aws-cdk/mixins-preview/lib/core/applicator.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/core/applicator.ts
@@ -2,7 +2,22 @@ import type { IConstruct } from 'constructs';
 import { ValidationError } from 'aws-cdk-lib/core';
 import type { IMixin } from './mixins';
 import { ConstructSelector, type IConstructSelector } from './selectors';
-import { addMetadata } from './private/metadata';
+import { applyMixin } from './private/metadata';
+import { memoizedGetter } from 'aws-cdk-lib/core/lib/helpers-internal';
+
+/**
+ * Represents a successful mixin application.
+ */
+export interface MixinApplication {
+  /**
+   * The construct the mixin was applied to.
+   */
+  readonly construct: IConstruct;
+  /**
+   * The mixin that was applied.
+   */
+  readonly mixin: IMixin;
+}
 
 /**
  * Applies mixins to constructs.
@@ -10,6 +25,25 @@ import { addMetadata } from './private/metadata';
 export class MixinApplicator {
   private readonly scope: IConstruct;
   private readonly selector: IConstructSelector;
+  private readonly applications: MixinApplication[] = [];
+
+  private expectAll = false;
+  private expectAny = false;
+
+  /**
+   * The constructs that match the selector in the given scope.
+   */
+  @memoizedGetter
+  public get selectedConstructs(): IConstruct[] {
+    return this.selector.select(this.scope);
+  }
+
+  /**
+   * Returns the successful mixin applications.
+   */
+  public get report(): MixinApplication[] {
+    return this.applications;
+  }
 
   constructor(
     scope: IConstruct,
@@ -23,35 +57,57 @@ export class MixinApplicator {
    * Applies a mixin to selected constructs.
    */
   public apply(...mixins: IMixin[]): this {
-    const constructs = this.selector.select(this.scope);
-    for (const construct of constructs) {
+    const applications: MixinApplication[] = [];
+    for (const construct of this.selectedConstructs) {
       for (const mixin of mixins) {
         if (mixin.supports(construct)) {
           applyMixin(construct, mixin);
+          applications.push({ construct, mixin });
+        } else if (this.expectAll) {
+          throw new ValidationError(`Mixin ${mixin.constructor.name} could not be applied to ${construct.constructor.name} but was required to.`, this.scope);
         }
       }
     }
+
+    if (this.expectAny && applications.length <= 0) {
+      throw new ValidationError('At least one mixin application was required, but none of the provided mixins could be applied to any selected construct.', this.scope);
+    }
+
+    // record all applications
+    this.applications.push(...applications);
+
     return this;
   }
 
   /**
-   * Applies a mixin and requires that it be applied to all constructs.
+   * Requires all selected constructs to support the applied mixins.
+   *
+   * Will only check for future call of `apply()`.
+   * Set this before calling `apply()` to take effect.
+   *
+   * @example
+   * Mixins.of(scope)
+   *   .requireAll()
+   *   .apply(new MyMixin());
    */
-  public mustApply(...mixins: IMixin[]): this {
-    const constructs = this.selector.select(this.scope);
-    for (const construct of constructs) {
-      for (const mixin of mixins) {
-        if (!mixin.supports(construct)) {
-          throw new ValidationError(`Mixin ${mixin.constructor.name} could not be applied to ${construct.constructor.name} but was requested to.`, this.scope);
-        }
-        applyMixin(construct, mixin);
-      }
-    }
+  public requireAll(): this {
+    this.expectAll = true;
     return this;
   }
-}
 
-function applyMixin(construct: IConstruct, mixin: IMixin) {
-  addMetadata(construct, mixin);
-  mixin.applyTo(construct);
+  /**
+   * Requires at least one mixin to be successfully applied.
+   *
+   * Will only check for future call of `apply()`.
+   * Set this before calling `apply()` to take effect.
+   *
+   * @example
+   * Mixins.of(scope)
+   *   .requireAny()
+   *   .apply(new MyMixin());
+   */
+  public requireAny(): this {
+    this.expectAny = true;
+    return this;
+  }
 }

--- a/packages/@aws-cdk/mixins-preview/lib/core/mixins.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/core/mixins.ts
@@ -30,7 +30,7 @@ export interface IMixin {
   /**
    * Applies the mixin functionality to the target construct.
    */
-  applyTo(construct: IConstruct): IConstruct;
+  applyTo(construct: IConstruct): void;
 }
 
 /**
@@ -55,5 +55,5 @@ export abstract class Mixin implements IMixin {
     return true;
   }
 
-  abstract applyTo(construct: IConstruct): IConstruct;
+  abstract applyTo(construct: IConstruct): void;
 }

--- a/packages/@aws-cdk/mixins-preview/lib/core/private/metadata.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/core/private/metadata.ts
@@ -11,12 +11,15 @@ const ALLOWED_FQN_PREFIXES: ReadonlyArray<string> = [
 ];
 
 export function addMetadata(construct: IConstruct, mixin: IMixin) {
+  let reportedValue = '*';
   const fqn = Object.getPrototypeOf(mixin).constructor[JSII_RUNTIME_SYMBOL]?.fqn;
-  if (fqn) {
-    if (ALLOWED_FQN_PREFIXES.find(prefix => fqn.startsWith(prefix))) {
-      construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: fqn });
-    } else {
-      construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: '*' });
-    }
+  if (fqn && ALLOWED_FQN_PREFIXES.find(prefix => fqn.startsWith(prefix))) {
+    reportedValue = fqn;
   }
+  construct.node.addMetadata(MIXIN_METADATA_KEY, { mixin: reportedValue });
+}
+
+export function applyMixin(construct: IConstruct, mixin: IMixin) {
+  addMetadata(construct, mixin);
+  mixin.applyTo(construct);
 }

--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-mwaaserverless/index.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-mwaaserverless/index.ts
@@ -1,0 +1,1 @@
+export * as mixins from './mixins';

--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-mwaaserverless/mixins.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-mwaaserverless/mixins.ts
@@ -1,0 +1,1 @@
+export * from './cfn-props-mixins.generated';

--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-s3/bucket-policy.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-s3/bucket-policy.ts
@@ -20,17 +20,15 @@ export class BucketPolicyStatementsMixin extends Mixin {
     return CfnBucketPolicy.isCfnBucketPolicy(construct);
   }
 
-  public applyTo(policy: IConstruct): IConstruct {
+  public applyTo(policy: IConstruct): void {
     if (!this.supports(policy)) {
-      return policy;
+      return;
     }
 
     const policyDocument = this.getPolicyDocument(policy);
     policyDocument.addStatements(...this.statements);
 
     policy.policyDocument = policyDocument;
-
-    return policy;
   }
 
   /**

--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-s3/bucket.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-s3/bucket.ts
@@ -17,9 +17,9 @@ export class AutoDeleteObjects implements IMixin {
     return CfnResource.isCfnResource(construct) && construct.cfnResourceType === s3.CfnBucket.CFN_RESOURCE_TYPE_NAME;
   }
 
-  applyTo(construct: IConstruct): IConstruct {
+  applyTo(construct: IConstruct): void {
     if (!this.supports(construct)) {
-      return construct;
+      return;
     }
 
     const ref = construct.bucketRef;
@@ -73,25 +73,24 @@ export class AutoDeleteObjects implements IMixin {
 
     // Tag the bucket to record that we want it autodeleted
     Tags.of(construct).add(AUTO_DELETE_OBJECTS_TAG, 'true');
-
-    return construct;
   }
 }
 
 /**
  * S3-specific mixin for enabling versioning.
  */
-export class EnableVersioning implements IMixin {
+export class BucketVersioning implements IMixin {
+  constructor(private readonly enabled = true) {}
+
   supports(construct: IConstruct): boolean {
     return construct instanceof s3.CfnBucket;
   }
 
-  applyTo(construct: IConstruct): IConstruct {
+  applyTo(construct: IConstruct): void {
     if (construct instanceof s3.CfnBucket) {
       construct.versioningConfiguration = {
-        status: 'Enabled',
+        status: this.enabled ? 'Enabled' : 'Suspended',
       };
     }
-    return construct;
   }
 }

--- a/packages/@aws-cdk/mixins-preview/lib/with.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/with.ts
@@ -1,7 +1,7 @@
 import type { IConstruct } from 'constructs';
 import { Construct } from 'constructs';
 import type { IMixin } from './core';
-import { Mixins, ConstructSelector } from './core';
+import { applyMixin } from './core/private/metadata';
 
 declare module 'constructs' {
   interface IConstruct {
@@ -15,6 +15,12 @@ declare module 'constructs' {
 
 // Hack the prototype to add .with() method
 (Construct.prototype as any).with = function(this: IConstruct, ...mixin: IMixin[]): IConstruct {
-  Mixins.of(this, ConstructSelector.cfnResource()).mustApply(...mixin);
+  for (const c of this.node.findAll()) {
+    for (const m of mixin) {
+      if (m.supports(c)) {
+        applyMixin(c, m);
+      }
+    }
+  }
   return this;
 };

--- a/packages/@aws-cdk/mixins-preview/rosetta/default.ts-fixture
+++ b/packages/@aws-cdk/mixins-preview/rosetta/default.ts-fixture
@@ -10,13 +10,18 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import '@aws-cdk/mixins-preview/with';
 import { ConstructSelector, Mixins, Mixin, IMixin } from '@aws-cdk/mixins-preview/core';
 import { PropertyMergeStrategy } from '@aws-cdk/mixins-preview/mixins';
-import { AutoDeleteObjects, EnableVersioning, CfnBucketPropsMixin, BucketPolicyStatementsMixin } from '@aws-cdk/mixins-preview/aws-s3/mixins';
+import { AutoDeleteObjects, BucketVersioning, CfnBucketPropsMixin, BucketPolicyStatementsMixin } from '@aws-cdk/mixins-preview/aws-s3/mixins';
 
 // for testing purposes, ensure these imports work
 import { mixins as alexa_mixins } from '@aws-cdk/mixins-preview/alexa-ask';
 import { aws_logs } from '@aws-cdk/mixins-preview';
 
 declare const scope: Construct;
+
+class MyMixin extends Mixins {
+  supports(_construct: any): boolean { return true; }
+  applyTo(construct: any): any { return construct; }
+}
 
 class ProductionSecurityMixin extends Mixins {
   supports(_construct: any): boolean { return true; }

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
@@ -2,7 +2,7 @@ import type { Resource, Service, SpecDatabase, VendedLogs } from '@aws-cdk/servi
 import { naming, util } from '@aws-cdk/spec2cdk';
 import { CDK_CORE, CDK_INTERFACES, CONSTRUCTS } from '@aws-cdk/spec2cdk/lib/cdk/cdk';
 import type { Method } from '@cdklabs/typewriter';
-import { Module, ExternalModule, ClassType, Stability, Type, expr, stmt, ThingSymbol, $this, CallableProxy, NewExpression, $E } from '@cdklabs/typewriter';
+import { Module, ExternalModule, ClassType, Stability, Type, expr, stmt, ThingSymbol, $this, CallableProxy, NewExpression, $E, $T } from '@cdklabs/typewriter';
 import { MIXINS_LOGS_DELIVERY } from './helpers';
 import type { ServiceSubmoduleProps, LocatedModule } from '@aws-cdk/spec2cdk/lib/cdk/service-submodule';
 import { BaseServiceSubmodule, relativeImportPath } from '@aws-cdk/spec2cdk/lib/cdk/service-submodule';
@@ -334,7 +334,7 @@ class LogsMixin extends ClassType {
         expr.binOp(
           CallableProxy.fromName('CfnResource.isCfnResource', CDK_CORE).invoke(construct),
           '&&',
-          expr.eq(expr.get(construct, 'cfnResourceType'), expr.lit(this.resource.cloudFormationType)),
+          $T(this.resourceType)[`is${this.resourceType.symbol}`](construct),
         ),
       ),
     );
@@ -345,7 +345,7 @@ class LogsMixin extends ClassType {
   private makeApplyToMethod(supports: Method) {
     const method = this.addMethod({
       name: 'applyTo',
-      returnType: CONSTRUCTS.IConstruct,
+      returnType: Type.VOID,
       docs: {
         summary: 'Apply vended logs configuration to the construct',
       },
@@ -362,12 +362,10 @@ class LogsMixin extends ClassType {
     method.addBody(
       stmt
         .if_(expr.not(CallableProxy.fromMethod(supports).invoke(resource)))
-        .then(stmt.block(stmt.ret(resource))),
+        .then(stmt.block(stmt.ret())),
 
       stmt.constVar(sourceArn, arnBuilder),
       $this.logDelivery.callMethod('bind', resource, $this.logType, sourceArn),
-
-      stmt.ret(resource),
     );
   }
 }

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
@@ -211,11 +211,12 @@ class L1PropsMixin extends ClassType {
   }
 
   private makeSupportsMethod(): Method {
-    const resClass = Type.fromName(this.constructLibModule, naming.classNameFromResource(this.resource));
+    const resourceClassName = naming.classNameFromResource(this.resource);
+    const resourceClass = Type.fromName(this.constructLibModule, resourceClassName);
 
     const method = this.addMethod({
       name: 'supports',
-      returnType: Type.ambient(`construct is service.${resClass.symbol}`),
+      returnType: Type.ambient(`construct is service.${resourceClass.symbol}`),
       docs: {
         summary: 'Check if this mixin supports the given construct',
       },
@@ -231,7 +232,7 @@ class L1PropsMixin extends ClassType {
         expr.binOp(
           CallableProxy.fromName('CfnResource.isCfnResource', CDK_CORE).invoke(construct),
           '&&',
-          expr.eq(expr.get(construct, 'cfnResourceType'), expr.lit(this.resource.cloudFormationType)),
+          $T(resourceClass)[`is${resourceClassName}`](construct),
         ),
       ),
     );
@@ -242,7 +243,7 @@ class L1PropsMixin extends ClassType {
   private makeApplyToMethod(supports: Method) {
     const method = this.addMethod({
       name: 'applyTo',
-      returnType: CONSTRUCTS.IConstruct,
+      returnType: Type.VOID,
       docs: {
         summary: 'Apply the mixin properties to the construct',
       },
@@ -274,7 +275,6 @@ class L1PropsMixin extends ClassType {
               ),
           ),
         ),
-      stmt.ret(construct),
     );
   }
 }

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
@@ -118,19 +118,18 @@ export class CfnThingLogsMixin extends core.Mixin implements core.IMixin {
    * Check if this mixin supports the given construct (has vendedLogs property)
    */
   public supports(construct: constructs.IConstruct): construct is service.CfnThing {
-    return (cdk.CfnResource.isCfnResource(construct) && (construct.cfnResourceType === "AWS::Some::Resource"));
+    return (cdk.CfnResource.isCfnResource(construct) && service.CfnThing.isCfnThing(construct));
   }
 
   /**
    * Apply vended logs configuration to the construct
    */
-  public applyTo(resource: constructs.IConstruct): constructs.IConstruct {
+  public applyTo(resource: constructs.IConstruct): void {
     if (!this.supports(resource)) {
-      return resource;
+      return;
     }
     const sourceArn = service.CfnThing.arnForThing(resource);
     this.logDelivery.bind(resource, this.logType, sourceArn);
-    return resource;
   }
 }"
 `;

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/resources.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/resources.test.ts.snap
@@ -38,13 +38,13 @@ export class CfnThingPropsMixin extends core.Mixin implements core.IMixin {
    * Check if this mixin supports the given construct
    */
   public supports(construct: constructs.IConstruct): construct is service.CfnThing {
-    return (cdk.CfnResource.isCfnResource(construct) && (construct.cfnResourceType === "AWS::Some::Resource"));
+    return (cdk.CfnResource.isCfnResource(construct) && service.CfnThing.isCfnThing(construct));
   }
 
   /**
    * Apply the mixin properties to the construct
    */
-  public applyTo(construct: constructs.IConstruct): constructs.IConstruct {
+  public applyTo(construct: constructs.IConstruct): void {
     if (this.supports(construct)) {
       if ((this.strategy === mixins.PropertyMergeStrategy.MERGE)) {
         helpers.deepMerge(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
@@ -52,7 +52,6 @@ export class CfnThingPropsMixin extends core.Mixin implements core.IMixin {
         helpers.shallowAssign(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
       }
     }
-    return construct;
   }
 }
 

--- a/packages/@aws-cdk/mixins-preview/test/core/metadata.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/core/metadata.test.ts
@@ -43,14 +43,6 @@ describe('Mixin Metadata', () => {
     expect(metadata?.data).toEqual({ mixin: '@aws-cdk/mixins-preview.TestMixin' });
   });
 
-  test('does not add metadata when mixin has no jsii fqn', () => {
-    const construct = new Construct(stack, 'Test');
-    Mixins.of(construct).apply(new MixinWithoutFqn());
-
-    const metadata = construct.node.metadata.find(m => m.type === MIXIN_METADATA_KEY);
-    expect(metadata).toBeUndefined();
-  });
-
   test('adds metadata for each applied mixin', () => {
     const construct = new Construct(stack, 'Test');
     Mixins.of(construct).apply(new TestMixin(), new TestMixin());
@@ -62,6 +54,15 @@ describe('Mixin Metadata', () => {
   test('redacts fqn for non-allowed prefixes', () => {
     const construct = new Construct(stack, 'Test');
     Mixins.of(construct).apply(new ThirdPartyMixin());
+
+    const metadata = construct.node.metadata.find(m => m.type === MIXIN_METADATA_KEY);
+    expect(metadata).toBeDefined();
+    expect(metadata?.data).toEqual({ mixin: '*' });
+  });
+
+  test('tracks redacted mixins when mixin has no jsii fqn', () => {
+    const construct = new Construct(stack, 'Test');
+    Mixins.of(construct).apply(new MixinWithoutFqn());
 
     const metadata = construct.node.metadata.find(m => m.type === MIXIN_METADATA_KEY);
     expect(metadata).toBeDefined();

--- a/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
@@ -118,23 +118,33 @@ describe('Core Mixins Framework', () => {
       expect((logGroup as any).selectiveMixinApplied).toBeUndefined();
     });
 
-    test('mustApply throws when no constructs match', () => {
-      const logGroup = new logs.CfnLogGroup(stack, 'LogGroup');
+    test('requireAny throws when no constructs match', () => {
+      new logs.CfnLogGroup(stack, 'LogGroup');
       const mixin = new SelectiveMixin();
 
       expect(() => {
-        Mixins.of(logGroup).mustApply(mixin);
+        Mixins.of(stack).requireAny().apply(mixin);
       }).toThrow();
     });
 
-    test('mustApply throws when some constructs match', () => {
+    test('requireAll throws when some constructs do not support mixin', () => {
       new s3.CfnBucket(stack, 'Bucket');
       new logs.CfnLogGroup(stack, 'LogGroup');
       const mixin = new SelectiveMixin();
 
       expect(() => {
-        Mixins.of(stack).mustApply(mixin);
+        Mixins.of(stack).requireAll().apply(mixin);
       }).toThrow();
+    });
+
+    test('report returns successful mixin applications', () => {
+      const bucket = new s3.CfnBucket(stack, 'Bucket');
+      new logs.CfnLogGroup(stack, 'LogGroup');
+      const mixin = new SelectiveMixin();
+
+      const applicator = Mixins.of(stack).apply(mixin);
+
+      expect(applicator.report).toEqual([{ construct: bucket, mixin }]);
     });
   });
 

--- a/packages/@aws-cdk/mixins-preview/test/mixins/full-example.ts
+++ b/packages/@aws-cdk/mixins-preview/test/mixins/full-example.ts
@@ -32,7 +32,7 @@ describe('Integration Tests', () => {
     Mixins.of(
       stack,
       ConstructSelector.resourcesOfType(s3.CfnBucket.CFN_RESOURCE_TYPE_NAME),
-    ).apply(new s3Mixins.EnableVersioning());
+    ).apply(new s3Mixins.BucketVersioning());
 
     // Verify auto-delete only applied to prod bucket
     const template = Template.fromStack(stack);
@@ -51,7 +51,7 @@ describe('Integration Tests', () => {
 
     Mixins.of(bucket)
       .apply(new s3Mixins.AutoDeleteObjects())
-      .apply(new s3Mixins.EnableVersioning());
+      .apply(new s3Mixins.BucketVersioning());
 
     const template = Template.fromStack(stack);
     template.hasResourceProperties('Custom::S3AutoDeleteObjects', {

--- a/packages/@aws-cdk/mixins-preview/test/services/aws-s3/s3-mixins.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/services/aws-s3/s3-mixins.test.ts
@@ -46,10 +46,10 @@ describe('S3 Mixins', () => {
     });
   });
 
-  describe('EnableVersioning', () => {
+  describe('BucketVersioning', () => {
     test('applies to S3 bucket', () => {
       const bucket = new s3.CfnBucket(stack, 'Bucket');
-      const mixin = new s3Mixins.EnableVersioning();
+      const mixin = new s3Mixins.BucketVersioning();
 
       expect(mixin.supports(bucket)).toBe(true);
       mixin.applyTo(bucket);
@@ -58,9 +58,19 @@ describe('S3 Mixins', () => {
       expect(versionConfig?.status).toBe('Enabled');
     });
 
+    test('suspends versioning when disabled', () => {
+      const bucket = new s3.CfnBucket(stack, 'Bucket');
+      const mixin = new s3Mixins.BucketVersioning(false);
+
+      mixin.applyTo(bucket);
+
+      const versionConfig = bucket.versioningConfiguration as any;
+      expect(versionConfig?.status).toBe('Suspended');
+    });
+
     test('does not support non-S3 constructs', () => {
       const construct = new TestConstruct(stack, 'test');
-      const mixin = new s3Mixins.EnableVersioning();
+      const mixin = new s3Mixins.BucketVersioning();
 
       expect(mixin.supports(construct)).toBe(false);
     });

--- a/packages/@aws-cdk/mixins-preview/test/with.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/with.test.ts
@@ -1,7 +1,6 @@
 import { Stack, App } from 'aws-cdk-lib/core';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as sns from 'aws-cdk-lib/aws-sns';
 import '../lib/with';
 import * as s3Mixins from '../lib/services/aws-s3/mixins';
 
@@ -17,7 +16,7 @@ describe('Mixin Extensions', () => {
   describe('.with() method', () => {
     test('can chain multiple mixins', () => {
       const bucket = new s3.CfnBucket(stack, 'Bucket')
-        .with(new s3Mixins.EnableVersioning())
+        .with(new s3Mixins.BucketVersioning())
         .with(new s3Mixins.AutoDeleteObjects());
 
       const versionConfig = bucket.versioningConfiguration as any;
@@ -31,7 +30,7 @@ describe('Mixin Extensions', () => {
 
     test('can apply multiple mixins', () => {
       const bucket = new s3.CfnBucket(stack, 'Bucket')
-        .with(new s3Mixins.EnableVersioning(), new s3Mixins.AutoDeleteObjects());
+        .with(new s3Mixins.BucketVersioning(), new s3Mixins.AutoDeleteObjects());
 
       const versionConfig = bucket.versioningConfiguration as any;
       expect(versionConfig?.status).toBe('Enabled');
@@ -44,17 +43,9 @@ describe('Mixin Extensions', () => {
 
     test('returns the same construct', () => {
       const bucket = new s3.CfnBucket(stack, 'Bucket');
-      const result = bucket.with(new s3Mixins.EnableVersioning());
+      const result = bucket.with(new s3Mixins.BucketVersioning());
 
       expect(result).toBe(bucket);
-    });
-
-    test('throws when mixin does not support construct', () => {
-      const topic = new sns.Topic(stack, 'Topic');
-
-      expect(() => {
-        topic.with(new s3Mixins.EnableVersioning());
-      }).toThrow();
     });
   });
 });

--- a/packages/@aws-cdk/mixins-preview/tsconfig.json
+++ b/packages/@aws-cdk/mixins-preview/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "declarationMap": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
+    "inlineSourceMap": false,
     "alwaysStrict": true,
     "declaration": true,
     "incremental": true,


### PR DESCRIPTION
### Reason for this change

The RFC for [CDK Mixins](https://github.com/aws/aws-cdk-rfcs/pull/824) was updated with several changes. This PR aligns the implementation of the preview package with the latest changes. It also includes some other API improvements to make Mixins more intuitive and consistent.

### Description of changes

- Replace `mustApply()` with separate `requireAll()` and `requireAny()` methods that set expectations before calling `apply()`. This was a change to the RFC. To support this change, this also includes:
  - New `report` getter to track successful applications, returning an array of the new `MixinApplication` interface 
  - New `selectedConstructs` getter to see which constructs were matched by the selector
- Make `.with()` silently skip unsupported constructs instead of throwing, this is implementing an RFC change
- Change `applyTo()` return type from `IConstruct` to `void` since mixins modify in place (RFC change)
- Rename `EnableVersioning` to `BucketVersioning` for consistency with other S3 mixins
- Add `BucketVersioning` constructor parameter to allow suspending versioning
- Add aws-mwaaserverless service module (wasn't committed before for some reason)
- Disable source maps in tsconfig, this aligns more with `aws-cdk-lib` which also doesn't emit sourcemaps.

### Description of how you validated changes

Updated existing unit tests to reflect the API changes and added new tests for `requireAll()`, `requireAny()`, and the `report` getter.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
