### PR TITLE
feat(ec2): add C8a instance class

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.c8a-instance.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.c8a-instance.ts
@@ -1,0 +1,25 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { App, Stack } from 'aws-cdk-lib';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+
+const app = new App();
+const stack = new Stack(app, 'C8aInstanceStack');
+
+const vpc = new ec2.Vpc(stack, 'VPC', {
+  maxAzs: 2,
+  natGateways: 0,
+});
+
+// Create instance using C8A instance class
+new ec2.Instance(stack, 'C8aInstance', {
+  vpc,
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.C8A, ec2.InstanceSize.LARGE),
+  machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+  vpcSubnets: {
+    subnetType: ec2.SubnetType.PUBLIC,
+  },
+});
+
+new IntegTest(app, 'C8aInstanceTest', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1362,6 +1362,13 @@ new ec2.Instance(this, 'Instance5', {
     cpuType: ec2.AmazonLinuxCpuType.ARM_64,
   }),
 });
+
+// AMD EPYC 5th Gen (Turin) Processor
+new ec2.Instance(this, 'Instance6', {
+  vpc,
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.C8A, ec2.InstanceSize.LARGE),
+  machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+});
 ```
 
 ### Latest Amazon Linux Images

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
@@ -783,6 +783,16 @@ export enum InstanceClass {
   C8I_FLEX = 'c8i-flex',
 
   /**
+   * Compute optimized instances based on 5th generation AMD EPYC (codename Turin), 8th generation
+   */
+  COMPUTE8_AMD = 'compute8-amd',
+
+  /**
+   * Compute optimized instances based on 5th generation AMD EPYC (codename Turin), 8th generation
+   */
+  C8A = 'c8a',
+
+  /**
    * Compute optimized instances based on 4th generation AMD EPYC (codename Genoa), 7th generation
    */
   COMPUTE7_AMD = 'compute7-amd',

--- a/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
@@ -5,4 +5,23 @@ describe('InstanceType', () => {
     const instanceType = InstanceType.of(InstanceClass.MAC2_M1ULTRA, InstanceSize.METAL);
     expect(instanceType.toString()).toEqual('mac2-m1ultra.metal');
   });
+
+  test('c8a instance types', () => {
+    const c8aLarge = InstanceType.of(InstanceClass.C8A, InstanceSize.LARGE);
+    expect(c8aLarge.toString()).toEqual('c8a.large');
+
+    const c8aXlarge = InstanceType.of(InstanceClass.C8A, InstanceSize.XLARGE);
+    expect(c8aXlarge.toString()).toEqual('c8a.xlarge');
+
+    const c8a2xlarge = InstanceType.of(InstanceClass.C8A, InstanceSize.XLARGE2);
+    expect(c8a2xlarge.toString()).toEqual('c8a.2xlarge');
+  });
+
+  test('compute8-amd instance types', () => {
+    const compute8AmdLarge = InstanceType.of(InstanceClass.COMPUTE8_AMD, InstanceSize.LARGE);
+    expect(compute8AmdLarge.toString()).toEqual('compute8-amd.large');
+
+    const compute8AmdXlarge = InstanceType.of(InstanceClass.COMPUTE8_AMD, InstanceSize.XLARGE);
+    expect(compute8AmdXlarge.toString()).toEqual('compute8-amd.xlarge');
+  });
 });


### PR DESCRIPTION
## Description

Adds support for C8a compute-optimized instances based on 5th generation AMD EPYC (codename Turin) processors announced by AWS in December 2025.

## Changes

- Added `COMPUTE8_AMD` and `C8A` constants to the `InstanceClass` enum in `packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts`

## Usage

Users can now create EC2 instances using the C8a instance family:

```typescript
new ec2.Instance(this, 'Instance', {
  instanceType: ec2.InstanceType.of(ec2.InstanceClass.C8A, ec2.InstanceSize.XLARGE),
  // ... other properties
});
```

Closes #36722

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*