### PR TITLE
feat(apigateway): added L2 construct support for Routing Rules on custom domain names

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-apigateway/test/integ.routing-rules.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-apigateway/test/integ.routing-rules.ts
@@ -1,0 +1,64 @@
+import * as cdk from 'aws-cdk-lib';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+
+/**
+ * Integration test for API Gateway custom domain routing rules.
+ * Creates a domain with routingMode ROUTING_RULE_ONLY and multiple routing rules
+ * (path-based, header-based, and catch-all).
+ */
+class RoutingRulesStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+
+    const certArn = 'arn:aws:acm:us-east-1:111111111111:certificate/00000000-0000-0000-0000-000000000000';
+    const certificate = acm.Certificate.fromCertificateArn(this, 'Cert', certArn);
+
+    const usersApi = new apigw.RestApi(this, 'UsersApi', { deploy: true });
+    usersApi.root.addMethod('GET');
+
+    const ordersApi = new apigw.RestApi(this, 'OrdersApi', { deploy: true });
+    ordersApi.root.addMethod('GET');
+
+    const defaultApi = new apigw.RestApi(this, 'DefaultApi', { deploy: true });
+    defaultApi.root.addMethod('GET');
+
+    const domainName = `api-${this.stackName.toLowerCase().replace(/[^a-z0-9-]/g, '-')}.example.com`;
+    const domain = new apigw.DomainName(this, 'Domain', {
+      domainName,
+      certificate,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    domain.addRoutingRule('UsersRule', {
+      priority: 100,
+      conditions: { basePaths: ['users'] },
+      action: {
+        restApi: usersApi,
+        stripBasePath: true,
+      },
+    });
+
+    domain.addRoutingRule('HeaderV2Rule', {
+      priority: 50,
+      conditions: {
+        headers: [{ header: 'x-api-version', valueGlob: 'v2' }],
+      },
+      action: { restApi: ordersApi },
+    });
+
+    domain.addRoutingRule('CatchAllRule', {
+      priority: 999999,
+      action: { restApi: defaultApi },
+    });
+  }
+}
+
+const app = new cdk.App();
+const stack = new RoutingRulesStack(app, 'integ-routing-rules');
+
+new IntegTest(app, 'routing-rules', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-apigateway/lib/index.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/index.ts
@@ -16,6 +16,7 @@ export * from './authorizer';
 export * from './json-schema';
 export * from './domain-name';
 export * from './base-path-mapping';
+export * from './routing-rule';
 export * from './cors';
 export * from './authorizers';
 export * from './access-log';

--- a/packages/aws-cdk-lib/aws-apigateway/lib/routing-rule.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/routing-rule.ts
@@ -1,0 +1,229 @@
+import type { Construct } from 'constructs';
+import type { IDomainNameRef, IRestApiRef } from './apigateway.generated';
+import { RestApiBase } from './restapi';
+import type { Stage } from './stage';
+import * as apigwv2 from '../../aws-apigatewayv2';
+import { Resource, Token } from '../../core';
+import { ValidationError } from '../../core/lib/errors';
+import { addConstructMetadata } from '../../core/lib/metadata-resource';
+import { propertyInjectable } from '../../core/lib/prop-injectable';
+
+/**
+ * Routing rule priority. Lower values are evaluated first.
+ * Must be in range 0–999999.
+ */
+const PRIORITY_MIN = 0;
+const PRIORITY_MAX = 999999;
+
+/**
+ * Header name max length and allowed pattern per AWS routing rules restrictions.
+ * Allowed: a-z, A-Z, 0-9, and *?-!#$%&'.^_`|~
+ */
+const HEADER_NAME_MAX_LEN = 40;
+const HEADER_NAME_PATTERN = /^[a-zA-Z0-9*?\-!#$%&'.^_`|~]+$/;
+
+/**
+ * Header value glob max length. Allowed: a-z, A-Z, 0-9, and *?-!#$%&'.^_`|~
+ */
+const VALUE_GLOB_MAX_LEN = 128;
+
+/**
+ * Condition for matching a request in a routing rule.
+ * You can specify base paths, headers, or both (AND logic).
+ */
+export interface RoutingRuleCondition {
+  /**
+   * Base path(s) to match. Request path must match one of these (case-sensitive).
+   * Each base path is a single path segment (e.g. 'users', 'orders').
+   */
+  readonly basePaths?: string[];
+
+  /**
+   * Header condition(s). Request must match at least one of these (anyOf).
+   * Header names are case-insensitive; value globs are case-sensitive.
+   */
+  readonly headers?: RoutingRuleHeaderCondition[];
+}
+
+/**
+ * A header name and value glob to match in a routing rule condition.
+ */
+export interface RoutingRuleHeaderCondition {
+  /**
+   * Case-insensitive header name. Max 40 chars; allowed: a-z, A-Z, 0-9, *?-!#$%&'.^_`|~
+   */
+  readonly header: string;
+
+  /**
+   * Case-sensitive glob for the header value. Max 128 chars.
+   * Supports *prefix*, *suffix*, *infix* style wildcards.
+   */
+  readonly valueGlob: string;
+}
+
+/**
+ * Action for a routing rule: invoke a REST API stage.
+ */
+export interface RoutingRuleAction {
+  /**
+   * The REST API to invoke.
+   */
+  readonly restApi: IRestApiRef;
+
+  /**
+   * The stage to invoke. If omitted, uses the API's deployment stage.
+   */
+  readonly stage?: Stage;
+
+  /**
+   * When true, API Gateway strips the matched base path before forwarding to the target API.
+   * @default false
+   */
+  readonly stripBasePath?: boolean;
+}
+
+/**
+ * Options for adding a routing rule to a domain via DomainName.addRoutingRule().
+ */
+export interface AddRoutingRuleOptions {
+  /**
+   * Priority (0–999999). Lower values are evaluated first.
+   */
+  readonly priority: number;
+
+  /**
+   * Conditions that must match for this rule to apply.
+   * Omit or pass empty for a catch-all rule.
+   */
+  readonly conditions?: RoutingRuleCondition;
+
+  /**
+   * Action to perform when the rule matches.
+   */
+  readonly action: RoutingRuleAction;
+}
+
+export interface RoutingRuleProps {
+  /**
+   * The domain name (or reference) this rule is attached to.
+   */
+  readonly domainName: IDomainNameRef;
+
+  /**
+   * Priority (0–999999). Lower values are evaluated first.
+   */
+  readonly priority: number;
+
+  /**
+   * Conditions that must match for this rule to apply.
+   * Omit or pass empty for a catch-all rule.
+   */
+  readonly conditions?: RoutingRuleCondition;
+
+  /**
+   * Action to perform when the rule matches.
+   */
+  readonly action: RoutingRuleAction;
+}
+
+function validatePriority(priority: number, scope: Construct): void {
+  if (Token.isUnresolved(priority)) return;
+  if (typeof priority !== 'number' || priority < PRIORITY_MIN || priority > PRIORITY_MAX) {
+    throw new ValidationError(
+      `Routing rule priority must be between ${PRIORITY_MIN} and ${PRIORITY_MAX}, got: ${priority}`,
+      scope,
+    );
+  }
+}
+
+function validateHeaderCondition(h: RoutingRuleHeaderCondition, scope: Construct): void {
+  if (Token.isUnresolved(h.header) || Token.isUnresolved(h.valueGlob)) return;
+  if (h.header.length > HEADER_NAME_MAX_LEN) {
+    throw new ValidationError(
+      `Routing rule header name must be at most ${HEADER_NAME_MAX_LEN} characters, got: ${h.header.length}`,
+      scope,
+    );
+  }
+  if (!HEADER_NAME_PATTERN.test(h.header)) {
+    throw new ValidationError(
+      'Routing rule header name may only contain a-z, A-Z, 0-9, and *?-!#$%&\'.^_`|~, got: ' + h.header,
+      scope,
+    );
+  }
+  if (h.valueGlob.length > VALUE_GLOB_MAX_LEN) {
+    throw new ValidationError(
+      `Routing rule header valueGlob must be at most ${VALUE_GLOB_MAX_LEN} characters, got: ${h.valueGlob.length}`,
+      scope,
+    );
+  }
+}
+
+function validateConditions(conditions: RoutingRuleCondition | undefined, scope: Construct): void {
+  if (!conditions) return;
+  if (conditions.headers) {
+    if (conditions.headers.length > 2) {
+      throw new ValidationError('Routing rule may have at most 2 matchHeaders conditions', scope);
+    }
+    conditions.headers.forEach((h) => validateHeaderCondition(h, scope));
+  }
+}
+
+/**
+ * L2 construct for an API Gateway routing rule on a custom domain.
+ * Routes traffic to a REST API stage when conditions (base path and/or headers) match.
+ *
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-routing-rules-use.html
+ */
+@propertyInjectable
+export class RoutingRule extends Resource {
+  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-apigateway.RoutingRule';
+
+  constructor(scope: Construct, id: string, props: RoutingRuleProps) {
+    super(scope, id);
+    addConstructMetadata(this, props);
+
+    validatePriority(props.priority, this);
+    validateConditions(props.conditions, this);
+
+    const domainNameArn = props.domainName.domainNameRef.domainNameArn;
+    const restApi = props.action.restApi;
+    const stage = props.action.stage ?? (restApi instanceof RestApiBase ? restApi.deploymentStage : undefined);
+    if (!stage) {
+      throw new ValidationError(
+        'Routing rule action must specify a stage or use a RestApi with a deployment stage',
+        this,
+      );
+    }
+
+    // One condition object can have both matchBasePaths and matchHeaders (AND logic).
+    const conditionList: apigwv2.CfnRoutingRule.ConditionProperty[] = [
+      {
+        ...(props.conditions?.basePaths?.length
+          ? { matchBasePaths: { anyOf: props.conditions.basePaths } }
+          : {}),
+        ...(props.conditions?.headers?.length
+          ? {
+            matchHeaders: {
+              anyOf: props.conditions.headers.map((h) => ({ header: h.header, valueGlob: h.valueGlob })),
+            },
+          }
+          : {}),
+      },
+    ];
+
+    new apigwv2.CfnRoutingRule(this, 'Resource', {
+      domainNameArn,
+      priority: props.priority,
+      conditions: conditionList,
+      actions: [
+        {
+          invokeApi: {
+            apiId: restApi.restApiRef.restApiId,
+            stage: stage.stageRef.stageName,
+            stripBasePath: props.action.stripBasePath ?? false,
+          },
+        },
+      ],
+    });
+  }
+}

--- a/packages/aws-cdk-lib/aws-apigateway/test/routing-rule.test.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/test/routing-rule.test.ts
@@ -1,0 +1,225 @@
+import { Template } from '../../assertions';
+import * as acm from '../../aws-certificatemanager';
+import { Stack } from '../../core';
+import * as apigw from '../lib';
+
+describe('RoutingRule', () => {
+  test('creates AWS::ApiGatewayV2::RoutingRule with path condition', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    domain.addRoutingRule('UsersRule', {
+      priority: 100,
+      conditions: { basePaths: ['users'] },
+      action: {
+        restApi: api,
+        stripBasePath: true,
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::DomainName', {
+      DomainName: 'api.example.com',
+      RoutingMode: 'ROUTING_RULE_ONLY',
+    });
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::RoutingRule', {
+      Priority: 100,
+      Conditions: [
+        {
+          MatchBasePaths: { AnyOf: ['users'] },
+        },
+      ],
+      Actions: [
+        {
+          InvokeApi: {
+            ApiId: { Ref: 'Api49610EDF' },
+            Stage: { Ref: 'ApiDeploymentStageprodE1054AF0' },
+            StripBasePath: true,
+          },
+        },
+      ],
+    });
+  });
+
+  test('creates routing rule with header condition', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    domain.addRoutingRule('HeaderRule', {
+      priority: 50,
+      conditions: {
+        headers: [{ header: 'x-api-version', valueGlob: 'v2' }],
+      },
+      action: { restApi: api },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::RoutingRule', {
+      Priority: 50,
+      Conditions: [
+        {
+          MatchHeaders: {
+            AnyOf: [{ Header: 'x-api-version', ValueGlob: 'v2' }],
+          },
+        },
+      ],
+    });
+  });
+
+  test('creates routing rule with base path and headers (AND)', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    domain.addRoutingRule('CombinedRule', {
+      priority: 75,
+      conditions: {
+        basePaths: ['orders'],
+        headers: [{ header: 'x-api-version', valueGlob: 'v2' }],
+      },
+      action: { restApi: api, stripBasePath: true },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::RoutingRule', {
+      Priority: 75,
+      Conditions: [
+        {
+          MatchBasePaths: { AnyOf: ['orders'] },
+          MatchHeaders: {
+            AnyOf: [{ Header: 'x-api-version', ValueGlob: 'v2' }],
+          },
+        },
+      ],
+      Actions: [
+        {
+          InvokeApi: {
+            StripBasePath: true,
+          },
+        },
+      ],
+    });
+  });
+
+  test('standalone RoutingRule with imported domain', () => {
+    const stack = new Stack();
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+
+    const domain = apigw.DomainName.fromDomainNameAttributes(stack, 'ImportedDomain', {
+      domainName: 'api.example.com',
+      domainNameAliasTarget: 'd-xxx.execute-api.us-east-1.amazonaws.com',
+      domainNameAliasHostedZoneId: 'Z123',
+    });
+
+    new apigw.RoutingRule(stack, 'Rule', {
+      domainName: domain,
+      priority: 100,
+      conditions: { basePaths: ['users'] },
+      action: {
+        restApi: api,
+        stage: api.deploymentStage,
+        stripBasePath: true,
+      },
+    });
+
+    Template.fromStack(stack).resourceCountIs('AWS::ApiGateway::DomainName', 0);
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::RoutingRule', {
+      Priority: 100,
+      Conditions: [{ MatchBasePaths: { AnyOf: ['users'] } }],
+    });
+  });
+
+  test('throws when priority out of range', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    expect(() => {
+      domain.addRoutingRule('Bad', {
+        priority: 1000000,
+        action: { restApi: api },
+      });
+    }).toThrow(/priority must be between 0 and 999999/);
+  });
+
+  test('throws when header name too long', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    expect(() => {
+      domain.addRoutingRule('Bad', {
+        priority: 100,
+        conditions: {
+          headers: [{ header: 'x'.repeat(41), valueGlob: 'v2' }],
+        },
+        action: { restApi: api },
+      });
+    }).toThrow(/header name must be at most 40/);
+  });
+
+  test('throws when more than 2 header conditions', () => {
+    const stack = new Stack();
+    const cert = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:111:certificate/11');
+    const api = new apigw.RestApi(stack, 'Api');
+    api.root.addMethod('GET');
+    const domain = new apigw.DomainName(stack, 'Domain', {
+      domainName: 'api.example.com',
+      certificate: cert,
+      endpointType: apigw.EndpointType.REGIONAL,
+      routingMode: apigw.RoutingMode.ROUTING_RULE_ONLY,
+    });
+
+    expect(() => {
+      domain.addRoutingRule('Bad', {
+        priority: 100,
+        conditions: {
+          headers: [
+            { header: 'a', valueGlob: '1' },
+            { header: 'b', valueGlob: '2' },
+            { header: 'c', valueGlob: '3' },
+          ],
+        },
+        action: { restApi: api },
+      });
+    }).toThrow(/at most 2 matchHeaders conditions/);
+  });
+});


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36917.

