### PR TITLE
fix(ivs-alpha): hardcode region for IVS integration tests

### DIFF
--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-insecure-ingest.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-insecure-ingest.ts
@@ -4,7 +4,10 @@ import * as ivs from '../lib';
 
 const app = new App();
 
-const stack = new Stack(app, 'aws-cdk-ivs-insecure-ingest');
+// Hardcoded to us-east-1 because IVS service is only available in specific regions
+const stack = new Stack(app, 'aws-cdk-ivs-insecure-ingest', {
+  env: { region: 'us-east-1' },
+});
 
 new ivs.Channel(stack, 'ChannelInsecureIngestEnabled', {
   type: ivs.ChannelType.STANDARD,

--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-multitrack-video.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-multitrack-video.ts
@@ -4,7 +4,10 @@ import * as ivs from '../lib';
 
 const app = new App();
 
-const stack = new Stack(app, 'aws-cdk-ivs-multitarck-video');
+// Hardcoded to us-east-1 because IVS service is only available in specific regions
+const stack = new Stack(app, 'aws-cdk-ivs-multitarck-video', {
+  env: { region: 'us-east-1' },
+});
 
 new ivs.Channel(stack, 'ChannelWithMultitrackVideo', {
   type: ivs.ChannelType.STANDARD,


### PR DESCRIPTION
- Fixed integ.ivs-multitrack-video.ts and integ.ivs-insecure-ingest.ts
- Added env: { region: 'us-east-1' } to stack configuration
- IVS service is only available in specific regions

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
