### PR TITLE
chore: git ignoring Kiro-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ read*lock
 
 # jsii-rosetta files
 type-fingerprints.txt
+
+# Kiro-specific files
+.kiro/


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Ignoring `.kiro` directory files so they aren't accidentally committed.

### Description of changes
Added `.kiro/` to `.gitignore`


### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