### Reason for this change

API Gateway supports [routing rules](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-routing-rules-use.html) on custom domain names to route traffic by path and/or header to different REST APIs. The `DomainName` L2 construct only exposed base path mappings and API mappings; using routing rules required dropping to L1 (`CfnRoutingRule`), manually building domain name ARNs, and losing synth-time validation. This change adds L2 support so routing rules can be defined with a type-safe API and validated at synth time.

### Description of changes

- **`RoutingMode` enum**  
  `BASE_PATH_MAPPING_ONLY` (default), `ROUTING_RULE_ONLY`, and `ROUTING_RULE_THEN_API_MAPPING` to control how the domain routes traffic (mappings only, routing rules only, or rules then mappings).

- **`DomainName`**  
  - New optional `routingMode` prop; passed through to `CfnDomainName`.  
  - When `routingMode` is `ROUTING_RULE_ONLY` or `ROUTING_RULE_THEN_API_MAPPING`, `addRoutingRule()` is allowed and `addBasePathMapping` / `addApiMapping` are disallowed when mode is `ROUTING_RULE_ONLY` (and vice versa), with clear errors.  
  - Routing rules are only supported for REGIONAL endpoints; constructor and `addRoutingRule()` enforce this.  
  - **`addRoutingRule(id, options)`** creates a routing rule with priority, conditions (base paths and/or headers), and action (restApi, optional stage, optional stripBasePath).

