### PR TITLE
feat(step-functions): add `Jsonata` class with helper methods for typed JSONata expressions

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/test/batch/submit-job.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/test/batch/submit-job.test.ts
@@ -590,3 +590,25 @@ test('supports passing jobQueueArn as JsonPath or JSONata', () => {
     },
   });
 });
+
+test('BatchSubmitJob.jsonata with Jsonata.numberAt for arraySize', () => {
+  // WHEN
+  const task = BatchSubmitJob.jsonata(stack, 'Task', {
+    jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+    jobName: 'myJob',
+    jobQueueArn: batchJobQueue.jobQueueArn,
+    arraySize: sfn.Jsonata.numberAt('$states.input.batchSize'),
+  });
+
+  // THEN
+  expect(stack.resolve(task.toStateJson())).toMatchObject({
+    Type: 'Task',
+    QueryLanguage: 'JSONata',
+    Resource: expect.any(Object),
+    Arguments: {
+      ArrayProperties: {
+        Size: '{% $states.input.batchSize %}',
+      },
+    },
+  });
+});

--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/private/jsonata.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/private/jsonata.ts
@@ -1,3 +1,6 @@
+import type { IResolvable, IResolveContext } from '../../../core';
+import { captureStackTrace, Token, UnscopedValidationError } from '../../../core';
+
 export const isValidJsonataExpression = (expression: string) => /^{%(.*)%}$/s.test(expression);
 
 export const findJsonataExpressions = (value: any): Set<string> => {
@@ -16,3 +19,59 @@ export const findJsonataExpressions = (value: any): Set<string> => {
   };
   return new Set(recursive(value));
 };
+
+const JSONATA_TOKEN_SYMBOL = Symbol.for('@aws-cdk/aws-stepfunctions.JsonataToken');
+
+/**
+ * A Token that represents a JSONata expression.
+ *
+ * When resolved, the expression is wrapped in `{% ... %}` delimiters.
+ */
+export class JsonataToken implements IResolvable {
+  /**
+   * Check if a value is a JsonataToken
+   */
+  public static isJsonataToken(x: IResolvable): x is JsonataToken {
+    return (x as any)[JSONATA_TOKEN_SYMBOL] === true;
+  }
+
+  public readonly creationStack: string[];
+  public displayHint: string;
+
+  constructor(public readonly expression: string) {
+    this.creationStack = captureStackTrace();
+    this.displayHint = expression.replace(/^[^a-zA-Z]+/, '');
+    Object.defineProperty(this, JSONATA_TOKEN_SYMBOL, { value: true });
+  }
+
+  public resolve(_ctx: IResolveContext): string {
+    // Wrap the expression in JSONata delimiters
+    return `{% ${this.expression} %}`;
+  }
+
+  public toString(): string {
+    return Token.asString(this, { displayHint: this.displayHint });
+  }
+
+  public toJSON(): string {
+    return `<jsonata:${this.expression}>`;
+  }
+}
+
+/**
+ * Validates that the expression is a valid JSONata expression.
+ * The expression should NOT include the {% %} delimiters.
+ */
+export function validateJsonataExpression(expression: string): void {
+  if (!expression || expression.trim() === '') {
+    throw new UnscopedValidationError('JSONata expression cannot be empty');
+  }
+
+  // Check if user accidentally included the delimiters
+  if (expression.startsWith('{%') || expression.endsWith('%}')) {
+    throw new UnscopedValidationError(
+      'JSONata expression should not include {% %} delimiters. ' +
+      `Received: ${expression}. Use just the expression, e.g., '$states.input.value'`,
+    );
+  }
+}

