### PR TITLE
chore(cx-api): updating @aws-cdk/cloud-assembly-schema peer dependency …

### DIFF
--- a/packages/@aws-cdk/cx-api/package.json
+++ b/packages/@aws-cdk/cx-api/package.json
@@ -84,7 +84,7 @@
     "@aws-cdk/cloud-assembly-api": "^2.0.1"
   },
   "peerDependencies": {
-    "@aws-cdk/cloud-assembly-schema": ">=45.0.0"
+    "@aws-cdk/cloud-assembly-schema": ">=50.3.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
…version

### Issue # (if applicable)

N/A

### Reason for this change

The release pipeline is failing:

```
[jsii-rosetta] [ERROR] Dependency conflict: @aws-cdk/cloud-assembly-schema can be either /codebuild/output/src3802084088/src/packages/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema or /codebuild/output/src3802084088/src/packages/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema
[jsii-rosetta] [ERROR] Error: Dependency conflict: @aws-cdk/cloud-assembly-schema can be either /codebuild/output/src3802084088/src/packages/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema or /codebuild/output/src3802084088/src/packages/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema
    at resolveConflict (/codebuild/output/src3802084088/src/node_modules/jsii-rosetta/lib/snippet-dependencies.js:91:19)
    at collectDependencies (/codebuild/output/src3802084088/src/node_modules/jsii-rosetta/lib/snippet-dependencies.js:29:25)
    at RosettaTranslator.translateAll (/codebuild/output/src3802084088/src/node_modules/jsii-rosetta/lib/rosetta-translator.js:112:84)
    at extractSnippets (/codebuild/output/src3802084088/src/node_modules/jsii-rosetta/lib/commands/extract.js:74:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /codebuild/output/src3802084088/src/node_modules/jsii-rosetta/lib/main.js:264:15
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The `@aws-cdk/cloud-assembly-schema` version for `aws-cdk-lib` was updated to `50.3.0` yesterday in [this PR](https://github.com/aws/aws-cdk/pull/36953/changes) - this is the same version as in the `devDependencies` for the `cx-api` package: https://github.com/aws/aws-cdk/blob/aa51aa2f5e6528cec6f139b772a694a6f2c509b1/packages/%40aws-cdk/cx-api/package.json#L92

The logs have this warning some time before the error:

```
@aws-cdk/cx-api: warning JSII6: A "peerDependency" on "@aws-cdk/cloud-assembly-schema" at ">=45.0.0" means you should take a "devDependency" on "@aws-cdk/cloud-assembly-schema" at "45.0.0" (found "^50.3.0")
```

### Description of changes

Updated the peer dependency version

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
