### PR TITLE
fix(kms): normalize and validate alias name in `Alias.fromAliasName`

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-kms/test/integ.alias-from-alias-name.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-kms/test/integ.alias-from-alias-name.ts
@@ -8,7 +8,7 @@ const app = new App({
   context: { [cxapi.KMS_APPLY_IMPORTED_ALIAS_PERMISSIONS_TO_PRINCIPAL]: true },
 });
 const stack = new Stack(app, 'aws-cdk-kms');
-const alias = Alias.fromAliasName(stack, 'alias', 'alias/MyKey');
+const alias = Alias.fromAliasName(stack, 'alias', 'MyKey');
 
 const role = new Role(stack, 'Role', {
   assumedBy: new ServicePrincipal('lambda.amazonaws.com'),


### PR DESCRIPTION
 **fix(kms): normalize and validate alias name in `Alias.fromAliasName`**

~P.S: I wasnt able to build the current main ([f8e3863](https://github.com/WtfJoke/aws-cdk/commit/f8e38638bb5be02bf006888c5d815570c4933c95)), but didnt produce any further build issues as far as I can tell.~

### Issue # (if applicable)

Closes #36693 

### Reason for this change

<!--What is the bug or use case behind this change?-->
Alias.fromAliasName did not include required "alias/" prefix when it was missing, however new Alias() did that. This PR aligns that.

### Description of changes
- Moved the validation + normalisation logic of alias name from constructor in dedicated method normalizeAliasName
- Emit a warning if token is completely unresolved, that alias name cant be validated
- Use that new method in constructor of `Alias` and in `Alias.fromAliasName`
- Omited the required prefix 'alias/' in integration test to see if it gets prefixed automatically. I suppose the integration test should still be green as the template should be the same.
- I didnt add a feature flag, because the change should remain backwards compatible (it just adds the prefix when its missing, not where its already correct). In the cases where the alias missing, it would have produced invalid ARNs before that change.
<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added
no new/updated permissions
<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes
- Added unit test and changed integration test slightly to validate it
<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Unit tests were added and an integration test was adjusted. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
