### PR TITLE
feat(cognito): add SecretValue option for OIDC client secret

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-cognito/test/integ.user-pool-idp.oidc.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-cognito/test/integ.user-pool-idp.oidc.ts
@@ -1,3 +1,4 @@
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { App, CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { ProviderAttribute, UserPool, UserPoolIdentityProviderOidc } from 'aws-cdk-lib/aws-cognito';
 
@@ -5,16 +6,48 @@ import { ProviderAttribute, UserPool, UserPoolIdentityProviderOidc } from 'aws-c
  * Stack verification steps
  * * Visit the URL provided by stack output 'SignInLink' in a browser, and verify the 'cdk' sign in link shows up.
  */
+
 const app = new App();
-const stack = new Stack(app, 'integ-user-pool-idp-google');
+const stack = new Stack(app, 'integ-user-pool-idp-oidc');
 
 const userpool = new UserPool(stack, 'pool', {
   removalPolicy: RemovalPolicy.DESTROY,
 });
 
-new UserPoolIdentityProviderOidc(stack, 'cdk', {
+const secret = new Secret(stack, 'OidcClientSecretValue', {
+  secretName: 'OidcClientSecretValueName',
+  generateSecretString: {
+    excludePunctuation: true,
+    passwordLength: 20,
+  },
+});
+
+const clientSecret = Secret.fromSecretAttributes(stack, 'OidcClientSecretResolvedValue', {
+  secretCompleteArn: secret.secretArn,
+}).secretValue;
+
+new UserPoolIdentityProviderOidc(stack, 'provider-with-secret-value', {
   userPool: userpool,
-  name: 'cdk',
+  name: 'provider-with-secret-value',
+  clientId: 'client-id',
+  clientSecretValue: clientSecret,
+  issuerUrl: 'https://www.issuer-url.com',
+  endpoints: {
+    authorization: 'https://www.issuer-url.com/authorize',
+    token: 'https://www.issuer-url.com/token',
+    userInfo: 'https://www.issuer-url.com/userinfo',
+    jwksUri: 'https://www.issuer-url.com/jwks',
+  },
+  scopes: ['openid', 'phone'],
+  attributeMapping: {
+    phoneNumber: ProviderAttribute.other('phone_number'),
+    emailVerified: ProviderAttribute.other('email_verified'),
+  },
+});
+
+new UserPoolIdentityProviderOidc(stack, 'provider-with-secret-string', {
+  userPool: userpool,
+  name: 'provider-with-secret-string',
   clientId: 'client-id',
   clientSecret: 'client-secret',
   issuerUrl: 'https://www.issuer-url.com',

--- a/packages/aws-cdk-lib/aws-cognito/README.md
+++ b/packages/aws-cdk-lib/aws-cognito/README.md
@@ -704,7 +704,7 @@ const provider = new cognito.UserPoolIdentityProviderAmazon(this, 'Amazon', {
 });
 ```
 
-Using Google identity provider is possible to use clientSecretValue with SecretValue from secrets manager.
+Using Google/OIDC identity provider is possible to use clientSecretValue with SecretValue from secrets manager.
 
 ```ts
 const userpool = new cognito.UserPool(this, 'Pool');

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool-idps/oidc.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool-idps/oidc.ts
@@ -1,7 +1,7 @@
 import type { Construct } from 'constructs';
 import type { UserPoolIdentityProviderProps } from './base';
 import { UserPoolIdentityProviderBase } from './private/user-pool-idp-base';
-import { Names, Token } from '../../../core';
+import { Names, Token, SecretValue } from '../../../core';
 import { ValidationError } from '../../../core/lib/errors';
 import { addConstructMetadata } from '../../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
@@ -17,9 +17,19 @@ export interface UserPoolIdentityProviderOidcProps extends UserPoolIdentityProvi
   readonly clientId: string;
 
   /**
-   * The client secret
+   * The client secret as a raw string
+   *
+   * @default none
+   * @deprecated use clientSecretValue instead
    */
-  readonly clientSecret: string;
+  readonly clientSecret?: string;
+
+  /**
+   * The client secret as a SecretValue
+   *
+   * @default none
+   */
+  readonly clientSecretValue?: SecretValue;
 
   /**
    * Issuer URL
@@ -117,13 +127,20 @@ export class UserPoolIdentityProviderOidc extends UserPoolIdentityProviderBase {
 
     const scopes = props.scopes ?? ['openid'];
 
+    // Exactly one of the properties must be configured.
+    const hasClientSecret = Boolean(props.clientSecret);
+    const hasClientSecretValue = Boolean(props.clientSecretValue);
+    if (hasClientSecret === hasClientSecretValue) {
+      throw new Error('Exactly one of "clientSecret" or "clientSecretValue" must be configured.');
+    }
+
     const resource = new CfnUserPoolIdentityProvider(this, 'Resource', {
       userPoolId: props.userPool.userPoolRef.userPoolId,
       providerName: this.getProviderName(props.name),
       providerType: 'OIDC',
       providerDetails: {
         client_id: props.clientId,
-        client_secret: props.clientSecret,
+        client_secret: props.clientSecretValue ? props.clientSecretValue.unsafeUnwrap() : props.clientSecret,
         authorize_scopes: scopes.join(' '),
         attributes_request_method: props.attributeRequestMethod ?? OidcAttributeRequestMethod.GET,
         oidc_issuer: props.issuerUrl,

--- a/packages/aws-cdk-lib/aws-cognito/test/user-pool-idps/oidc.test.ts
+++ b/packages/aws-cdk-lib/aws-cognito/test/user-pool-idps/oidc.test.ts
@@ -1,10 +1,10 @@
 import { Template } from '../../../assertions';
-import { Stack } from '../../../core';
+import { SecretValue, Stack } from '../../../core';
 import { ProviderAttribute, UserPool, UserPoolIdentityProviderOidc } from '../../lib';
 
 describe('UserPoolIdentityProvider', () => {
   describe('oidc', () => {
-    test('defaults', () => {
+    test('defaults with clientSecret', () => {
       // GIVEN
       const stack = new Stack();
       const pool = new UserPool(stack, 'userpool');
@@ -28,6 +28,48 @@ describe('UserPoolIdentityProvider', () => {
           oidc_issuer: 'https://my-issuer-url.com',
         },
       });
+    });
+
+    test('defaults with clientSecretValue', () => {
+      // GIVEN
+      const stack = new Stack();
+      const pool = new UserPool(stack, 'userpool');
+
+      // WHEN
+      new UserPoolIdentityProviderOidc(stack, 'userpoolidp', {
+        userPool: pool,
+        clientId: 'client-id',
+        clientSecretValue: SecretValue.unsafePlainText('client-secret'),
+        issuerUrl: 'https://my-issuer-url.com',
+      });
+
+      Template.fromStack(stack).hasResourceProperties('AWS::Cognito::UserPoolIdentityProvider', {
+        ProviderName: 'userpoolidp',
+        ProviderType: 'OIDC',
+        ProviderDetails: {
+          client_id: 'client-id',
+          client_secret: 'client-secret',
+          authorize_scopes: 'openid',
+          attributes_request_method: 'GET',
+          oidc_issuer: 'https://my-issuer-url.com',
+        },
+      });
+    });
+
+    test('throws when both clientSecret and clientSecretValue are provided', () => {
+      // GIVEN
+      const stack = new Stack();
+      const pool = new UserPool(stack, 'userpool');
+
+      // THEN
+      expect(() => new UserPoolIdentityProviderOidc(stack, 'userpoolidp', {
+        userPool: pool,
+        name: 'xy',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        clientSecretValue: SecretValue.unsafePlainText('client-secret'),
+        issuerUrl: 'https://my-issuer-url.com',
+      })).toThrow(/Exactly one of "clientSecret" or "clientSecretValue" must be configured/);
     });
 
     test('endpoints', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #29851.

### Reason for this change

Support SecretValue for UserPoolIdentityProviderOidc to avoid exposing secrets.

### Description of changes

Adapt `UserPoolIdentityProviderOidc`'s use of client_secret to the way `UserPoolIdentityProviderGoogle` is using it

### Describe any new or updated permissions being added

N/A


### Description of how you validated changes

Added unit tests in `packages/aws-cdk-lib/aws-cognito/test/user-pool-idps/oidc.test.ts`

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
