### PR TITLE
fix(mixins-preview): apply mixins in order in `MixinApplicator`

### DIFF
--- a/packages/@aws-cdk/mixins-preview/lib/core/applicator.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/core/applicator.ts
@@ -58,8 +58,10 @@ export class MixinApplicator {
    */
   public apply(...mixins: IMixin[]): this {
     const applications: MixinApplication[] = [];
-    for (const construct of this.selectedConstructs) {
-      for (const mixin of mixins) {
+
+    const allConstructs = Array.from(this.selectedConstructs);
+    for (const mixin of mixins) {
+      for (const construct of allConstructs) {
         if (mixin.supports(construct)) {
           applyMixin(construct, mixin);
           applications.push({ construct, mixin });

--- a/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
@@ -1,4 +1,4 @@
-import { Construct, IConstruct } from 'constructs';
+import { Construct, type IConstruct } from 'constructs';
 import { Stack, App } from 'aws-cdk-lib/core';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as logs from 'aws-cdk-lib/aws-logs';
@@ -7,6 +7,12 @@ import {
   Mixin,
   Mixins,
 } from '../../lib/core';
+
+class Root extends Construct {
+  constructor() {
+    super(undefined as any, '');
+  }
+}
 
 class TestConstruct extends Construct {
   constructor(scope: Construct, id: string) {
@@ -148,7 +154,7 @@ describe('Core Mixins Framework', () => {
     });
 
     test('applies mixins in order, completing each mixin before the next', () => {
-      const root = new RootApp();
+      const root = new Root();
       new Construct(root, 'child');
 
       const order: string[] = [];
@@ -167,7 +173,7 @@ describe('Core Mixins Framework', () => {
     });
 
     test('does not apply mixins to constructs added by other mixins', () => {
-      const root = new RootApp();
+      const root = new Root();
 
       const applied: string[] = [];
       const addingMixin = {
@@ -202,15 +208,3 @@ describe('Core Mixins Framework', () => {
     });
   });
 });
-
-export class RootConstruct extends Construct {
-  constructor(id?: string) {
-    super(undefined as any, id ?? '');
-  }
-}
-
-export class RootApp extends RootConstruct {
-  constructor() {
-    super();
-  }
-}

--- a/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/core/mixins.test.ts
@@ -1,4 +1,4 @@
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import { Stack, App } from 'aws-cdk-lib/core';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as logs from 'aws-cdk-lib/aws-logs';
@@ -146,6 +146,44 @@ describe('Core Mixins Framework', () => {
 
       expect(applicator.report).toEqual([{ construct: bucket, mixin }]);
     });
+
+    test('applies mixins in order, completing each mixin before the next', () => {
+      const root = new RootApp();
+      new Construct(root, 'child');
+
+      const order: string[] = [];
+      const mixin1 = {
+        supports: () => true,
+        applyTo: (c: IConstruct) => order.push(`m1:${c.node.id || 'root'}`),
+      };
+      const mixin2 = {
+        supports: () => true,
+        applyTo: (c: IConstruct) => order.push(`m2:${c.node.id || 'root'}`),
+      };
+
+      Mixins.of(root).apply(mixin1, mixin2);
+
+      expect(order).toEqual(['m1:root', 'm1:child', 'm2:root', 'm2:child']);
+    });
+
+    test('does not apply mixins to constructs added by other mixins', () => {
+      const root = new RootApp();
+
+      const applied: string[] = [];
+      const addingMixin = {
+        supports: (c: IConstruct) => c.node.id === '',
+        applyTo: (c: IConstruct) => new Construct(c, 'added-by-mixin'),
+      };
+      const trackingMixin = {
+        supports: () => true,
+        applyTo: (c: IConstruct) => applied.push(c.node.id || 'root'),
+      };
+
+      Mixins.of(root).apply(addingMixin, trackingMixin);
+
+      expect(applied).toEqual(['root']);
+      expect(root.node.findChild('added-by-mixin')).toBeDefined();
+    });
   });
 
   describe('Mixin base class', () => {
@@ -164,3 +202,15 @@ describe('Core Mixins Framework', () => {
     });
   });
 });
+
+export class RootConstruct extends Construct {
+  constructor(id?: string) {
+    super(undefined as any, id ?? '');
+  }
+}
+
+export class RootApp extends RootConstruct {
+  constructor() {
+    super();
+  }
+}


### PR DESCRIPTION
### Issue # (if applicable)

### Reason for this change

<!--What is the bug or use case behind this change?-->

The `MixinApplicator.apply()` method has the same loop order issue that was fixed for `.with()` in #36847.

According to the [README](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/mixins-preview/README.md#fluent-syntax-with-with), `.with()` and `Mixins.of().apply()` provide the same functionality:

> The `.with()` method is available after importing `@aws-cdk/mixins-preview/with`, which augments all constructs with this method. It provides the same functionality as `Mixins.of().apply()` but with a more chainable API.

However, #36847 fixed the loop order for `.with()` but did not update `Mixins.of().apply()`, causing inconsistent behavior between the two APIs.

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

Unit tests.

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
