### PR TITLE
fix(codedeploy): include applicationName in DeploymentGroupReference

### DIFF
--- a/packages/aws-cdk-lib/aws-codedeploy/lib/private/base-deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/private/base-deployment-group.ts
@@ -9,6 +9,14 @@ import type { CfnDeploymentGroup } from '../codedeploy.generated';
 import { isIBindableDeploymentConfig } from './predefined-deployment-config';
 
 /**
+ * Extract application name from deployment group ARN
+ * ARN format: arn:aws:codedeploy:region:account:deploymentgroup:ApplicationName/DeploymentGroupName
+ */
+function extractApplicationNameFromDeploymentGroupArn(arn: string): string {
+  return Arn.split(arn, ArnFormat.COLON_RESOURCE_NAME).resourceName!.split('/')[0];
+}
+
+/**
  */
 export interface ImportedDeploymentGroupBaseProps {
   /**
@@ -37,6 +45,7 @@ export class ImportedDeploymentGroupBase extends Resource {
 
   public get deploymentGroupRef(): DeploymentGroupReference {
     return {
+      applicationName: extractApplicationNameFromDeploymentGroupArn(this.deploymentGroupArn),
       deploymentGroupName: this.deploymentGroupName,
     };
   }
@@ -116,6 +125,7 @@ export class DeploymentGroupBase extends Resource {
    */
   public get deploymentGroupRef(): DeploymentGroupReference {
     return {
+      applicationName: extractApplicationNameFromDeploymentGroupArn(this.deploymentGroupArn),
       deploymentGroupName: this.deploymentGroupName,
     };
   }


### PR DESCRIPTION
### Issue # (if applicable)

N/A - Fixes compatibility with updated CloudFormation schema

### Reason for this change

The CloudFormation schema for `AWS::CodeDeploy::DeploymentGroup` was updated to include both `ApplicationName` and `DeploymentGroupName` in the `primaryIdentifier`. This causes the generated `DeploymentGroupReference` interface to require both fields, but the current implementation only returns `deploymentGroupName`.

### Description of changes

Updated `deploymentGroupRef` getter in both `ImportedDeploymentGroupBase` and `DeploymentGroupBase` classes to extract and include `applicationName` from the deployment group ARN.

The ARN format is: `arn:aws:codedeploy:region:account:deploymentgroup:ApplicationName/DeploymentGroupName`

The fix parses the ARN to extract the application name without requiring additional state storage.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

- Verified ARN format includes application name in resource name
- Confirmed both classes construct ARNs with `ApplicationName/DeploymentGroupName` format
- No additional state storage required

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
