### PR TITLE
chore(rds): add RDS engine versions

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -3069,6 +3069,8 @@ export class SqlServerEngineVersion {
   public static readonly VER_13_00_6465_1_V1 = SqlServerEngineVersion.of('13.00.6465.1.v1', '13.00');
   /** Version "13.00.6470.1.v1". */
   public static readonly VER_13_00_6470_1_V1 = SqlServerEngineVersion.of('13.00.6470.1.v1', '13.00');
+  /** Version "13.00.6475.1.v1". */
+  public static readonly VER_13_00_6475_1_V1 = SqlServerEngineVersion.of('13.00.6475.1.v1', '13.00');
 
   /** Version "14.00" (only a major version, without a specific minor version). */
   public static readonly VER_14 = SqlServerEngineVersion.of('14.00', '14.00');
@@ -3134,6 +3136,8 @@ export class SqlServerEngineVersion {
   public static readonly VER_14_00_3500_1_V1 = SqlServerEngineVersion.of('14.00.3500.1.v1', '14.00');
   /** Version "14.00.3505.1.v1". */
   public static readonly VER_14_00_3505_1_V1 = SqlServerEngineVersion.of('14.00.3505.1.v1', '14.00');
+  /** Version "14.00.3515.1.v1". */
+  public static readonly VER_14_00_3515_1_V1 = SqlServerEngineVersion.of('14.00.3515.1.v1', '14.00');
 
   /** Version "15.00" (only a major version, without a specific minor version). */
   public static readonly VER_15 = SqlServerEngineVersion.of('15.00', '15.00');
@@ -3190,6 +3194,8 @@ export class SqlServerEngineVersion {
   public static readonly VER_15_00_4440_1_V1 = SqlServerEngineVersion.of('15.00.4440.1.v1', '15.00');
   /** Version "15.00.4445.1.v1". */
   public static readonly VER_15_00_4445_1_V1 = SqlServerEngineVersion.of('15.00.4445.1.v1', '15.00');
+  /** Version "15.00.4455.2.v1". */
+  public static readonly VER_15_00_4455_2_V1 = SqlServerEngineVersion.of('15.00.4455.2.v1', '15.00');
 
   /** Version "16.00" (only a major version, without a specific minor version). */
   public static readonly VER_16 = SqlServerEngineVersion.of('16.00', '16.00');
@@ -3227,6 +3233,12 @@ export class SqlServerEngineVersion {
   public static readonly VER_16_00_4210_1_V1 = SqlServerEngineVersion.of('16.00.4210.1.v1', '16.00');
   /** Version "16.00.4215.2.v1". */
   public static readonly VER_16_00_4215_2_V1 = SqlServerEngineVersion.of('16.00.4215.2.v1', '16.00');
+  /** Version "16.00.4225.2.v1". */
+  public static readonly VER_16_00_4225_2_V1 = SqlServerEngineVersion.of('16.00.4225.2.v1', '16.00');
+  /** Version "16.00.4230.2.v1". */
+  public static readonly VER_16_00_4230_2_V1 = SqlServerEngineVersion.of('16.00.4230.2.v1', '16.00');
+  /** Version "16.00.4236.2.v1". */
+  public static readonly VER_16_00_4236_2_V1 = SqlServerEngineVersion.of('16.00.4236.2.v1', '16.00');
 
   /**
    * Create a new SqlServerEngineVersion with an arbitrary version.

--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -2980,9 +2980,10 @@ export class SqlServerEngineVersion {
    */
   public static readonly VER_12_00_6449_1_V1 = SqlServerEngineVersion.of('12.00.6449.1.v1', '12.00');
 
-  /** Version "13.00" (only a major version, without a specific minor version). 
+  /**
+   * Version "13.00" (only a major version, without a specific minor version).
    * @deprecated SQL Server 13.00 is no longer supported by Amazon RDS. See https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
-  */
+   */
   public static readonly VER_13 = SqlServerEngineVersion.of('13.00', '13.00');
   /**
    * Version "13.00.2164.0.v1".

--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -2982,96 +2982,160 @@ export class SqlServerEngineVersion {
 
   /**
    * Version "13.00" (only a major version, without a specific minor version).
-   * @deprecated SQL Server 13.00 is no longer supported by Amazon RDS. See https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   * @deprecated SQL Server 13.00 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13 = SqlServerEngineVersion.of('13.00', '13.00');
   /**
    * Version "13.00.2164.0.v1".
    * @deprecated SQL Server 13.00.2164.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_2164_0_V1 = SqlServerEngineVersion.of('13.00.2164.0.v1', '13.00');
   /**
    * Version "13.00.4422.0.v1".
    * @deprecated SQL Server 13.00.4422.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_4422_0_V1 = SqlServerEngineVersion.of('13.00.4422.0.v1', '13.00');
   /**
    * Version "13.00.4451.0.v1".
    * @deprecated SQL Server 13.00.4451.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_4451_0_V1 = SqlServerEngineVersion.of('13.00.4451.0.v1', '13.00');
   /**
    * Version "13.00.4466.4.v1".
    * @deprecated SQL Server 13.00.4466.4.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_4466_4_V1 = SqlServerEngineVersion.of('13.00.4466.4.v1', '13.00');
   /**
    * Version "13.00.4522.0.v1".
    * @deprecated SQL Server 13.00.4522.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_4522_0_V1 = SqlServerEngineVersion.of('13.00.4522.0.v1', '13.00');
   /**
    * Version "13.00.5216.0.v1".
    * @deprecated SQL Server 13.00.5216.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5216_0_V1 = SqlServerEngineVersion.of('13.00.5216.0.v1', '13.00');
   /**
    * Version "13.00.5292.0.v1".
    * @deprecated SQL Server 13.00.5292.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5292_0_V1 = SqlServerEngineVersion.of('13.00.5292.0.v1', '13.00');
   /**
    * Version "13.00.5366.0.v1".
    * @deprecated SQL Server 13.00.5366.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5366_0_V1 = SqlServerEngineVersion.of('13.00.5366.0.v1', '13.00');
   /**
    * Version "13.00.5426.0.v1".
    * @deprecated SQL Server 13.00.5426.0.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5426_0_V1 = SqlServerEngineVersion.of('13.00.5426.0.v1', '13.00');
   /**
    * Version "13.00.5598.27.v1".
    * @deprecated SQL Server 13.00.5598.27.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5598_27_V1 = SqlServerEngineVersion.of('13.00.5598.27.v1', '13.00');
   /**
    * Version "13.00.5820.21.v1".
    * @deprecated SQL Server 13.00.5820.21.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5820_21_V1 = SqlServerEngineVersion.of('13.00.5820.21.v1', '13.00');
   /**
    * Version "13.00.5850.14.v1".
    * @deprecated SQL Server 13.00.5850.14.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5850_14_V1 = SqlServerEngineVersion.of('13.00.5850.14.v1', '13.00');
   /**
    * Version "13.00.5882.1.v1".
    * @deprecated SQL Server 13.00.5882.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
    */
   public static readonly VER_13_00_5882_1_V1 = SqlServerEngineVersion.of('13.00.5882.1.v1', '13.00');
-  /** Version "13.00.6300.2.v1". */
+  /**
+   * Version "13.00.6300.2.v1".
+   * @deprecated SQL Server 13.00.6300.2.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6300_2_V1 = SqlServerEngineVersion.of('13.00.6300.2.v1', '13.00');
-  /** Version "13.00.6419.1.v1". */
+  /**
+   * Version "13.00.6419.1.v1".
+   * @deprecated SQL Server 13.00.6419.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6419_1_V1 = SqlServerEngineVersion.of('13.00.6419.1.v1', '13.00');
-  /** Version "13.00.6430.49.v1". */
+  /**
+   * Version "13.00.6430.49.v1".
+   * @deprecated SQL Server 13.00.6430.49.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6430_49_V1 = SqlServerEngineVersion.of('13.00.6430.49.v1', '13.00');
-  /** Version "13.00.6435.1.v1". */
+  /**
+   * Version "13.00.6435.1.v1".
+   * @deprecated SQL Server 13.00.6435.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6435_1_V1 = SqlServerEngineVersion.of('13.00.6435.1.v1', '13.00');
-  /** Version "13.00.6441.1.v1". */
+  /**
+   * Version "13.00.6441.1.v1".
+   * @deprecated SQL Server 13.00.6441.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6441_1_V1 = SqlServerEngineVersion.of('13.00.6441.1.v1', '13.00');
-  /** Version "13.00.6445.1.v1". */
+  /**
+   * Version "13.00.6445.1.v1".
+   * @deprecated SQL Server 13.00.6445.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6445_1_V1 = SqlServerEngineVersion.of('13.00.6445.1.v1', '13.00');
-  /** Version "13.00.6450.1.v1". */
+  /**
+   * Version "13.00.6450.1.v1".
+   * @deprecated SQL Server 13.00.6450.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6450_1_V1 = SqlServerEngineVersion.of('13.00.6450.1.v1', '13.00');
-  /** Version "13.00.6455.2.v1". */
+  /**
+   * Version "13.00.6455.2.v1".
+   * @deprecated SQL Server 13.00.6455.2.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6455_2_V1 = SqlServerEngineVersion.of('13.00.6455.2.v1', '13.00');
-  /** Version "13.00.6460.7.v1". */
+  /**
+   * Version "13.00.6460.7.v1".
+   * @deprecated SQL Server 13.00.6460.7.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6460_7_V1 = SqlServerEngineVersion.of('13.00.6460.7.v1', '13.00');
-  /** Version "13.00.6465.1.v1". */
+  /**
+   * Version "13.00.6465.1.v1".
+   * @deprecated SQL Server 13.00.6465.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6465_1_V1 = SqlServerEngineVersion.of('13.00.6465.1.v1', '13.00');
-  /** Version "13.00.6470.1.v1". */
+  /**
+   * Version "13.00.6470.1.v1".
+   * @deprecated SQL Server 13.00.6470.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
   public static readonly VER_13_00_6470_1_V1 = SqlServerEngineVersion.of('13.00.6470.1.v1', '13.00');
+  /**
+   * Version "13.00.6475.1.v1".
+   * @deprecated SQL Server 13.00.6475.1.v1 is no longer supported by Amazon RDS.
+   * @see https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+   */
+  public static readonly VER_13_00_6475_1_V1 = SqlServerEngineVersion.of('13.00.6475.1.v1', '13.00');
 
   /** Version "14.00" (only a major version, without a specific minor version). */
   public static readonly VER_14 = SqlServerEngineVersion.of('14.00', '14.00');

--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -2980,7 +2980,9 @@ export class SqlServerEngineVersion {
    */
   public static readonly VER_12_00_6449_1_V1 = SqlServerEngineVersion.of('12.00.6449.1.v1', '12.00');
 
-  /** Version "13.00" (only a major version, without a specific minor version). */
+  /** Version "13.00" (only a major version, without a specific minor version). 
+   * @deprecated SQL Server 13.00 is no longer supported by Amazon RDS. See https://repost.aws/articles/ARGkeWligDSU-MQgBwUQj0nA
+  */
   public static readonly VER_13 = SqlServerEngineVersion.of('13.00', '13.00');
   /**
    * Version "13.00.2164.0.v1".
@@ -3069,8 +3071,6 @@ export class SqlServerEngineVersion {
   public static readonly VER_13_00_6465_1_V1 = SqlServerEngineVersion.of('13.00.6465.1.v1', '13.00');
   /** Version "13.00.6470.1.v1". */
   public static readonly VER_13_00_6470_1_V1 = SqlServerEngineVersion.of('13.00.6470.1.v1', '13.00');
-  /** Version "13.00.6475.1.v1". */
-  public static readonly VER_13_00_6475_1_V1 = SqlServerEngineVersion.of('13.00.6475.1.v1', '13.00');
 
   /** Version "14.00" (only a major version, without a specific minor version). */
   public static readonly VER_14 = SqlServerEngineVersion.of('14.00', '14.00');


### PR DESCRIPTION
### Issue
Closes #36993

### Reason for this change
RDS now supports newer cumulative updates (CU) and GDR updates for Microsoft SQL Server.

### Description of changes

Added new SQL Server engine version

**SQL Server 2022 (16.00):**
- `VER_16_00_4225_2_V1` (CU22)
- `VER_16_00_4230_2_V1` (CU22 GDR)
- `VER_16_00_4236_2_V1` (CU23)

**SQL Server 2019 (15.00):**
- `VER_15_00_4455_2_V1` (CU32 GDR)

**SQL Server 2017 (14.00):**
- `VER_14_00_3515_1_V1` (CU31 GDR)

**SQL Server 2016 (13.00):**
- `VER_13_00_6475_1_V1` (GDR)

### Describe any new or updated permissions being added
None

### Description of how you validated changes
Confirmed version strings match AWS RDS documentation

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
