### PR TITLE
fix(cloudfront-origins): add InvokeFunction permission for Lambda FURL OAC

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/function-url-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/function-url-origin.ts
@@ -143,12 +143,23 @@ class FunctionUrlOriginWithOAC extends cloudfront.OriginBase {
 
   private addInvokePermission(scope: Construct, options: cloudfront.OriginBindOptions) {
     const distributionId = options.distributionId;
+    const sourceArn = `arn:${cdk.Aws.PARTITION}:cloudfront::${cdk.Aws.ACCOUNT_ID}:distribution/${distributionId}`;
 
-    new lambda.CfnPermission(scope, `InvokeFromApiFor${options.originId}`, {
+    // Grant lambda:InvokeFunctionUrl permission
+    new lambda.CfnPermission(scope, `InvokeFunctionUrlFor${options.originId}`, {
       principal: 'cloudfront.amazonaws.com',
       action: 'lambda:InvokeFunctionUrl',
       functionName: this.functionUrl.functionArn,
-      sourceArn: `arn:${cdk.Aws.PARTITION}:cloudfront::${cdk.Aws.ACCOUNT_ID}:distribution/${distributionId}`,
+      sourceArn,
+    });
+
+    // Grant lambda:InvokeFunction permission for Dual Auth requirement
+    // See: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html
+    new lambda.CfnPermission(scope, `InvokeFunctionFor${options.originId}`, {
+      principal: 'cloudfront.amazonaws.com',
+      action: 'lambda:InvokeFunction',
+      functionName: this.functionUrl.functionArn,
+      sourceArn,
     });
   }
 

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/test/function-url-origin.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/test/function-url-origin.test.ts
@@ -72,7 +72,7 @@ test('Correctly sets readTimeout and keepaliveTimeout', () => {
 });
 
 describe('FunctionUrlOriginAccessControl', () => {
-  test('Correctly adds permission to Lambda for CloudFront', () => {
+  test('Correctly adds both InvokeFunctionUrl and InvokeFunction permissions for Dual Auth', () => {
     const fn = new lambda.Function(stack, 'MyFunction', {
       code: lambda.Code.fromInline('exports.handler = async () => {};'),
       handler: 'index.handler',
@@ -119,8 +119,31 @@ describe('FunctionUrlOriginAccessControl', () => {
       },
     });
 
+    // Verify lambda:InvokeFunctionUrl permission is granted
     template.hasResourceProperties('AWS::Lambda::Permission', {
       Action: 'lambda:InvokeFunctionUrl',
+      FunctionName: {
+        'Fn::GetAtt': ['MyFunctionFunctionUrlFF6DE78C', 'FunctionArn'],
+      },
+      Principal: 'cloudfront.amazonaws.com',
+      SourceArn: {
+        'Fn::Join': [
+          '',
+          [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':cloudfront::',
+            { Ref: 'AWS::AccountId' },
+            ':distribution/',
+            { Ref: 'MyDistribution6271DFB5' },
+          ],
+        ],
+      },
+    });
+
+    // Verify lambda:InvokeFunction permission is also granted for Dual Auth requirement
+    template.hasResourceProperties('AWS::Lambda::Permission', {
+      Action: 'lambda:InvokeFunction',
       FunctionName: {
         'Fn::GetAtt': ['MyFunctionFunctionUrlFF6DE78C', 'FunctionArn'],
       },


### PR DESCRIPTION
## Description

Adds the required `lambda:InvokeFunction` permission for CloudFront to invoke Lambda Function URLs with Origin Access Control, ensuring compliance with AWS Lambda's Dual Authentication requirement.

## Problem

AWS Lambda introduced [Dual Authentication for Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html), requiring **both** `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions for invocation.

When using `FunctionUrlOrigin.withOriginAccessControl()`, the generated resource-based policy only granted `lambda:InvokeFunctionUrl`, missing the required `lambda:InvokeFunction` permission.

AWS is providing a temporary grace period until **November 1, 2026**, after which CloudFront will fail to invoke Function URLs without both permissions.

## Solution

Modified `addInvokePermission` method to grant both required permissions:
1. `lambda:InvokeFunctionUrl` (existing)
2. `lambda:InvokeFunction` (new, required for Dual Auth)

Both permissions are granted to the CloudFront service principal with appropriate source ARN conditions.

## Changes

- Updated `packages/aws-cdk-lib/aws-cloudfront-origins/lib/function-url-origin.ts` to add second `CfnPermission` for `lambda:InvokeFunction`

Closes #35872

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*