### PR TITLE
fix(redshift-alpha): use frameworkOnEventRole instead of deprecated ProviderProps#role

### DIFF
--- a/packages/@aws-cdk/aws-redshift-alpha/lib/private/database-query.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/lib/private/database-query.ts
@@ -64,7 +64,7 @@ export class DatabaseQuery<HandlerProps> extends Construct implements iam.IGrant
 
     const provider = new customresources.Provider(this, 'Provider', {
       onEventHandler: handler,
-      role: this.getOrCreateInvokerRole(handler),
+      frameworkOnEventRole: this.getOrCreateInvokerRole(handler),
     });
 
     const queryHandlerProps: DatabaseQueryHandlerProps & HandlerProps = {

--- a/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import * as customresources from 'aws-cdk-lib/custom-resources';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as redshift from '../lib';
@@ -250,5 +251,26 @@ describe('database query', () => {
       .filter(([k, v]) => v === 'AWS::IAM::Role' && k.toString().includes('InvokerRole'));
 
     expect(iamRoles.length === 1);
+  });
+
+  it('uses frameworkOnEventRole instead of deprecated role when creating Provider', () => {
+    const providerSpy = jest.spyOn(customresources, 'Provider');
+
+    new DatabaseQuery(stack, 'Query', {
+      ...minimalProps,
+    });
+
+    expect(providerSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Provider',
+      expect.objectContaining({
+        onEventHandler: expect.anything(),
+        frameworkOnEventRole: expect.anything(),
+      }),
+    );
+    const providerProps = providerSpy.mock.calls[0][2];
+    expect(providerProps).not.toHaveProperty('role');
+
+    providerSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37006.

### Reason for this change

The property `role` in `aws-cdk-lib.custom_resources.ProviderProps` is deprecated and scheduled for removal in the next major release. The `DatabaseQuery` construct in `aws-redshift-alpha` was still passing `role` to `customresources.Provider`, which caused a deprecation warning during synthesis when using constructs like `User` that depend on it.

### Description of changes

- In `packages/@aws-cdk/aws-redshift-alpha/lib/private/database-query.ts`, the `Provider` instantiation was updated to use `frameworkOnEventRole` instead of the deprecated `role` property.

### Describe any new or updated permissions being added

None. IAM permissions are unchanged; only the Provider API used to pass the existing invoker role was updated.

### Description of how you validated changes

- Confirmed no linter errors on the modified file.
- No new unit or integration tests were added; the change is a one-line property rename with no intended behavior change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
