### PR TITLE
fix: jest-autoclean leaves a lot of files if tests are interrupted

### DIFF
--- a/packages/aws-cdk-lib/testhelpers/jest-autoclean.ts
+++ b/packages/aws-cdk-lib/testhelpers/jest-autoclean.ts
@@ -11,4 +11,4 @@
  */
 import { CloudAssembly } from '../cx-api';
 
-afterAll(CloudAssembly.cleanupTemporaryDirectories);
+afterEach(CloudAssembly.cleanupTemporaryDirectories);


### PR DESCRIPTION
In `jest-autoclean.ts` we put:

```ts
afterAll(/* cleanup */);
```

This runs cleanup of temporary assemblies at the end of every test file, if the test file runs to completion.

This potentially leaves a lot of temporary assemblies in place if the test suite is interrupted by Ctrl-C midway through.

Instead, change to `afterEach`, so that the set of cloud assemblies left accidentally on a Ctrl-C is bounded by the parallelism.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