- **`RoutingRule` L2 construct**  
  Wraps `AWS::ApiGatewayV2::RoutingRule` with:  
  - **Conditions:** `basePaths?: string[]` and/or `headers?: { header, valueGlob }[]` (AND between path and headers).  
  - **Action:** `restApi`, optional `stage` (defaults to API deployment stage), optional `stripBasePath`.  
  - Synth-time validation: priority 0–999999, header name length/pattern, valueGlob length, at most 2 header conditions.  
  - Can be used standalone with `domainName: IDomainNameRef` for cross-stack or imported domains.

- **`AddRoutingRuleOptions` interface**  
  Named type for `addRoutingRule()` options (priority, conditions, action) for JSII compatibility.

- **README**  
  New “Custom domain routing rules” subsection under Custom Domains with examples for `addRoutingRule()` and standalone `RoutingRule`.

- **Integration test**  
  Domain name made unique per stack (`api-${stackName}.example.com`) to avoid “domain already exists” conflicts on re-runs.

### Describe any new or updated permissions being added

None. The change only defines new L2 constructs that create existing CloudFormation resources (`AWS::ApiGateway::DomainName` with `RoutingMode`, `AWS::ApiGatewayV2::RoutingRule`). No new APIs or IAM permissions are introduced.

### Description of how you validated changes

- **Unit tests**  
  - `test/routing-rule.test.ts`: path-only, header-only, and combined path+header conditions; standalone `RoutingRule` with imported domain; validation for priority range, header length, and max 2 header conditions.  
  - `test/domains.test.ts`: `routingMode` on Cfn; `addRoutingRule` rejected when `BASE_PATH_MAPPING_ONLY`; `addBasePathMapping`/`addApiMapping` rejected when `ROUTING_RULE_ONLY`; no `mapping` when `ROUTING_RULE_ONLY`; REGIONAL-only; and “addRoutingRule creates rule and uses domain ARN”.

- **Integration test**  
  `integ.routing-rules.ts`: stack with domain in `ROUTING_RULE_ONLY`, path-based rule, header-based rule, and catch-all rule; domain name made unique per stack to avoid “domain already exists” on re-runs.

- **Build/lint**  
  `yarn build` and lint pass (import order, indentation, JSII, TS6133 addressed).

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
