### PR TITLE
chore: update jsii-rosetta version

### DIFF
--- a/tools/@aws-cdk/cdk-build-tools/package.json
+++ b/tools/@aws-cdk/cdk-build-tools/package.json
@@ -54,7 +54,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^13.2.0",
     "jsii": "~5.9.26",
-    "jsii-rosetta": "~5.9.29",
+    "jsii-rosetta": "~5.9.31",
     "jsii-pacmak": "1.126.0",
     "jsii-reflect": "1.126.0",
     "markdownlint-cli": "^0.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10222,10 +10222,10 @@ jsii-reflect@1.126.0, jsii-reflect@^1.126.0:
     oo-ascii-tree "^1.126.0"
     yargs "^17.7.2"
 
-jsii-rosetta@~5.9.29:
-  version "5.9.29"
-  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.29.tgz#3baa26b169915775a16a841383978903f20ab6dc"
-  integrity sha512-9XfwiS6puc0wcTLoNFmjEPLRmjLu1HJatZ5Ue9OdSztHrqnrV0IvgT9LiSdVpCw7Q3WCIQeOlOCewf+B2qMA9Q==
+jsii-rosetta@~5.9.31:
+  version "5.9.31"
+  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.31.tgz#65d1a203a1545249b8329c86951b23f6a88df7ae"
+  integrity sha512-g0WR8oeFKe0xGtuPy6QU8BFArv5h2OlioKlemnHNAHUvnl+uahVy+I+qOw+HKtzr74LWi6Tv5nOZKhxnwSVuAQ==
   dependencies:
     "@jsii/check-node" "^1.126.0"
     "@jsii/spec" "^1.126.0"


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Upgrading the `jsii-rosetta` version to bring in this fix (https://github.com/aws/jsii-rosetta/pull/3579) which is more tolerant of multiple concrete dependencies with the same version number - it picks either one dependency instead of failing (which was causing pipeline build failures)

### Description of changes

Upgraded the `jsii-rosetta` version.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
