### PR TITLE
fix(ecs): restore -EnableTaskIAMRole for Windows container hosts

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -807,7 +807,7 @@ export class Cluster extends Resource implements ICluster {
       autoScalingGroup.addUserData('[Environment]::SetEnvironmentVariable("ECS_ENABLE_SPOT_INSTANCE_DRAINING", "true", "Machine")');
     }
 
-    autoScalingGroup.addUserData(`Initialize-ECSAgent -Cluster '${this.clusterName}'`);
+    autoScalingGroup.addUserData(`Initialize-ECSAgent -Cluster '${this.clusterName}' -EnableTaskIAMRole`);
   }
 
   /**
@@ -1852,13 +1852,13 @@ export class ManagedInstancesCapacityProvider extends Construct implements ec2.I
   ): CfnCapacityProvider.InstanceRequirementsRequestProperty {
     // Validate that allowedInstanceTypes and excludedInstanceTypes are not both specified
     if (instanceRequirements.allowedInstanceTypes && instanceRequirements.allowedInstanceTypes.length > 0 &&
-        instanceRequirements.excludedInstanceTypes && instanceRequirements.excludedInstanceTypes.length > 0) {
+      instanceRequirements.excludedInstanceTypes && instanceRequirements.excludedInstanceTypes.length > 0) {
       throw new ValidationError('Cannot specify both allowedInstanceTypes and excludedInstanceTypes. Use one or the other.', this);
     }
 
     // Validate that spotMaxPricePercentageOverLowestPrice and onDemandMaxPricePercentageOverLowestPrice are not both specified
     if (instanceRequirements.spotMaxPricePercentageOverLowestPrice !== undefined &&
-        instanceRequirements.onDemandMaxPricePercentageOverLowestPrice !== undefined) {
+      instanceRequirements.onDemandMaxPricePercentageOverLowestPrice !== undefined) {
       throw new ValidationError('Cannot specify both spotMaxPricePercentageOverLowestPrice and onDemandMaxPricePercentageOverLowestPrice. Use one or the other.', this);
     }
 
@@ -1872,25 +1872,25 @@ export class ManagedInstancesCapacityProvider extends Construct implements ec2.I
         max: instanceRequirements.memoryMax?.toMebibytes(),
       },
       acceleratorCount: (instanceRequirements.acceleratorCountMin !== undefined ||
-          instanceRequirements.acceleratorCountMax !== undefined) ? {
-          min: instanceRequirements.acceleratorCountMin,
-          max: instanceRequirements.acceleratorCountMax,
-        } : undefined,
+        instanceRequirements.acceleratorCountMax !== undefined) ? {
+        min: instanceRequirements.acceleratorCountMin,
+        max: instanceRequirements.acceleratorCountMax,
+      } : undefined,
       acceleratorManufacturers: instanceRequirements.acceleratorManufacturers?.map(m => m.toString()),
       acceleratorNames: instanceRequirements.acceleratorNames?.map(n => n.toString()),
       acceleratorTotalMemoryMiB: (instanceRequirements.acceleratorTotalMemoryMin !== undefined ||
-          instanceRequirements.acceleratorTotalMemoryMax !== undefined) ? {
-          min: instanceRequirements.acceleratorTotalMemoryMin?.toMebibytes(),
-          max: instanceRequirements.acceleratorTotalMemoryMax?.toMebibytes(),
-        } : undefined,
+        instanceRequirements.acceleratorTotalMemoryMax !== undefined) ? {
+        min: instanceRequirements.acceleratorTotalMemoryMin?.toMebibytes(),
+        max: instanceRequirements.acceleratorTotalMemoryMax?.toMebibytes(),
+      } : undefined,
       acceleratorTypes: instanceRequirements.acceleratorTypes?.map(t => t.toString()),
       allowedInstanceTypes: instanceRequirements.allowedInstanceTypes,
       bareMetal: instanceRequirements.bareMetal?.toString(),
       baselineEbsBandwidthMbps: (instanceRequirements.baselineEbsBandwidthMbpsMin !== undefined ||
-          instanceRequirements.baselineEbsBandwidthMbpsMax !== undefined) ? {
-          min: instanceRequirements.baselineEbsBandwidthMbpsMin,
-          max: instanceRequirements.baselineEbsBandwidthMbpsMax,
-        } : undefined,
+        instanceRequirements.baselineEbsBandwidthMbpsMax !== undefined) ? {
+        min: instanceRequirements.baselineEbsBandwidthMbpsMin,
+        max: instanceRequirements.baselineEbsBandwidthMbpsMax,
+      } : undefined,
       burstablePerformance: instanceRequirements.burstablePerformance?.toString(),
       cpuManufacturers: instanceRequirements.cpuManufacturers?.map(m => m.toString()),
       excludedInstanceTypes: instanceRequirements.excludedInstanceTypes,
@@ -1900,28 +1900,28 @@ export class ManagedInstancesCapacityProvider extends Construct implements ec2.I
       maxSpotPriceAsPercentageOfOptimalOnDemandPrice:
         instanceRequirements.maxSpotPriceAsPercentageOfOptimalOnDemandPrice,
       memoryGiBPerVCpu: (instanceRequirements.memoryPerVCpuMin !== undefined ||
-          instanceRequirements.memoryPerVCpuMax !== undefined) ? {
-          min: instanceRequirements.memoryPerVCpuMin?.toGibibytes(),
-          max: instanceRequirements.memoryPerVCpuMax?.toGibibytes(),
-        } : undefined,
+        instanceRequirements.memoryPerVCpuMax !== undefined) ? {
+        min: instanceRequirements.memoryPerVCpuMin?.toGibibytes(),
+        max: instanceRequirements.memoryPerVCpuMax?.toGibibytes(),
+      } : undefined,
       networkBandwidthGbps: (instanceRequirements.networkBandwidthGbpsMin !== undefined ||
-          instanceRequirements.networkBandwidthGbpsMax !== undefined) ? {
-          min: instanceRequirements.networkBandwidthGbpsMin,
-          max: instanceRequirements.networkBandwidthGbpsMax,
-        } : undefined,
+        instanceRequirements.networkBandwidthGbpsMax !== undefined) ? {
+        min: instanceRequirements.networkBandwidthGbpsMin,
+        max: instanceRequirements.networkBandwidthGbpsMax,
+      } : undefined,
       networkInterfaceCount: (instanceRequirements.networkInterfaceCountMin !== undefined ||
-          instanceRequirements.networkInterfaceCountMax !== undefined) ? {
-          min: instanceRequirements.networkInterfaceCountMin,
-          max: instanceRequirements.networkInterfaceCountMax,
-        } : undefined,
+        instanceRequirements.networkInterfaceCountMax !== undefined) ? {
+        min: instanceRequirements.networkInterfaceCountMin,
+        max: instanceRequirements.networkInterfaceCountMax,
+      } : undefined,
       onDemandMaxPricePercentageOverLowestPrice: instanceRequirements.onDemandMaxPricePercentageOverLowestPrice,
       requireHibernateSupport: instanceRequirements.requireHibernateSupport,
       spotMaxPricePercentageOverLowestPrice: instanceRequirements.spotMaxPricePercentageOverLowestPrice,
       totalLocalStorageGb: (instanceRequirements.totalLocalStorageGBMin !== undefined ||
-          instanceRequirements.totalLocalStorageGBMax !== undefined) ? {
-          min: instanceRequirements.totalLocalStorageGBMin,
-          max: instanceRequirements.totalLocalStorageGBMax,
-        } : undefined,
+        instanceRequirements.totalLocalStorageGBMax !== undefined) ? {
+        min: instanceRequirements.totalLocalStorageGBMin,
+        max: instanceRequirements.totalLocalStorageGBMax,
+      } : undefined,
     };
   }
 }
@@ -2047,7 +2047,7 @@ class MaybeCreateCapacityProviderAssociations implements IAspect {
   public visit(node: IConstruct): void {
     if (Cluster.isCluster(node)) {
       if ((this.scope.defaultCapacityProviderStrategy.length > 0
-          || (this.scope.capacityProviderNames.length > 0) && !this.resource)) {
+        || (this.scope.capacityProviderNames.length > 0) && !this.resource)) {
         this.resource = new CfnClusterCapacityProviderAssociations(this.scope, this.id, {
           cluster: node.clusterName,
           defaultCapacityProviderStrategy: this.scope.defaultCapacityProviderStrategy,

--- a/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts
@@ -984,7 +984,7 @@ describe('cluster', () => {
               {
                 Ref: 'EcsCluster97242B84',
               },
-              "'</powershell>",
+              "' -EnableTaskIAMRole</powershell>",
             ],
           ],
         },


### PR DESCRIPTION
# PR: fix(ecs): restore -EnableTaskIAMRole for Windows container hosts

## Issue Reference
Fixes #36805

---

## Summary

This PR restores the `-EnableTaskIAMRole` parameter to the `Initialize-ECSAgent` PowerShell command for Windows ECS container hosts. Without this parameter, Windows container instances fail to support Task IAM Roles.

---

## Problem Description

### Observed Behavior
- Windows ECS container hosts appear to register with the ECS cluster successfully
- However, they lack the `com.amazonaws.ecs.capability.task-iam-role` attribute
- Tasks requiring IAM roles fail with `TaskFailedToStart: ATTRIBUTE` error
- Clusters enter a "hung state" as old instances cannot drain properly because new instances cannot accept tasks requiring IAM roles

### Impact
- **Severity**: P1 - Critical production issue
- **Affected Versions**: CDK 2.235.1 and later (last known working: 2.32.2)
- **Scope**: All Windows ECS container hosts created via CDK

### Error Example
```
TaskFailedToStart: ATTRIBUTE - Cannot find instances with 
com.amazonaws.ecs.capability.task-iam-role capability
```

---

## Root Cause Analysis

The `Initialize-ECSAgent` PowerShell command in `configureWindowsAutoScalingGroup()` was missing the `-EnableTaskIAMRole` parameter.

### Location
- **File**: `packages/aws-cdk-lib/aws-ecs/lib/cluster.ts`
- **Function**: `configureWindowsAutoScalingGroup()`
- **Line**: 810

### Before (Broken)
```typescript
autoScalingGroup.addUserData(`Initialize-ECSAgent -Cluster '${this.clusterName}'`);
```

### After (Fixed)
```typescript
autoScalingGroup.addUserData(`Initialize-ECSAgent -Cluster '${this.clusterName}' -EnableTaskIAMRole`);
```

---

## Solution

Added the `-EnableTaskIAMRole` parameter to the `Initialize-ECSAgent` command. This parameter:

1. Configures the ECS Agent to support Task IAM Roles
2. Sets up the Task IAM Role credential provider on port 80
3. Enables the `com.amazonaws.ecs.capability.task-iam-role` capability attribute

---

## Changes Made

### 1. `packages/aws-cdk-lib/aws-ecs/lib/cluster.ts`
- Added `-EnableTaskIAMRole` to the `Initialize-ECSAgent` command

### 2. `packages/aws-cdk-lib/aws-ecs/test/cluster.test.ts`
- Updated test expectations to include the new parameter in UserData validation

---

## Testing

### Unit Tests
- Updated the Windows PowerShell UserData test to expect `-EnableTaskIAMRole`
- All existing ECS cluster tests pass

### Manual Verification Steps
1. Deploy a Windows ECS cluster using CDK
2. Launch a Windows container instance
3. Verify the instance has `com.amazonaws.ecs.capability.task-iam-role` attribute:
   ```bash
   aws ecs describe-container-instances \
     --cluster <cluster-name> \
     --container-instances <instance-arn> \
     --query 'containerInstances[0].attributes[?name==`com.amazonaws.ecs.capability.task-iam-role`]'
   ```
4. Deploy a task with a Task IAM Role
5. Verify the task starts successfully

---

## References

- [AWS ECS Task IAM Roles Documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
- [Windows ECS Agent Configuration](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
- [ECSTools PowerShell Module](https://github.com/aws/amazon-ecs-agent/blob/master/misc/bootstrap-windows/AmazonECSAgent.ECSTools.ps1)

---

## Checklist

- [x] Fix applied to source code
- [x] Unit tests updated
- [x] Documentation reviewed
- [ ] Integration test (exemption requested - existing integ tests cover Windows ECS)
- [x] Backwards compatible (additive change only)

---

## Breaking Changes

**None** - This is an additive fix that restores expected functionality.

---

## Exemption Request

This PR requests an exemption from the integration test requirement because:

1. The fix is a single-line addition to restore a missing parameter
2. Existing Windows ECS integration tests cover the general functionality
3. The change is additive and does not modify any existing behavior
4. The unit test has been updated to validate the new parameter

The integration test infrastructure for Windows ECS is complex and this specific parameter is difficult to validate without a full Windows ECS environment.
