### PR TITLE
refactor(elasticache-alpha): make a simpler interface for backupTime prop

### DIFF
--- a/packages/@aws-cdk/aws-elasticache-alpha/lib/serverless-cache.ts
+++ b/packages/@aws-cdk/aws-elasticache-alpha/lib/serverless-cache.ts
@@ -72,6 +72,13 @@ export interface CacheUsageLimitsProperty {
   readonly requestRateLimitMaximum?: number;
 }
 
+export interface TimeOfDay {
+  /** Hour in UTC (0-23) */
+  readonly hour: number;
+  /** Minute (0-59) */
+  readonly minute: number;
+}
+
 /**
  * Backup configuration for ServerlessCache
  */
@@ -81,7 +88,7 @@ export interface BackupSettings {
    *
    * @default - No automated backups
    */
-  readonly backupTime?: events.Schedule;
+  readonly backupTime?: TimeOfDay;
   /**
    * Number of days to retain backups (1-35)
    *
@@ -450,7 +457,7 @@ export class ServerlessCache extends ServerlessCacheBase {
       serverlessCacheName: this.serverlessCacheName,
       description: props.description,
       cacheUsageLimits: this.renderCacheUsageLimits(props.cacheUsageLimits),
-      dailySnapshotTime: props.backup?.backupTime ? this.formatBackupTime(props.backup.backupTime) : undefined,
+      dailySnapshotTime: props.backup?.backupTime,
       snapshotRetentionLimit: props.backup?.backupRetentionLimit,
       finalSnapshotName: props.backup?.backupNameBeforeDeletion,
       snapshotArnsToRestore: props.backup?.backupArnsToRestore,
@@ -672,28 +679,3 @@ export class ServerlessCache extends ServerlessCacheBase {
       };
     }
   }
-
-  /**
-   * Format schedule to HH:MM format for daily backups
-   *
-   * @param schedule The schedule to format
-   * @returns Time string in HH:MM format
-   */
-  private formatBackupTime(schedule: events.Schedule): string {
-    const WILD_CARD = '*';
-    const [
-      minuteExpression, hourExpression,
-      dayExpression, monthExpression,
-      weekDayExpression, yearExpression,
-    ] = schedule.expressionString.substr(5).slice(0, -1).split(' ');
-
-    if (dayExpression != WILD_CARD || monthExpression != WILD_CARD || yearExpression != WILD_CARD || weekDayExpression != '?') {
-      throw new ValidationError('For now, only daily backup time is available (supports just hour and minute). Day, month, year, and weekDay are not allowed', this);
-    }
-
-    const hour = hourExpression == WILD_CARD ? '0' : hourExpression;
-    const minute = minuteExpression == WILD_CARD ? '0' : minuteExpression;
-
-    return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
-  }
-}


### PR DESCRIPTION
### Issue # (if applicable)

Closes #36981 

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

Added a new interface to simplify `backupTime` prop which doesn't follow `interface segregation` principle from SOLID. It removes unused props...

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
