### PR TITLE
fix(events): restore `Match.anyOf` support for raw strings

### DIFF
--- a/packages/aws-cdk-lib/aws-events/lib/event-pattern.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-pattern.ts
@@ -226,7 +226,14 @@ export class Match implements IResolvable {
       throw new UnscopedValidationError('A list of matchers must contain at least one element.');
     }
 
-    return matchers.map(match => match.map(Token.asString)).flatMap(a => a);
+    return matchers.flatMap(match => {
+      // If it's already an array (from other Match methods), process each element
+      if (Array.isArray(match)) {
+        return match.map((m: any) => Token.asString(m));
+      }
+      // If it's a raw value (string, number, etc.), wrap it as a single element
+      return [Token.asString(match)];
+    });
   }
 
   private static anythingButConjunction(filterKey: string, values: string[]): string[] {

--- a/packages/aws-cdk-lib/aws-events/test/matchers.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/matchers.test.ts
@@ -113,6 +113,40 @@ describe(Match, () => {
     expect(() => stack.resolve(Match.anyOf())).toThrow(/A list of matchers must contain at least one element/);
   });
 
+  test('anyOf with raw strings', () => {
+    // Test raw strings only (regression test for issue #36902)
+    expect(stack.resolve(Match.anyOf('string1', 'string2'))).toEqual([
+      'string1',
+      'string2',
+    ]);
+
+    // Test single raw string
+    expect(stack.resolve(Match.anyOf('single-string'))).toEqual([
+      'single-string',
+    ]);
+  });
+
+  test('anyOf with mixed inputs', () => {
+    // Test mixed raw strings and Match method results (regression test for issue #36902)
+    expect(stack.resolve(Match.anyOf('raw-string', Match.prefix('pre')))).toEqual([
+      'raw-string',
+      { prefix: 'pre' },
+    ]);
+
+    // Test mixed with multiple Match methods
+    expect(stack.resolve(Match.anyOf('string1', Match.prefix('pre'), Match.suffix('suf')))).toEqual([
+      'string1',
+      { prefix: 'pre' },
+      { suffix: 'suf' },
+    ]);
+
+    // Test mixed with raw string at the end
+    expect(stack.resolve(Match.anyOf(Match.prefix('pre'), 'raw-string'))).toEqual([
+      { prefix: 'pre' },
+      'raw-string',
+    ]);
+  });
+
   test('prefix', () => {
     expect(stack.resolve(Match.prefix('foo'))).toEqual([
       { prefix: 'foo' },


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36902.

### Reason for this change

PR #36602 introduced a regression where `Match.anyOf()` no longer accepts raw strings as arguments. The change assumed all arguments are arrays (results from other Match methods), causing the method to call `.map()` on strings, which fails. Users who previously used `Match.anyOf("string1", "string2")` now get a TypeError.

### Description of changes

Modified the `anyOf()` method in `event-pattern.ts` to handle both raw values (strings, numbers) and arrays (results from other Match methods):

- Added `Array.isArray()` check to detect input type
- Arrays from Match methods are processed with `match.map(Token.asString)`
- Raw values are wrapped as single-element arrays with `[Token.asString(match)]`
- Added unit tests for raw string inputs and mixed inputs

This restores backward compatibility while maintaining the fix from PR #36602 for array inputs.

### Describe any new or updated permissions being added

N/A - No IAM permission changes. This is a CDK API fix that does not affect CloudFormation template generation or resource permissions.

### Description of how you validated changes

- **Unit tests**: Added 2 new test cases in `matchers.test.ts`:
  - `anyOf with raw strings` - Tests `Match.anyOf('string1', 'string2')` and single string inputs
  - `anyOf with mixed inputs` - Tests combinations of raw strings and Match method results
- **Existing tests**: All 39 existing tests continue to pass
- **Build verification**: Module compiles successfully with no linting errors

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

[comment]: <> (cdk-contribution-power preview)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*