--- a/packages/aws-cdk-lib/aws-stepfunctions/test/private/jsonata.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/test/private/jsonata.test.ts
@@ -1,4 +1,5 @@
-import { findJsonataExpressions, isValidJsonataExpression } from '../../lib/private/jsonata';
+import { Stack, Tokenization } from '../../../core';
+import { findJsonataExpressions, isValidJsonataExpression, JsonataToken, validateJsonataExpression } from '../../lib/private/jsonata';
 
 describe('jsonata', () => {
   describe('isValidJsonataExpression', () => {
@@ -42,6 +43,76 @@ describe('jsonata', () => {
           %}`,
         ]);
       });
+    });
+  });
+
+  describe('JsonataToken', () => {
+    test('resolve wraps expression in {% %} delimiters', () => {
+      const token = new JsonataToken('$states.input.count');
+      const stack = new Stack();
+      const resolved = stack.resolve(token);
+      expect(resolved).toBe('{% $states.input.count %}');
+    });
+
+    test('toString returns a string token', () => {
+      const token = new JsonataToken('$states.input.name');
+      const str = token.toString();
+      expect(typeof str).toBe('string');
+      // The string should be a token that can be resolved
+      expect(Tokenization.isResolvable(token)).toBe(true);
+    });
+
+    test('toJSON returns a descriptive string', () => {
+      const token = new JsonataToken('$states.input.data');
+      expect(token.toJSON()).toBe('<jsonata:$states.input.data>');
+    });
+
+    test('isJsonataToken returns true for JsonataToken instances', () => {
+      const token = new JsonataToken('$states.input.value');
+      expect(JsonataToken.isJsonataToken(token)).toBe(true);
+    });
+
+    test('isJsonataToken returns false for non-JsonataToken objects', () => {
+      const notAToken = { resolve: () => 'test', creationStack: [] };
+      expect(JsonataToken.isJsonataToken(notAToken as any)).toBe(false);
+    });
+
+    test('displayHint strips leading non-alphabetic characters', () => {
+      const token = new JsonataToken('$states.input.value');
+      expect(token.displayHint).toBe('states.input.value');
+    });
+
+    test('creationStack is captured', () => {
+      const token = new JsonataToken('$states.input.value');
+      expect(Array.isArray(token.creationStack)).toBe(true);
+    });
+  });
+
+  describe('validateJsonataExpression', () => {
+    test('accepts valid expressions', () => {
+      expect(() => validateJsonataExpression('$states.input.count')).not.toThrow();
+      expect(() => validateJsonataExpression('$count($states.input.items)')).not.toThrow();
+      expect(() => validateJsonataExpression('$states.input.price * $states.input.quantity')).not.toThrow();
+    });
+
+    test('throws on empty expression', () => {
+      expect(() => validateJsonataExpression('')).toThrow(/cannot be empty/);
+    });
+
+    test('throws on whitespace-only expression', () => {
+      expect(() => validateJsonataExpression('   ')).toThrow(/cannot be empty/);
+    });
+
+    test('throws if expression includes opening delimiter', () => {
+      expect(() => validateJsonataExpression('{% $states.input.count')).toThrow(/should not include/);
+    });
+
+    test('throws if expression includes closing delimiter', () => {
+      expect(() => validateJsonataExpression('$states.input.count %}')).toThrow(/should not include/);
+    });
+
+    test('throws if expression includes both delimiters', () => {
+      expect(() => validateJsonataExpression('{% $states.input.count %}')).toThrow(/should not include/);
     });
   });
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #34228.

### Reason for this change

When using JSONata with Step Functions tasks like `BatchSubmitJob`, properties typed as `number` (such as `arraySize`) cannot accept JSONata expression strings directly, resulting in TypeScript compilation errors. While `JsonPath.numberAt()` exists for JSONPath expressions, there was no equivalent helper for JSONata expressions.

This forces users to use `@ts-expect-error` workarounds, which bypasses type safety and provides a poor developer experience.

### Description of changes

Added a new public `Jsonata` class to the `aws-stepfunctions` module with static helper methods that mirror the existing `JsonPath` class pattern:

- **`Jsonata.numberAt(expression)`** - Returns a number token for JSONata expressions where numbers are expected
- **`Jsonata.stringAt(expression)`** - Returns a string token for JSONata expressions where strings are expected
- **`Jsonata.listAt(expression)`** - Returns a list token for JSONata expressions where lists are expected
- **`Jsonata.objectAt(expression)`** - Returns an IResolvable for JSONata expressions where objects are expected

Implementation details:
- Added `JsonataToken` class (internal) that implements `IResolvable` and wraps expressions with `{% ... %}` delimiters on resolution
- Added `validateJsonataExpression()` function that validates expressions are non-empty and don't include delimiters (which are added automatically)
- Uses CDK's Token system to allow JSONata expressions to satisfy TypeScript type constraints

**Usage example:**

```typescript
import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';

// Before (TypeScript error)
tasks.BatchSubmitJob.jsonata(this, 'Job', {
  jobDefinitionArn: 'arn:aws:batch:...',
  jobName: 'myJob',
  jobQueueArn: 'arn:aws:batch:...',
  arraySize: '{% $states.input.batchSize %}',  // ❌ Type 'string' is not assignable to type 'number'
});

// After (works correctly)
tasks.BatchSubmitJob.jsonata(this, 'Job', {
  jobDefinitionArn: 'arn:aws:batch:...',
  jobName: 'myJob',
  jobQueueArn: 'arn:aws:batch:...',
  arraySize: sfn.Jsonata.numberAt('$states.input.batchSize'),  // ✅ Works!
});
```

### Describe any new or updated permissions being added

N/A - No IAM permission changes. This is a CDK type system enhancement only.

### Description of how you validated changes

- **Unit tests**: Added 18 new unit tests in `fields.test.ts` covering:
  - All four helper methods (`numberAt`, `stringAt`, `listAt`, `objectAt`)
  - Token resolution to correct `{% ... %}` wrapped expressions
  - Validation error cases (empty expressions, expressions with delimiters)
  - Complex JSONata expressions (function calls, arithmetic, string concatenation)
- **Integration tests**: Added test in `submit-job.test.ts` verifying `BatchSubmitJob.jsonata()` correctly accepts `Jsonata.numberAt()` for `arraySize` property

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

[comment]: <> (cdk-contribution-power preview)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

---

## Additional Context

### Related Issues
- #33343 - "(stepfunctions): No replacement for JSONPath.numberAt, etc." - Similar issue for DynamoDB (closed as completed)
- #33793 - "feat(stepfunctions): ResultWriter support JSONPath/JSONata bucket" - Shows pattern for handling JSONPath/JSONata in properties

### Dependencies
No new dependencies added.

### Documentation Updates
- JSDoc comments added to all public methods with usage examples
- Links to AWS documentation for JSONata in Step Functions

### Follow-up Work
This pattern can be applied to other Step Functions task properties that need JSONata support for typed values.

## Review Guidelines

### Focus Areas
1. **API Design**: Verify the `Jsonata` class API mirrors `JsonPath` appropriately
2. **Token Resolution**: Ensure `JsonataToken.resolve()` correctly wraps expressions with `{% ... %}` delimiters
3. **Validation**: Confirm validation catches common user errors (empty expressions, included delimiters)
4. **JSII Compatibility**: All public APIs use JSII-compatible types

### Testing Notes
- All 70 tests in `fields.test.ts` pass
- Integration test in `submit-job.test.ts` verifies end-to-end usage with `BatchSubmitJob`
- No snapshot changes to existing tests (purely additive change)

### Risk Assessment
- **Low Risk**: Purely additive change with no modifications to existing code paths
- **No Breaking Changes**: Existing behavior is completely unchanged
- **Well-Tested**: Comprehensive unit test coverage for all new functionality
