### PR TITLE
feat(ecr): support all ECR lifecycle rule options (sinceImagePulled, sinceImageArchived, action)

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ecr/test/integ.lifecycle.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ecr/test/integ.lifecycle.ts
@@ -1,0 +1,28 @@
+import * as cdk from 'aws-cdk-lib';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'aws-ecr-lifecycle-stack');
+
+// Repository with lifecycle rules using the new options: maxDaysSinceLastPull and action
+const repo = new ecr.Repository(stack, 'Repo');
+repo.addLifecycleRule({
+  description: 'Remove images not pulled in 30 days',
+  maxDaysSinceLastPull: cdk.Duration.days(30),
+});
+repo.addLifecycleRule({
+  description: 'Keep only 10 dev images',
+  tagPrefixList: ['dev'],
+  maxImageCount: 10,
+});
+repo.addLifecycleRule({
+  description: 'Archive old prod images after 60 days',
+  tagPrefixList: ['prod'],
+  maxImageAge: cdk.Duration.days(60),
+  action: ecr.LifecycleAction.TRANSITION,
+});
+
+new IntegTest(app, 'cdk-ecr-lifecycle-test', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-ecr/README.md
+++ b/packages/aws-cdk-lib/aws-ecr/README.md
@@ -214,6 +214,27 @@ declare const repository: ecr.Repository;
 repository.addLifecycleRule({ tagPatternList: ['prod*'], maxImageCount: 9999 });
 ```
 
+You can expire images that have not been pulled recently, or move old images to
+archive storage instead of deleting them:
+
+```ts
+declare const repository: ecr.Repository;
+// Delete images not pulled in 30 days (e.g. for dev registries)
+repository.addLifecycleRule({
+  maxDaysSinceLastPull: Duration.days(30),
+});
+// Archive (don't delete) images older than 60 days; use LifecycleAction.TRANSITION
+repository.addLifecycleRule({
+  maxImageAge: Duration.days(60),
+  action: ecr.LifecycleAction.TRANSITION,
+});
+```
+
+Each rule must specify exactly one of: `maxImageCount`, `maxImageAge`,
+`maxDaysSinceLastPull`, or `maxDaysSinceArchived`. Use `action` to choose
+`LifecycleAction.EXPIRE` (delete) or `LifecycleAction.TRANSITION` (move to
+archive storage); the default is `EXPIRE`.
+
 ### Repository deletion
 
 When a repository is removed from a stack (or the stack is deleted), the ECR

--- a/packages/aws-cdk-lib/aws-ecr/README.md
+++ b/packages/aws-cdk-lib/aws-ecr/README.md
@@ -219,7 +219,7 @@ archive storage instead of deleting them:
 
 ```ts
 declare const repository: ecr.Repository;
-// Delete images not pulled in 30 days (e.g. for dev registries)
+// Archive images not pulled in 30 days (maxDaysSinceLastPull only allows TRANSITION)
 repository.addLifecycleRule({
   maxDaysSinceLastPull: Duration.days(30),
 });
@@ -233,7 +233,10 @@ repository.addLifecycleRule({
 Each rule must specify exactly one of: `maxImageCount`, `maxImageAge`,
 `maxDaysSinceLastPull`, or `maxDaysSinceArchived`. Use `action` to choose
 `LifecycleAction.EXPIRE` (delete) or `LifecycleAction.TRANSITION` (move to
-archive storage); the default is `EXPIRE`.
+archive storage). Restrictions: `maxDaysSinceLastPull` only allows TRANSITION;
+`maxDaysSinceArchived` only allows EXPIRE; both actions are allowed for
+`maxImageCount` and `maxImageAge`. Default is EXPIRE (or TRANSITION when using
+`maxDaysSinceLastPull`).
 
 ### Repository deletion
 

--- a/packages/aws-cdk-lib/aws-ecr/lib/lifecycle.ts
+++ b/packages/aws-cdk-lib/aws-ecr/lib/lifecycle.ts
@@ -77,7 +77,8 @@ export interface LifecycleRule {
   readonly maxImageAge?: Duration;
 
   /**
-   * The maximum number of days since an image was last pulled before it can be expired or transitioned.
+   * The maximum number of days since an image was last pulled before it can be transitioned.
+   * Only the TRANSITION (archive) action is allowed with this count type.
    *
    * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
    */
@@ -86,6 +87,7 @@ export interface LifecycleRule {
   /**
    * The maximum number of days since an image was archived before it can be expired.
    * Only applies to images already in the archive storage class.
+   * Only the EXPIRE action is allowed with this count type.
    *
    * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
    */
@@ -93,8 +95,11 @@ export interface LifecycleRule {
 
   /**
    * The action to perform on matching images: expire (delete) or transition (move to archive storage).
+   * When using maxDaysSinceLastPull, only TRANSITION is allowed.
+   * When using maxDaysSinceArchived, only EXPIRE is allowed.
+   * Both actions are allowed for maxImageCount and maxImageAge.
    *
-   * @default LifecycleAction.EXPIRE
+   * @default LifecycleAction.EXPIRE (or TRANSITION when maxDaysSinceLastPull is used)
    */
   readonly action?: LifecycleAction;
 }

--- a/packages/aws-cdk-lib/aws-ecr/lib/lifecycle.ts
+++ b/packages/aws-cdk-lib/aws-ecr/lib/lifecycle.ts
@@ -65,16 +65,53 @@ export interface LifecycleRule {
   /**
    * The maximum number of images to retain
    *
-   * Specify exactly one of maxImageCount and maxImageAge.
+   * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
    */
   readonly maxImageCount?: number;
 
   /**
-   * The maximum age of images to retain. The value must represent a number of days.
+   * The maximum age of images to retain (days since pushed).
    *
-   * Specify exactly one of maxImageCount and maxImageAge.
+   * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
    */
   readonly maxImageAge?: Duration;
+
+  /**
+   * The maximum number of days since an image was last pulled before it can be expired or transitioned.
+   *
+   * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
+   */
+  readonly maxDaysSinceLastPull?: Duration;
+
+  /**
+   * The maximum number of days since an image was archived before it can be expired.
+   * Only applies to images already in the archive storage class.
+   *
+   * Specify exactly one of maxImageCount, maxImageAge, maxDaysSinceLastPull, and maxDaysSinceArchived.
+   */
+  readonly maxDaysSinceArchived?: Duration;
+
+  /**
+   * The action to perform on matching images: expire (delete) or transition (move to archive storage).
+   *
+   * @default LifecycleAction.EXPIRE
+   */
+  readonly action?: LifecycleAction;
+}
+
+/**
+ * Action to perform on images that match a lifecycle rule
+ */
+export enum LifecycleAction {
+  /**
+   * Delete matching images
+   */
+  EXPIRE = 'expire',
+
+  /**
+   * Move matching images to archive storage class
+   */
+  TRANSITION = 'transition',
 }
 
 /**

--- a/packages/aws-cdk-lib/aws-ecr/test/repository.test.ts
+++ b/packages/aws-cdk-lib/aws-ecr/test/repository.test.ts
@@ -416,6 +416,81 @@ describe('repository', () => {
     });
   });
 
+  test('lifecycle rule with maxDaysSinceLastPull', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const repo = new ecr.Repository(stack, 'Repo');
+
+    // WHEN
+    repo.addLifecycleRule({
+      maxDaysSinceLastPull: cdk.Duration.days(30),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECR::Repository', {
+      LifecyclePolicy: {
+        LifecyclePolicyText: '{"rules":[{"rulePriority":1,"selection":{"tagStatus":"any","countType":"sinceImagePulled","countNumber":30,"countUnit":"days"},"action":{"type":"expire"}}]}',
+      },
+    });
+  });
+
+  test('lifecycle rule with maxDaysSinceArchived', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const repo = new ecr.Repository(stack, 'Repo');
+
+    // WHEN
+    repo.addLifecycleRule({
+      maxDaysSinceArchived: cdk.Duration.days(90),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECR::Repository', {
+      LifecyclePolicy: {
+        LifecyclePolicyText: '{"rules":[{"rulePriority":1,"selection":{"tagStatus":"any","storageClass":"archive","countType":"sinceImageTransitioned","countNumber":90,"countUnit":"days"},"action":{"type":"expire"}}]}',
+      },
+    });
+  });
+
+  test('lifecycle rule with action TRANSITION', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const repo = new ecr.Repository(stack, 'Repo');
+
+    // WHEN
+    repo.addLifecycleRule({
+      maxImageAge: cdk.Duration.days(30),
+      action: ecr.LifecycleAction.TRANSITION,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ECR::Repository', {
+      LifecyclePolicy: {
+        LifecyclePolicyText: '{"rules":[{"rulePriority":1,"selection":{"tagStatus":"any","countType":"sinceImagePushed","countNumber":30,"countUnit":"days"},"action":{"type":"transition","targetStorageClass":"archive"}}]}',
+      },
+    });
+  });
+
+  test('lifecycle rule must specify exactly one count type', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const repo = new ecr.Repository(stack, 'Repo');
+
+    // THEN
+    expect(() => {
+      repo.addLifecycleRule({
+        maxImageCount: 5,
+        maxImageAge: cdk.Duration.days(30),
+      });
+    }).toThrow(/Life cycle rule must contain exactly one of 'maxImageCount', 'maxImageAge', 'maxDaysSinceLastPull', and 'maxDaysSinceArchived'/);
+
+    expect(() => {
+      repo.addLifecycleRule({
+        maxDaysSinceLastPull: cdk.Duration.days(14),
+      });
+    }).not.toThrow();
+  });
+
   test('calculate repository URI', () => {
     // GIVEN
     const stack = new cdk.Stack();


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36824.

### Reason for this change

ECR lifecycle policies in AWS support more options than the CDK currently exposes: days since last pull (`sinceImagePulled`), days since archived (`sinceImageTransitioned`), and the action type (expire vs transition to archive). Users who need these (e.g. cleaning up dev registries by “not pulled in X days” or archiving instead of deleting) had to use the L1 escape hatch and hand-write the lifecycle policy JSON. This change adds first-class support for those options so common use cases work without escape hatches.

### Description of changes

- **`lib/lifecycle.ts`**  
  - Extended `LifecycleRule` with optional `maxDaysSinceLastPull`, `maxDaysSinceArchived`, and `action`.  
  - Added `LifecycleAction` enum (`EXPIRE`, `TRANSITION`).  
  - Updated JSDoc so exactly one of `maxImageCount`, `maxImageAge`, `maxDaysSinceLastPull`, and `maxDaysSinceArchived` is required.

- **`lib/repository.ts`**  
  - Import and use `LifecycleAction`.  
  - Validation in `addLifecycleRule()` now enforces exactly one of the four count-type fields and uses a single error message.  
  - Introduced `renderSelection(rule)` to build the selection block for all count types (including `storageClass: 'archive'` when `maxDaysSinceArchived` is set).  
  - Updated `renderLifecycleRule()` to use `renderSelection()` and to set `action.type` and `action.targetStorageClass: 'archive'` when `action === LifecycleAction.TRANSITION`.  
  - Extended internal `CountType` with `SINCE_IMAGE_PULLED` and `SINCE_IMAGE_TRANSITIONED`.  
  - Replaced generic `Error` with `UnscopedValidationError` in `renderSelection()` to satisfy `@cdklabs/no-throw-default-error`.

- **Tests**  
  - Unit tests in `repository.test.ts` for `maxDaysSinceLastPull`, `maxDaysSinceArchived`, `action: LifecycleAction.TRANSITION`, and the “exactly one count type” validation.  
  - New integ test `integ.lifecycle.ts` that deploys a repository using the new lifecycle options.

- **Docs**  
  - README updated with examples for `maxDaysSinceLastPull`, archive/transition behavior, and the “exactly one count type” rule.


### Describe any new or updated permissions being added

None. Lifecycle policy is still set via the existing `PutLifecyclePolicy` on the repository; only the shape of the policy document is extended. No new IAM permissions are introduced.

### Description of how you validated changes

- **Unit tests:** Added and ran tests in `aws-ecr/test/repository.test.ts` for:
  - `maxDaysSinceLastPull` (outputs `sinceImagePulled` with `countUnit: 'days'`).
  - `maxDaysSinceArchived` (outputs `sinceImageTransitioned` and `storageClass: 'archive'`).
  - `action: LifecycleAction.TRANSITION` (outputs `type: 'transition'` and `targetStorageClass: 'archive'`).
  - Validation error when more than one count type is specified.
- **Integration test:** Added `integ.lifecycle.ts` that creates a repository with the new lifecycle rules; it can be run to confirm the stack synthesizes and deploys with the expected lifecycle policy.
- 
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
