### PR TITLE
fix(ivs-alpha): add region constraints to integration tests

### DIFF
--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-channel-advanced.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-channel-advanced.ts
@@ -22,6 +22,7 @@ const standardChannelWithPresetSetting = new ivs.Channel(stack, 'StandardChannel
 
 const test = new integ.IntegTest(app, 'ivs-test', {
   testCases: [stack],
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-south-1'], // IVS is only available in these regions
 });
 
 test.assertions.awsApiCall('IVS', 'GetChannel', {

--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-insecure-ingest.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-insecure-ingest.ts
@@ -13,4 +13,5 @@ new ivs.Channel(stack, 'ChannelInsecureIngestEnabled', {
 
 new integ.IntegTest(app, 'ivs-insecure-ingest-test', {
   testCases: [stack],
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-south-1'], // IVS is only available in these regions
 });

--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-multitrack-video.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-multitrack-video.ts
@@ -17,4 +17,5 @@ new ivs.Channel(stack, 'ChannelWithMultitrackVideo', {
 
 new integ.IntegTest(app, 'aws-cdk-ivs-multitarck-video-test', {
   testCases: [stack],
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-south-1'], // IVS is only available in these regions
 });

--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-recording-configuration.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs-recording-configuration.ts
@@ -34,4 +34,5 @@ new Channel(stack, 'Channel', {
 
 new integ.IntegTest(app, 'ivs-recording-configuration-test', {
   testCases: [stack],
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-south-1'], // IVS is only available in these regions
 });

--- a/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs.ts
+++ b/packages/@aws-cdk/aws-ivs-alpha/test/integ.ivs.ts
@@ -67,6 +67,7 @@ new AllProperties(stack, 'AllProperties');
 
 new IntegTest(app, 'ivs-test', {
   testCases: [stack],
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-south-1'], // IVS is only available in these regions
 });
 
 app.synth();


### PR DESCRIPTION

### Issue # (if applicable)

NA

### Reason for this change

Fix integ tests

### Description of changes

IVS service is only available in specific regions: us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1, ap-northeast-2, ap-south-1.

Added region constraints to all IVS integration tests to prevent deployment failures in unsupported regions.


### Describe any new or updated permissions being added

None

### Description of how you validated changes

Deployed integ tests

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
