### PR TITLE
fix(events): validate against empty arrays in EventPattern at synth time

### DIFF
--- a/packages/aws-cdk-lib/aws-events/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/util.ts
@@ -70,6 +70,12 @@ export function renderEventPattern(eventPattern: EventPattern): any {
     if (key === 'detailType') {
       key = 'detail-type';
     }
+
+    // Validate: EventBridge rejects empty arrays in event patterns
+    if (Array.isArray(value) && value.length === 0) {
+      throw new UnscopedValidationError(`Invalid event pattern field '${key}': empty arrays are not allowed`);
+    }
+
     out[key] = value;
   }
 

--- a/packages/aws-cdk-lib/aws-events/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/util.test.ts
@@ -1,4 +1,4 @@
-import { mergeEventPattern } from '../lib/util';
+import { mergeEventPattern, renderEventPattern } from '../lib/util';
 
 describe('util', () => {
   describe('mergeEventPattern', () => {
@@ -86,6 +86,32 @@ describe('util', () => {
         'detail-type': ['AWS API Call via CloudTrail'],
         'time': [{ prefix: '2017-10-02' }, { prefix: '2017-10-03' }],
       });
+    });
+  });
+
+  describe('renderEventPattern', () => {
+    test('throws on empty source array', () => {
+      expect(() => renderEventPattern({ source: [] }))
+        .toThrow(/Invalid event pattern field 'source': empty arrays are not allowed/);
+    });
+
+    test('throws on empty detailType array and error message uses detail-type', () => {
+      expect(() => renderEventPattern({ detailType: [] }))
+        .toThrow(/Invalid event pattern field 'detail-type': empty arrays are not allowed/);
+    });
+
+    test('does not throw on non-empty arrays', () => {
+      expect(renderEventPattern({ source: ['aws.source'] }))
+        .toEqual({ source: ['aws.source'] });
+    });
+
+    test('returns undefined for empty object', () => {
+      expect(renderEventPattern({})).toBeUndefined();
+    });
+
+    test('does not throw on detail object with arrays', () => {
+      expect(renderEventPattern({ detail: { foo: ['bar'] } }))
+        .toEqual({ detail: { foo: ['bar'] } });
     });
   });
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36904.

### Reason for this change

When an `EventPattern` property (e.g., `detailType`, `source`, `account`) is set to an empty array `[]`, CDK synthesizes the template without error. However, EventBridge rejects empty arrays in event patterns at deploy time, causing a cryptic CloudFormation deployment failure:

```
Resource handler returned message: "Event pattern is not valid. Reason: Empty arrays are not allowed ..."
```

### Description of changes

Added a validation guard in `renderEventPattern()` in `packages/aws-cdk-lib/aws-events/lib/util.ts` that checks for empty arrays in top-level `EventPattern` fields and throws an `UnscopedValidationError` at synth time with a clear, actionable error message:

```
Invalid event pattern field 'detail-type': empty arrays are not allowed
```

This is consistent with existing validation patterns in the same module — for example, `Match.anythingBut()` already throws `UnscopedValidationError` when given an empty list.

The check is placed after the `detailType` → `detail-type` key rename so the error message shows the rendered key name, matching what the user would see in the CloudFormation template.

### Describe any new or updated permissions being added

N/A — no IAM permission changes.

### Description of how you validated changes

Added 5 new unit tests in `packages/aws-cdk-lib/aws-events/test/util.test.ts`:

1. Throws on empty `source` array — validates the core fix
2. Throws on empty `detailType` array with `detail-type` in error message — validates key rename happens before the error
3. Does not throw on non-empty arrays — regression guard for valid patterns
4. Returns `undefined` for empty object — preserves existing behavior
5. Does not throw on `detail` object with arrays — ensures object-typed fields pass through

All 10 tests pass (5 existing `mergeEventPattern` + 5 new `renderEventPattern`).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
```