### PR TITLE
fix(docdb): create instances when serverlessV2ScalingConfiguration is set

### DIFF
--- a/packages/aws-cdk-lib/aws-docdb/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-docdb/lib/cluster.ts
@@ -651,43 +651,41 @@ export class DatabaseCluster extends DatabaseClusterBase {
       this.secret = secret.attach(this);
     }
 
-    // Create instances only for provisioned clusters
-    if (!isServerless) {
-      const instanceCount = props.instances ?? DatabaseCluster.DEFAULT_NUM_INSTANCES;
-      if (instanceCount < 1) {
-        throw new ValidationError('At least one instance is required for provisioned clusters', this);
-      }
+    // Create instances
+    const instanceCount = props.instances ?? DatabaseCluster.DEFAULT_NUM_INSTANCES;
+    if (instanceCount < 1) {
+      throw new ValidationError('At least one instance is required', this);
+    }
 
-      const instanceRemovalPolicy = this.getInstanceRemovalPolicy(props);
-      const caCertificateIdentifier = props.caCertificate ? props.caCertificate.toString() : undefined;
+    const instanceRemovalPolicy = this.getInstanceRemovalPolicy(props);
+    const caCertificateIdentifier = props.caCertificate ? props.caCertificate.toString() : undefined;
 
-      for (let i = 0; i < instanceCount; i++) {
-        const instanceIndex = i + 1;
+    for (let i = 0; i < instanceCount; i++) {
+      const instanceIndex = i + 1;
 
-        const instanceIdentifier = props.instanceIdentifierBase != null ? `${props.instanceIdentifierBase}${instanceIndex}`
-          : props.dbClusterName != null ? `${props.dbClusterName}instance${instanceIndex}` : undefined;
+      const instanceIdentifier = props.instanceIdentifierBase != null ? `${props.instanceIdentifierBase}${instanceIndex}`
+        : props.dbClusterName != null ? `${props.dbClusterName}instance${instanceIndex}` : undefined;
 
-        const instance = new CfnDBInstance(this, `Instance${instanceIndex}`, {
-          // Link to cluster
-          dbClusterIdentifier: this.cluster.ref,
-          dbInstanceIdentifier: instanceIdentifier,
-          // Instance properties
-          dbInstanceClass: databaseInstanceType(props.instanceType!),
-          enablePerformanceInsights: props.enablePerformanceInsights,
-          caCertificateIdentifier: caCertificateIdentifier,
-        });
+      const instance = new CfnDBInstance(this, `Instance${instanceIndex}`, {
+        // Link to cluster
+        dbClusterIdentifier: this.cluster.ref,
+        dbInstanceIdentifier: instanceIdentifier,
+        // Instance properties
+        dbInstanceClass: isServerless ? 'db.serverless' : databaseInstanceType(props.instanceType!),
+        enablePerformanceInsights: props.enablePerformanceInsights,
+        caCertificateIdentifier: caCertificateIdentifier,
+      });
 
-        instance.applyRemovalPolicy(instanceRemovalPolicy, {
-          applyToUpdateReplacePolicy: true,
-        });
+      instance.applyRemovalPolicy(instanceRemovalPolicy, {
+        applyToUpdateReplacePolicy: true,
+      });
 
-        // We must have a dependency on the NAT gateway provider here to create
-        // things in the right order.
-        instance.node.addDependency(internetConnectivityEstablished);
+      // We must have a dependency on the NAT gateway provider here to create
+      // things in the right order.
+      instance.node.addDependency(internetConnectivityEstablished);
 
-        this.instanceIdentifiers.push(instance.ref);
-        this.instanceEndpoints.push(new Endpoint(instance.attrEndpoint, port));
-      }
+      this.instanceIdentifiers.push(instance.ref);
+      this.instanceEndpoints.push(new Endpoint(instance.attrEndpoint, port));
     }
 
     this.connections = new ec2.Connections({

--- a/packages/aws-cdk-lib/aws-docdb/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-docdb/test/cluster.test.ts
@@ -1274,11 +1274,14 @@ describe('DatabaseCluster', () => {
           MaxCapacity: 1,
         },
       });
-      // Should not create any instances
-      Template.fromStack(stack).resourceCountIs('AWS::DocDB::DBInstance', 0);
+      // Should create instances with db.serverless instance class
+      Template.fromStack(stack).hasResourceProperties('AWS::DocDB::DBInstance', {
+        DBInstanceClass: 'db.serverless',
+      });
+      Template.fromStack(stack).resourceCountIs('AWS::DocDB::DBInstance', 1);
     });
 
-    test('serverless cluster has empty instance arrays', () => {
+    test('serverless cluster creates instances with db.serverless class', () => {
       // GIVEN
       const stack = testStack();
       const vpc = new ec2.Vpc(stack, 'VPC');
@@ -1296,8 +1299,33 @@ describe('DatabaseCluster', () => {
       });
 
       // THEN
-      expect(cluster.instanceIdentifiers).toEqual([]);
-      expect(cluster.instanceEndpoints).toEqual([]);
+      expect(cluster.instanceIdentifiers.length).toBe(1);
+      expect(cluster.instanceEndpoints.length).toBe(1);
+    });
+
+    test('serverless cluster respects instanceCount', () => {
+      // GIVEN
+      const stack = testStack();
+      const vpc = new ec2.Vpc(stack, 'VPC');
+
+      // WHEN
+      new DatabaseCluster(stack, 'Database', {
+        masterUser: {
+          username: 'admin',
+        },
+        vpc,
+        instances: 3,
+        serverlessV2ScalingConfiguration: {
+          minCapacity: 0.5,
+          maxCapacity: 2,
+        },
+      });
+
+      // THEN
+      Template.fromStack(stack).resourceCountIs('AWS::DocDB::DBInstance', 3);
+      Template.fromStack(stack).hasResourceProperties('AWS::DocDB::DBInstance', {
+        DBInstanceClass: 'db.serverless',
+      });
     });
 
     test('cannot specify instanceType with serverless configuration', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

Currently, when `serverlessV2ScalingConfiguration` is set, no instances are created for the DocumentDB cluster. Due to the condition on L655, the instance creation is completely skipped.

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

Instead of skipping the instance creation, the logic will now add instances of type `db.serverless` for the configured amount by `instanceCount`.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->

N/A

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
