### PR TITLE
chore: bump minimum constructs version to 10.5.0

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/package.json
@@ -52,7 +52,7 @@
     "aws-cdk-lib": "0.0.0",
     "cdk8s": "2.70.47",
     "cdk8s-plus-27": "2.9.5",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "repository": {
     "url": "https://github.com/aws/aws-cdk.git",

--- a/packages/@aws-cdk/app-staging-synthesizer-alpha/package.json
+++ b/packages/@aws-cdk/app-staging-synthesizer-alpha/package.json
@@ -92,13 +92,13 @@
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/integ-runner": "^2.195.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/cdk-build-tools": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "publishConfig": {
     "tag": "latest"

--- a/packages/@aws-cdk/aws-amplify-alpha/package.json
+++ b/packages/@aws-cdk/aws-amplify-alpha/package.json
@@ -97,12 +97,12 @@
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-applicationsignals-alpha/package.json
+++ b/packages/@aws-cdk/aws-applicationsignals-alpha/package.json
@@ -90,12 +90,12 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-apprunner-alpha/package.json
+++ b/packages/@aws-cdk/aws-apprunner-alpha/package.json
@@ -88,13 +88,13 @@
     "@aws-cdk/integ-runner": "^2.195.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/package.json
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/package.json
@@ -85,13 +85,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@types/jest": "^29.5.14",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0"
   },
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/aws-bedrock-alpha": "0.0.0"
   },
   "engines": {

--- a/packages/@aws-cdk/aws-bedrock-alpha/package.json
+++ b/packages/@aws-cdk/aws-bedrock-alpha/package.json
@@ -83,13 +83,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@types/jest": "^29.5.14",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0"
   },
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-cloud9-alpha/package.json
+++ b/packages/@aws-cdk/aws-cloud9-alpha/package.json
@@ -87,14 +87,14 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-codestar-alpha/package.json
+++ b/packages/@aws-cdk/aws-codestar-alpha/package.json
@@ -89,12 +89,12 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-ec2-alpha/package.json
+++ b/packages/@aws-cdk/aws-ec2-alpha/package.json
@@ -89,7 +89,7 @@
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "separate-module": false,
   "engines": {

--- a/packages/@aws-cdk/aws-eks-v2-alpha/package.json
+++ b/packages/@aws-cdk/aws-eks-v2-alpha/package.json
@@ -98,7 +98,7 @@
     "@types/jest": "^29.5.14",
     "aws-sdk": "^2.1693.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "sinon": "^9.2.4",
     "cdk8s": "2.70.47",
     "cdk8s-plus-27": "2.9.5"
@@ -108,7 +108,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "bundledDependencies": [
     "yaml"

--- a/packages/@aws-cdk/aws-elasticache-alpha/package.json
+++ b/packages/@aws-cdk/aws-elasticache-alpha/package.json
@@ -91,13 +91,13 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-gamelift-alpha/package.json
+++ b/packages/@aws-cdk/aws-gamelift-alpha/package.json
@@ -88,14 +88,14 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-glue-alpha/package.json
+++ b/packages/@aws-cdk/aws-glue-alpha/package.json
@@ -88,13 +88,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0"
   },
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-imagebuilder-alpha/package.json
+++ b/packages/@aws-cdk/aws-imagebuilder-alpha/package.json
@@ -83,7 +83,7 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@types/jest": "^29.5.14",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0"
   },
   "dependencies": {
@@ -95,7 +95,7 @@
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-iot-actions-alpha/package.json
+++ b/packages/@aws-cdk/aws-iot-actions-alpha/package.json
@@ -87,7 +87,7 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/aws-iot-alpha": "0.0.0",
@@ -101,7 +101,7 @@
     "@aws-cdk/aws-iot-alpha": "0.0.0",
     "@aws-cdk/aws-iotevents-alpha": "0.0.0",
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "bundledDependencies": [
     "case"

--- a/packages/@aws-cdk/aws-iot-alpha/package.json
+++ b/packages/@aws-cdk/aws-iot-alpha/package.json
@@ -88,14 +88,14 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-iotevents-actions-alpha/package.json
+++ b/packages/@aws-cdk/aws-iotevents-actions-alpha/package.json
@@ -81,7 +81,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/aws-iotevents-alpha": "0.0.0"
   },
@@ -90,7 +90,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-iotevents-alpha": "0.0.0",
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-iotevents-alpha/package.json
+++ b/packages/@aws-cdk/aws-iotevents-alpha/package.json
@@ -90,13 +90,13 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-ivs-alpha/package.json
+++ b/packages/@aws-cdk/aws-ivs-alpha/package.json
@@ -90,13 +90,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/package.json
+++ b/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/package.json
@@ -84,14 +84,14 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-lambda-go-alpha/package.json
+++ b/packages/@aws-cdk/aws-lambda-go-alpha/package.json
@@ -82,13 +82,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-lambda-python-alpha/package.json
+++ b/packages/@aws-cdk/aws-lambda-python-alpha/package.json
@@ -82,14 +82,14 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-location-alpha/package.json
+++ b/packages/@aws-cdk/aws-location-alpha/package.json
@@ -88,13 +88,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-msk-alpha/package.json
+++ b/packages/@aws-cdk/aws-msk-alpha/package.json
@@ -90,13 +90,13 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-neptune-alpha/package.json
+++ b/packages/@aws-cdk/aws-neptune-alpha/package.json
@@ -88,13 +88,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-pipes-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-alpha/package.json
@@ -88,13 +88,13 @@
     "@types/jest": "^29.5.14",
     "jest": "^29",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-pipes-enrichments-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-enrichments-alpha/package.json
@@ -88,7 +88,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-pipes-sources-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-sources-alpha/package.json
@@ -88,7 +88,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-pipes-targets-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-targets-alpha/package.json
@@ -88,7 +88,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-pipes-alpha": "0.0.0",
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-redshift-alpha/package.json
+++ b/packages/@aws-cdk/aws-redshift-alpha/package.json
@@ -94,14 +94,14 @@
     "@aws-sdk/client-secrets-manager": "3.632.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-route53resolver-alpha/package.json
+++ b/packages/@aws-cdk/aws-route53resolver-alpha/package.json
@@ -88,12 +88,12 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-s3objectlambda-alpha/package.json
+++ b/packages/@aws-cdk/aws-s3objectlambda-alpha/package.json
@@ -89,12 +89,12 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-s3tables-alpha/package.json
+++ b/packages/@aws-cdk/aws-s3tables-alpha/package.json
@@ -81,14 +81,14 @@
     "@aws-cdk/cdk-build-tools": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "separate-module": false,
   "engines": {

--- a/packages/@aws-cdk/aws-sagemaker-alpha/package.json
+++ b/packages/@aws-cdk/aws-sagemaker-alpha/package.json
@@ -89,13 +89,13 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/aws-servicecatalogappregistry-alpha/package.json
+++ b/packages/@aws-cdk/aws-servicecatalogappregistry-alpha/package.json
@@ -88,13 +88,13 @@
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/packages/@aws-cdk/example-construct-library/package.json
+++ b/packages/@aws-cdk/example-construct-library/package.json
@@ -84,7 +84,7 @@
   "homepage": "https://github.com/aws/aws-cdk",
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "separate-module": false,
   "engines": {

--- a/packages/@aws-cdk/integ-tests-alpha/package.json
+++ b/packages/@aws-cdk/integ-tests-alpha/package.json
@@ -85,12 +85,12 @@
     "aws-cdk-lib": "0.0.0",
     "node-fetch": "^2.7.0",
     "@types/node-fetch": "^2.6.13",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {},
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "repository": {
     "url": "https://github.com/aws/aws-cdk.git",

--- a/packages/@aws-cdk/mixins-preview/package.json
+++ b/packages/@aws-cdk/mixins-preview/package.json
@@ -669,7 +669,7 @@
     "@cdklabs/typewriter": "^0.0.15",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "jest": "^29.7.0",
     "tsx": "^4.21.0"
   },
@@ -681,7 +681,7 @@
   ],
   "peerDependencies": {
     "aws-cdk-lib": "^0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "separate-module": false,
   "engines": {

--- a/packages/aws-cdk-lib/README.md
+++ b/packages/aws-cdk-lib/README.md
@@ -28,7 +28,7 @@ For example, let's say the minimum version your library needs is `2.38.0`. Your 
 {
   "peerDependencies": {
     "aws-cdk-lib": "^2.38.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "devDependencies": {
     /* Install the oldest version for testing so we don't accidentally use features from a newer version than we declare */
@@ -43,7 +43,7 @@ For CDK apps, declare them under the `dependencies` section. Use a caret so you 
 {
   "dependencies": {
     "aws-cdk-lib": "^2.38.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   }
 }
 ```

--- a/packages/aws-cdk-lib/aws-eks/README.md
+++ b/packages/aws-cdk-lib/aws-eks/README.md
@@ -1928,7 +1928,7 @@ To get started, add the following dependencies to your `package.json` file:
 "dependencies": {
   "cdk8s": "^2.0.0",
   "cdk8s-plus-25": "^2.0.0",
-  "constructs": "^10.0.0"
+  "constructs": "^10.5.0"
 }
 ```
 

--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -168,7 +168,7 @@
     "aws-sdk-client-mock": "4.1.0",
     "aws-sdk-client-mock-jest": "4.1.0",
     "cdk8s": "2.70.47",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "delay": "5.0.0",
     "esbuild": "^0.27.3",
     "fast-check": "^3.23.2",
@@ -185,7 +185,7 @@
     "typescript-json-schema": "^0.67.1"
   },
   "peerDependencies": {
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "homepage": "https://github.com/aws/aws-cdk",
   "engines": {

--- a/tools/@aws-cdk/pkglint/lib/rules.ts
+++ b/tools/@aws-cdk/pkglint/lib/rules.ts
@@ -643,7 +643,7 @@ export class NoPeerDependenciesAwsCdkLib extends ValidationRule {
  */
 export class ConstructsVersion extends ValidationRule {
   public static readonly VERSION = cdkMajorVersion() === 2
-    ? '^10.0.0'
+    ? '^10.5.0'
     : '^3.3.69';
 
   public readonly name = 'deps/constructs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6989,7 +6989,7 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-constructs@^10.0.0:
+constructs@^10.5.0:
   version "10.5.0"
   resolved "https://registry.npmjs.org/constructs/-/constructs-10.5.0.tgz#66d1a5fb748f4adeb8698ea5f53f27e06f99b930"
   integrity sha512-zWjwqIgk4nAWmQGrPnDWv+M2Yly6m7ROyqmmQVLgJiHnWP762It22uWFaF2Pu/sSx0u8WsoUcvt0PZ4DQIQYwQ==


### PR DESCRIPTION
### Reason for this change

The `constructs` library version 10.5.0 introduces the new `IMixin` interface and `Construct.with()` method. To use these new APIs in aws-cdk-lib and alpha modules, we need to raise the minimum required version of the `constructs` peer dependency.

This is a necessary prerequisite for implementing mixin support in the CDK.

### Description of changes

The minimum `constructs` version is bumped from `^10.0.0` to `^10.5.0` across the entire codebase. This includes updates to `peerDependencies` and `devDependencies` in all packages, as well as documentation examples that reference the constructs version.

The pkglint rule `ConstructsVersion` is updated to enforce the new minimum version, ensuring consistency across all packages.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

The change is mechanical and enforced by pkglint. All package.json files and documentation have been updated consistently.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
