### PR TITLE
fix(rds): correct engine version deprecation tags and add missing versions

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
@@ -1191,35 +1191,20 @@ export class AuroraPostgresEngineVersion {
    * @deprecated Version 13.15 is no longer supported by Amazon RDS.
    */
   public static readonly VER_13_15 = AuroraPostgresEngineVersion.of('13.15', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.16".
-   * @deprecated Version 13.16 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.16". */
   public static readonly VER_13_16 = AuroraPostgresEngineVersion.of('13.16', '13', { s3Import: true, s3Export: true });
   /**
    * Version "13.17".
    * @deprecated Version 13.17 is no longer supported by Amazon RDS.
    */
   public static readonly VER_13_17 = AuroraPostgresEngineVersion.of('13.17', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.18".
-   * @deprecated Version 13.18 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.18". */
   public static readonly VER_13_18 = AuroraPostgresEngineVersion.of('13.18', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.20".
-   * @deprecated Version 13.20 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.20". */
   public static readonly VER_13_20 = AuroraPostgresEngineVersion.of('13.20', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.21".
-   * @deprecated Version 13.21 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.21". */
   public static readonly VER_13_21 = AuroraPostgresEngineVersion.of('13.21', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.22".
-   * @deprecated Version 13.22 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.22". */
   public static readonly VER_13_22 = AuroraPostgresEngineVersion.of('13.22', '13', { s3Import: true, s3Export: true });
   /** Version "13.23". */
   public static readonly VER_13_23 = AuroraPostgresEngineVersion.of('13.23', '13', { s3Import: true, s3Export: true });
@@ -1271,40 +1256,22 @@ export class AuroraPostgresEngineVersion {
    * @deprecated Version 14.12 is no longer supported by Amazon RDS.
    */
   public static readonly VER_14_12 = AuroraPostgresEngineVersion.of('14.12', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.13".
-   * @deprecated Version 14.13 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.13". */
   public static readonly VER_14_13 = AuroraPostgresEngineVersion.of('14.13', '14', { s3Import: true, s3Export: true });
   /**
    * Version "14.14".
    * @deprecated Version 14.14 is no longer supported by Amazon RDS.
    */
   public static readonly VER_14_14 = AuroraPostgresEngineVersion.of('14.14', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.15".
-   * @deprecated Version 14.15 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.15". */
   public static readonly VER_14_15 = AuroraPostgresEngineVersion.of('14.15', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.17".
-   * @deprecated Version 14.17 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.17". */
   public static readonly VER_14_17 = AuroraPostgresEngineVersion.of('14.17', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.18".
-   * @deprecated Version 14.18 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.18". */
   public static readonly VER_14_18 = AuroraPostgresEngineVersion.of('14.18', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.19".
-   * @deprecated Version 14.19 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.19". */
   public static readonly VER_14_19 = AuroraPostgresEngineVersion.of('14.19', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.20".
-   * @deprecated Version 14.20 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.20". */
   public static readonly VER_14_20 = AuroraPostgresEngineVersion.of('14.20', '14', { s3Import: true, s3Export: true });
 
   /**
@@ -1337,35 +1304,20 @@ export class AuroraPostgresEngineVersion {
    * @deprecated Version 15.7 is no longer supported by Amazon RDS.
    */
   public static readonly VER_15_7 = AuroraPostgresEngineVersion.of('15.7', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.8".
-   * @deprecated Version 15.8 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.8". */
   public static readonly VER_15_8 = AuroraPostgresEngineVersion.of('15.8', '15', { s3Import: true, s3Export: true });
   /**
    * Version "15.9".
    * @deprecated Version 15.9 is no longer supported by Amazon RDS.
    */
   public static readonly VER_15_9 = AuroraPostgresEngineVersion.of('15.9', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.10".
-   * @deprecated Version 15.10 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.10". */
   public static readonly VER_15_10 = AuroraPostgresEngineVersion.of('15.10', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.12".
-   * @deprecated Version 15.12 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.12". */
   public static readonly VER_15_12 = AuroraPostgresEngineVersion.of('15.12', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.13".
-   * @deprecated Version 15.13 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.13". */
   public static readonly VER_15_13 = AuroraPostgresEngineVersion.of('15.13', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.14".
-   * @deprecated Version 15.14 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.14". */
   public static readonly VER_15_14 = AuroraPostgresEngineVersion.of('15.14', '15', { s3Import: true, s3Export: true });
   /** Version "15.15". */
   public static readonly VER_15_15 = AuroraPostgresEngineVersion.of('15.15', '15', { s3Import: true, s3Export: true });
@@ -1390,61 +1342,35 @@ export class AuroraPostgresEngineVersion {
    * @deprecated Version 16.3 is no longer supported by Amazon RDS.
    */
   public static readonly VER_16_3 = AuroraPostgresEngineVersion.of('16.3', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.4".
-   * @deprecated Version 16.4 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.4". */
   public static readonly VER_16_4 = AuroraPostgresEngineVersion.of('16.4', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.4 limitless"
-   * @deprecated Version 16.4 limitless is no longer supported by Amazon RDS.
-   */
+  /** Version "16.4 limitless". */
   public static readonly VER_16_4_LIMITLESS = AuroraPostgresEngineVersion.of('16.4-limitless', '16', { s3Import: true, s3Export: true });
   /**
    * Version "16.5"
    * @deprecated Version 16.5 is no longer supported by Amazon RDS.
    */
   public static readonly VER_16_5 = AuroraPostgresEngineVersion.of('16.5', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.6".
-   * @deprecated Version 16.6 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.6". */
   public static readonly VER_16_6 = AuroraPostgresEngineVersion.of('16.6', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.6 limitless"
-   * @deprecated Version 16.6 limitless is no longer supported by Amazon RDS.
-   */
+  /** Version "16.6 limitless". */
   public static readonly VER_16_6_LIMITLESS = AuroraPostgresEngineVersion.of('16.6-limitless', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.8".
-   * @deprecated Version 16.8 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.8". */
   public static readonly VER_16_8 = AuroraPostgresEngineVersion.of('16.8', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.8 limitless"
-   * @deprecated Version 16.8 limitless is no longer supported by Amazon RDS.
-   */
+  /** Version "16.8 limitless". */
   public static readonly VER_16_8_LIMITLESS = AuroraPostgresEngineVersion.of('16.8-limitless', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.9".
-   * @deprecated Version 16.9 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.9". */
   public static readonly VER_16_9 = AuroraPostgresEngineVersion.of('16.9', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.9 limitless"
-   * @deprecated Version 16.9 limitless is no longer supported by Amazon RDS.
-   */
+  /** Version "16.9 limitless". */
   public static readonly VER_16_9_LIMITLESS = AuroraPostgresEngineVersion.of('16.9-limitless', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.10".
-   * @deprecated Version 16.10 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.10". */
   public static readonly VER_16_10 = AuroraPostgresEngineVersion.of('16.10', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.11".
-   * @deprecated Version 16.11 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.10 limitless". */
+  public static readonly VER_16_10_LIMITLESS = AuroraPostgresEngineVersion.of('16.10-limitless', '16', { s3Import: true, s3Export: true });
+  /** Version "16.11". */
   public static readonly VER_16_11 = AuroraPostgresEngineVersion.of('16.11', '16', { s3Import: true, s3Export: true });
+  /** Version "16.11 limitless". */
+  public static readonly VER_16_11_LIMITLESS = AuroraPostgresEngineVersion.of('16.11-limitless', '16', { s3Import: true, s3Export: true });
 
   /**
    * Version "17.1"
@@ -1456,20 +1382,11 @@ export class AuroraPostgresEngineVersion {
    * @deprecated Version 17.2 is no longer supported by Amazon RDS.
    */
   public static readonly VER_17_2 = AuroraPostgresEngineVersion.of('17.2', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.4".
-   * @deprecated Version 17.4 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.4". */
   public static readonly VER_17_4 = AuroraPostgresEngineVersion.of('17.4', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.5".
-   * @deprecated Version 17.5 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.5". */
   public static readonly VER_17_5 = AuroraPostgresEngineVersion.of('17.5', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.6".
-   * @deprecated Version 17.6 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.6". */
   public static readonly VER_17_6 = AuroraPostgresEngineVersion.of('17.6', '17', { s3Import: true, s3Export: true });
   /** Version "17.7". */
   public static readonly VER_17_7 = AuroraPostgresEngineVersion.of('17.7', '17', { s3Import: true, s3Export: true });

--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -530,9 +530,15 @@ export class MariaDbEngineVersion {
    * @deprecated MariaDB 10.5.24 is no longer supported by Amazon RDS.
    */
   public static readonly VER_10_5_24 = MariaDbEngineVersion.of('10.5.24', '10.5');
-  /** Version "10.5.25". */
+  /**
+   * Version "10.5.25".
+   * @deprecated MariaDB 10.5.25 is no longer supported by Amazon RDS.
+   */
   public static readonly VER_10_5_25 = MariaDbEngineVersion.of('10.5.25', '10.5');
-  /** Version "10.5.26". */
+  /**
+   * Version "10.5.26".
+   * @deprecated MariaDB 10.5.26 is no longer supported by Amazon RDS.
+   */
   public static readonly VER_10_5_26 = MariaDbEngineVersion.of('10.5.26', '10.5');
   /** Version "10.5.27". */
   public static readonly VER_10_5_27 = MariaDbEngineVersion.of('10.5.27', '10.5');
@@ -598,7 +604,10 @@ export class MariaDbEngineVersion {
    * @deprecated MariaDB 10.6.17 is no longer supported by Amazon RDS.
    */
   public static readonly VER_10_6_17 = MariaDbEngineVersion.of('10.6.17', '10.6');
-  /** Version "10.6.18". */
+  /**
+   * Version "10.6.18".
+   * @deprecated MariaDB 10.6.18 is no longer supported by Amazon RDS.
+   */
   public static readonly VER_10_6_18 = MariaDbEngineVersion.of('10.6.18', '10.6');
   /** Version "10.6.19". */
   public static readonly VER_10_6_19 = MariaDbEngineVersion.of('10.6.19', '10.6');
@@ -612,6 +621,8 @@ export class MariaDbEngineVersion {
   public static readonly VER_10_6_23 = MariaDbEngineVersion.of('10.6.23', '10.6');
   /** Version "10.6.24". */
   public static readonly VER_10_6_24 = MariaDbEngineVersion.of('10.6.24', '10.6');
+  /** Version "10.6.25". */
+  public static readonly VER_10_6_25 = MariaDbEngineVersion.of('10.6.25', '10.6');
 
   /** Version "10.11" (only a major version, without a specific minor version). */
   public static readonly VER_10_11 = MariaDbEngineVersion.of('10.11', '10.11');
@@ -632,10 +643,13 @@ export class MariaDbEngineVersion {
   public static readonly VER_10_11_6 = MariaDbEngineVersion.of('10.11.6', '10.11');
   /**
    * Version "10.11.7"
-   * @deprecated MariaDB 10.11.8 is no longer supported by Amazon RDS.
+   * @deprecated MariaDB 10.11.7 is no longer supported by Amazon RDS.
    */
   public static readonly VER_10_11_7 = MariaDbEngineVersion.of('10.11.7', '10.11');
-  /** Version "10.11.8". */
+  /**
+   * Version "10.11.8".
+   * @deprecated MariaDB 10.11.8 is no longer supported by Amazon RDS.
+   */
   public static readonly VER_10_11_8 = MariaDbEngineVersion.of('10.11.8', '10.11');
   /** Version "10.11.9". */
   public static readonly VER_10_11_9 = MariaDbEngineVersion.of('10.11.9', '10.11');
@@ -649,6 +663,8 @@ export class MariaDbEngineVersion {
   public static readonly VER_10_11_14 = MariaDbEngineVersion.of('10.11.14', '10.11');
   /** Version "10.11.15". */
   public static readonly VER_10_11_15 = MariaDbEngineVersion.of('10.11.15', '10.11');
+  /** Version "10.11.16". */
+  public static readonly VER_10_11_16 = MariaDbEngineVersion.of('10.11.16', '10.11');
 
   /** Version "11.4.3". */
   public static readonly VER_11_4_3 = MariaDbEngineVersion.of('11.4.3', '11.4');
@@ -662,11 +678,15 @@ export class MariaDbEngineVersion {
   public static readonly VER_11_4_8 = MariaDbEngineVersion.of('11.4.8', '11.4');
   /** Version "11.4.9". */
   public static readonly VER_11_4_9 = MariaDbEngineVersion.of('11.4.9', '11.4');
+  /** Version "11.4.10". */
+  public static readonly VER_11_4_10 = MariaDbEngineVersion.of('11.4.10', '11.4');
 
   /** Version "11.8.3". */
   public static readonly VER_11_8_3 = MariaDbEngineVersion.of('11.8.3', '11.8');
   /** Version "11.8.5". */
   public static readonly VER_11_8_5 = MariaDbEngineVersion.of('11.8.5', '11.8');
+  /** Version "11.8.6". */
+  public static readonly VER_11_8_6 = MariaDbEngineVersion.of('11.8.6', '11.8');
 
   /**
    * Create a new MariaDbEngineVersion with an arbitrary version.
@@ -1848,45 +1868,27 @@ export class PostgresEngineVersion {
    * @deprecated PostgreSQL 13.14 is no longer supported by Amazon RDS.
    */
   public static readonly VER_13_14 = PostgresEngineVersion.of('13.14', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.15"
-   * @deprecated PostgreSQL 13.15 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.15". */
   public static readonly VER_13_15 = PostgresEngineVersion.of('13.15', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.16"
-   * @deprecated PostgreSQL 13.16 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.16". */
   public static readonly VER_13_16 = PostgresEngineVersion.of('13.16', '13', { s3Import: true, s3Export: true });
   /**
    * Version "13.17".
    * @deprecated PostgreSQL 13.17 is no longer supported by Amazon RDS
    */
   public static readonly VER_13_17 = PostgresEngineVersion.of('13.17', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.18".
-   * @deprecated PostgreSQL 13.18 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.18". */
   public static readonly VER_13_18 = PostgresEngineVersion.of('13.18', '13', { s3Import: true, s3Export: true });
   /**
    * Version "13.19".
    * @deprecated PostgreSQL 13.19 is no longer supported by Amazon RDS
    */
   public static readonly VER_13_19 = PostgresEngineVersion.of('13.19', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.20".
-   * @deprecated PostgreSQL 13.20 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.20". */
   public static readonly VER_13_20 = PostgresEngineVersion.of('13.20', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.21".
-   * @deprecated PostgreSQL 13.21 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.21". */
   public static readonly VER_13_21 = PostgresEngineVersion.of('13.21', '13', { s3Import: true, s3Export: true });
-  /**
-   * Version "13.22".
-   * @deprecated PostgreSQL 13.22 is no longer supported by Amazon RDS.
-   */
+  /** Version "13.22". */
   public static readonly VER_13_22 = PostgresEngineVersion.of('13.22', '13', { s3Import: true, s3Export: true });
   /** Version "13.23". */
   public static readonly VER_13_23 = PostgresEngineVersion.of('13.23', '13', { s3Import: true, s3Export: true });
@@ -1948,51 +1950,32 @@ export class PostgresEngineVersion {
    * @deprecated PostgreSQL 14.11 is no longer supported by Amazon RDS.
    */
   public static readonly VER_14_11 = PostgresEngineVersion.of('14.11', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.12"
-   * @deprecated PostgreSQL 14.12 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.12". */
   public static readonly VER_14_12 = PostgresEngineVersion.of('14.12', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.13"
-   * @deprecated PostgreSQL 14.13 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.13". */
   public static readonly VER_14_13 = PostgresEngineVersion.of('14.13', '14', { s3Import: true, s3Export: true });
   /**
    * Version "14.14".
    * @deprecated PostgreSQL 14.14 is no longer supported by Amazon RDS
    */
   public static readonly VER_14_14 = PostgresEngineVersion.of('14.14', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.15".
-   * @deprecated PostgreSQL 14.15 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.15". */
   public static readonly VER_14_15 = PostgresEngineVersion.of('14.15', '14', { s3Import: true, s3Export: true });
   /**
    * Version "14.16".
    * @deprecated PostgreSQL 14.16 is no longer supported by Amazon RDS
    */
   public static readonly VER_14_16 = PostgresEngineVersion.of('14.16', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.17".
-   * @deprecated PostgreSQL 14.17 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.17". */
   public static readonly VER_14_17 = PostgresEngineVersion.of('14.17', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.18".
-   * @deprecated PostgreSQL 14.18 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.18". */
   public static readonly VER_14_18 = PostgresEngineVersion.of('14.18', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.19".
-   * @deprecated PostgreSQL 14.19 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.19". */
   public static readonly VER_14_19 = PostgresEngineVersion.of('14.19', '14', { s3Import: true, s3Export: true });
-  /**
-   * Version "14.20".
-   * @deprecated PostgreSQL 14.20 is no longer supported by Amazon RDS.
-   */
+  /** Version "14.20". */
   public static readonly VER_14_20 = PostgresEngineVersion.of('14.20', '14', { s3Import: true, s3Export: true });
+  /** Version "14.21". */
+  public static readonly VER_14_21 = PostgresEngineVersion.of('14.21', '14', { s3Import: true, s3Export: true });
 
   /** Version "15" (only a major version, without a specific minor version). */
   public static readonly VER_15 = PostgresEngineVersion.of('15', '15', { s3Import: true, s3Export: true });
@@ -2021,48 +2004,32 @@ export class PostgresEngineVersion {
    * @deprecated PostgreSQL 15.6 is no longer supported by Amazon RDS
    */
   public static readonly VER_15_6 = PostgresEngineVersion.of('15.6', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.7"
-   * @deprecated PostgreSQL 15.7 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.7". */
   public static readonly VER_15_7 = PostgresEngineVersion.of('15.7', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.8"
-   * @deprecated PostgreSQL 15.8 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.8". */
   public static readonly VER_15_8 = PostgresEngineVersion.of('15.8', '15', { s3Import: true, s3Export: true });
   /**
    * Version "15.9".
    * @deprecated PostgreSQL 15.9 is no longer supported by Amazon RDS
    */
   public static readonly VER_15_9 = PostgresEngineVersion.of('15.9', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.10".
-   * @deprecated PostgreSQL 15.10 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.10". */
   public static readonly VER_15_10 = PostgresEngineVersion.of('15.10', '15', { s3Import: true, s3Export: true });
   /**
    * Version "15.11".
    * @deprecated PostgreSQL 15.11 is no longer supported by Amazon RDS
    */
   public static readonly VER_15_11 = PostgresEngineVersion.of('15.11', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.12".
-   * @deprecated PostgreSQL 15.12 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.12". */
   public static readonly VER_15_12 = PostgresEngineVersion.of('15.12', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.13".
-   * @deprecated PostgreSQL 15.13 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.13". */
   public static readonly VER_15_13 = PostgresEngineVersion.of('15.13', '15', { s3Import: true, s3Export: true });
-  /**
-   * Version "15.14".
-   * @deprecated PostgreSQL 15.14 is no longer supported by Amazon RDS.
-   */
+  /** Version "15.14". */
   public static readonly VER_15_14 = PostgresEngineVersion.of('15.14', '15', { s3Import: true, s3Export: true });
   /** Version "15.15". */
   public static readonly VER_15_15 = PostgresEngineVersion.of('15.15', '15', { s3Import: true, s3Export: true });
+  /** Version "15.16". */
+  public static readonly VER_15_16 = PostgresEngineVersion.of('15.16', '15', { s3Import: true, s3Export: true });
 
   /** Version "16" (only a major version, without a specific minor version). */
   public static readonly VER_16 = PostgresEngineVersion.of('16', '16', { s3Import: true, s3Export: true });
@@ -2076,51 +2043,32 @@ export class PostgresEngineVersion {
    * @deprecated PostgreSQL 16.2 is no longer supported by Amazon RDS
    */
   public static readonly VER_16_2 = PostgresEngineVersion.of('16.2', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.3"
-   * @deprecated PostgreSQL 16.3 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.3". */
   public static readonly VER_16_3 = PostgresEngineVersion.of('16.3', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.4"
-   * @deprecated PostgreSQL 16.4 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.4". */
   public static readonly VER_16_4 = PostgresEngineVersion.of('16.4', '16', { s3Import: true, s3Export: true });
   /**
    * Version "16.5".
    * @deprecated PostgreSQL 16.5 is no longer supported by Amazon RDS
    */
   public static readonly VER_16_5 = PostgresEngineVersion.of('16.5', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.6"
-   * @deprecated PostgreSQL 16.6 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.6". */
   public static readonly VER_16_6 = PostgresEngineVersion.of('16.6', '16', { s3Import: true, s3Export: true });
   /**
    * Version "16.7".
    * @deprecated PostgreSQL 16.7 is no longer supported by Amazon RDS
    */
   public static readonly VER_16_7 = PostgresEngineVersion.of('16.7', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.8"
-   * @deprecated PostgreSQL 16.8 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.8". */
   public static readonly VER_16_8 = PostgresEngineVersion.of('16.8', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.9"
-   * @deprecated PostgreSQL 16.9 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.9". */
   public static readonly VER_16_9 = PostgresEngineVersion.of('16.9', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.10"
-   * @deprecated PostgreSQL 16.10 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.10". */
   public static readonly VER_16_10 = PostgresEngineVersion.of('16.10', '16', { s3Import: true, s3Export: true });
-  /**
-   * Version "16.11"
-   * @deprecated PostgreSQL 16.11 is no longer supported by Amazon RDS.
-   */
+  /** Version "16.11". */
   public static readonly VER_16_11 = PostgresEngineVersion.of('16.11', '16', { s3Import: true, s3Export: true });
+  /** Version "16.12". */
+  public static readonly VER_16_12 = PostgresEngineVersion.of('16.12', '16', { s3Import: true, s3Export: true });
 
   /** Version "17" (only a major version, without a specific minor version). */
   public static readonly VER_17 = PostgresEngineVersion.of('17', '17', { s3Import: true, s3Export: true });
@@ -2129,38 +2077,30 @@ export class PostgresEngineVersion {
    * @deprecated PostgreSQL 17.1 is no longer supported by Amazon RDS
    */
   public static readonly VER_17_1 = PostgresEngineVersion.of('17.1', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.2".
-   * @deprecated PostgreSQL 17.2 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.2". */
   public static readonly VER_17_2 = PostgresEngineVersion.of('17.2', '17', { s3Import: true, s3Export: true });
   /**
    * Version "17.3".
    * @deprecated PostgreSQL 17.3 is no longer supported by Amazon RDS
    */
   public static readonly VER_17_3 = PostgresEngineVersion.of('17.3', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.4".
-   * @deprecated PostgreSQL 17.4 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.4". */
   public static readonly VER_17_4 = PostgresEngineVersion.of('17.4', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.5".
-   * @deprecated PostgreSQL 17.5 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.5". */
   public static readonly VER_17_5 = PostgresEngineVersion.of('17.5', '17', { s3Import: true, s3Export: true });
-  /**
-   * Version "17.6".
-   * @deprecated PostgreSQL 17.6 is no longer supported by Amazon RDS.
-   */
+  /** Version "17.6". */
   public static readonly VER_17_6 = PostgresEngineVersion.of('17.6', '17', { s3Import: true, s3Export: true });
   /** Version "17.7". */
   public static readonly VER_17_7 = PostgresEngineVersion.of('17.7', '17', { s3Import: true, s3Export: true });
+  /** Version "17.8". */
+  public static readonly VER_17_8 = PostgresEngineVersion.of('17.8', '17', { s3Import: true, s3Export: true });
 
   /** Version "18" (only a major version, without a specific minor version). */
   public static readonly VER_18 = PostgresEngineVersion.of('18', '18', { s3Import: true, s3Export: true });
   /** Version "18.1". */
   public static readonly VER_18_1 = PostgresEngineVersion.of('18.1', '18', { s3Import: true, s3Export: true });
+  /** Version "18.2". */
+  public static readonly VER_18_2 = PostgresEngineVersion.of('18.2', '18', { s3Import: true, s3Export: true });
 
   /**
    * Create a new PostgresEngineVersion with an arbitrary version.
@@ -3190,6 +3130,8 @@ export class SqlServerEngineVersion {
   public static readonly VER_15_00_4440_1_V1 = SqlServerEngineVersion.of('15.00.4440.1.v1', '15.00');
   /** Version "15.00.4445.1.v1". */
   public static readonly VER_15_00_4445_1_V1 = SqlServerEngineVersion.of('15.00.4445.1.v1', '15.00');
+  /** Version "15.00.4455.2.v1". */
+  public static readonly VER_15_00_4455_2_V1 = SqlServerEngineVersion.of('15.00.4455.2.v1', '15.00');
 
   /** Version "16.00" (only a major version, without a specific minor version). */
   public static readonly VER_16 = SqlServerEngineVersion.of('16.00', '16.00');
@@ -3227,6 +3169,12 @@ export class SqlServerEngineVersion {
   public static readonly VER_16_00_4210_1_V1 = SqlServerEngineVersion.of('16.00.4210.1.v1', '16.00');
   /** Version "16.00.4215.2.v1". */
   public static readonly VER_16_00_4215_2_V1 = SqlServerEngineVersion.of('16.00.4215.2.v1', '16.00');
+  /** Version "16.00.4225.2.v1". */
+  public static readonly VER_16_00_4225_2_V1 = SqlServerEngineVersion.of('16.00.4225.2.v1', '16.00');
+  /** Version "16.00.4230.2.v1". */
+  public static readonly VER_16_00_4230_2_V1 = SqlServerEngineVersion.of('16.00.4230.2.v1', '16.00');
+  /** Version "16.00.4236.2.v1". */
+  public static readonly VER_16_00_4236_2_V1 = SqlServerEngineVersion.of('16.00.4236.2.v1', '16.00');
 
   /**
    * Create a new SqlServerEngineVersion with an arbitrary version.


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37079

### Reason for this change

PR #36937 incorrectly marked many available RDS engine versions as deprecated.

### Description of changes

Queried the AWS RDS API with `--filters Name=status,Values=deprecated` for each engine type, then corrected the CDK source to match. Changes across all engines:

- Removed incorrect `@deprecated` tags from versions that are actually available
- Added `@deprecated` tags to versions that are actually deprecated but were missing them
- Added new engine versions not yet present in CDK

**All deprecated versions (per AWS RDS API):**

| Engine | Deprecated versions |
|--------|-------------------|
| PostgreSQL | 9.3.x, 9.4.x, 9.5.x, 9.6.x, 10.x, 11.x, 12.2-12.21, 13.1-14, 13.17, 13.19, 14.1-11, 14.14, 14.16, 15.2-6, 15.9, 15.11, 16.1-2, 16.5, 16.7, 17.1, 17.3 |
| MySQL | 5.5.62, 5.6.51, 5.7.33-44, 8.0.11-37, 8.0.39 |
| MariaDB | 10.0.38, 10.1.48, 10.2.44, 10.3.34-39, 10.4.13-34, 10.5.8-26, 10.6.5-18, 10.11.4-8, 11.8.4 |
| Aurora MySQL | 5.7.12, 2.02.3-2.11.0, 2.12.0.1, 3.01.0-3.03.3, 3.05.0-3.07.1 |
| Aurora PostgreSQL | 9.6.22, 10.7, 10.21, 11.12-20, 12.4-20, 13.3-15, 14.3-12, 15.2-7, 16.1-3 |
| SQL Server | 11.00.x, 12.00.x, 13.00.x, 14.00.1000-3223 |

**Changes in this PR:**

| Engine | Incorrect deprecations removed | Missing deprecations added | New versions added |
|--------|-------------------------------|---------------------------|-------------------|
| PostgreSQL | 13.15-16, 13.18, 13.20-22, 14.12-13, 14.15, 14.17-20, 15.7-8, 15.10, 15.12-14, 16.3-4, 16.6, 16.8-11, 17.2, 17.4-6 | — | 14.21, 15.16, 16.12, 17.8, 18.2 |
| Aurora MySQL | 3.04.6, 3.10.3 | — | 3.12.0 |
| Aurora PostgreSQL | 13.16, 13.18, 13.20-22, 14.13, 14.15, 14.17-20, 15.8, 15.10, 15.12-14, 16.4 (+limitless), 16.6 (+limitless), 16.8-11 (+limitless), 17.2, 17.4-6 | — | 16.10-limitless, 16.11-limitless |
| MariaDB | — | 10.5.25, 10.5.26, 10.6.18, 10.11.8 | 10.11.16, 11.4.10, 11.8.6 |
| MySQL | — | — | — (already correct) |
| SQL Server | — | — | 15.00.4455.2, 16.00.4225.2, 16.00.4230.2, 16.00.4236.2 |

Also fixed a typo in MariaDB 10.11.7's deprecation message (incorrectly said "10.11.8").

### Describe any new or updated permissions being added

No new permissions required.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

---


### Description of how you validated changes

1. Queried AWS RDS API using `describe-db-engine-versions` with `--filters Name=status,Values=deprecated` for each engine type
2. Compared deprecated versions from AWS with CDK's `@deprecated` tags
3. Verified available versions from AWS match CDK's non-deprecated versions
4. Added missing versions that are currently available in AWS RDS

All queries run in `us-east-1` using `aws rds describe-db-engine-versions --engine <engine> --filters Name=status,Values=deprecated`.

<details>
<summary>PostgreSQL — Deprecated Versions</summary>

| Version |
|---------|
| 9.3.1 |
| 9.3.2 |
| 9.3.3 |
| 9.3.5 |
| 9.3.6 |
| 9.3.9 |
| 9.3.10 |
| 9.3.12 |
| 9.3.14 |
| 9.3.16 |
| 9.3.17 |
| 9.3.19 |
| 9.3.20 |
| 9.3.22 |
| 9.3.23 |
| 9.3.24 |
| 9.3.25 |
| 9.4.1 |
| 9.4.4 |
| 9.4.5 |
| 9.4.7 |
| 9.4.9 |
| 9.4.11 |
| 9.4.12 |
| 9.4.14 |
| 9.4.15 |
| 9.4.17 |
| 9.4.18 |
| 9.4.19 |
| 9.4.20 |
| 9.4.21 |
| 9.4.23 |
| 9.4.24 |
| 9.4.25 |
| 9.4.26 |
| 9.5.2 |
| 9.5.4 |
| 9.5.6 |
| 9.5.7 |
| 9.5.9 |
| 9.5.10 |
| 9.5.12 |
| 9.5.13 |
| 9.5.14 |
| 9.5.15 |
| 9.5.16 |
| 9.5.18 |
| 9.5.19 |
| 9.5.20 |
| 9.5.21 |
| 9.5.22 |
| 9.5.23 |
| 9.5.24 |
| 9.5.25 |
| 9.6.1 |
| 9.6.2 |
| 9.6.3 |
| 9.6.5 |
| 9.6.6 |
| 9.6.8 |
| 9.6.9 |
| 9.6.10 |
| 9.6.11 |
| 9.6.12 |
| 9.6.14 |
| 9.6.15 |
| 9.6.16 |
| 9.6.17 |
| 9.6.18 |
| 9.6.19 |
| 9.6.20 |
| 9.6.21 |
| 9.6.22 |
| 9.6.23 |
| 9.6.24 |
| 10.1 |
| 10.3 |
| 10.4 |
| 10.5 |
| 10.6 |
| 10.7 |
| 10.9 |
| 10.10 |
| 10.11 |
| 10.12 |
| 10.13 |
| 10.14 |
| 10.15 |
| 10.16 |
| 10.17 |
| 10.18 |
| 10.19 |
| 10.20 |
| 10.21 |
| 10.22 |
| 10.23 |
| 11.1 |
| 11.2 |
| 11.4 |
| 11.5 |
| 11.6 |
| 11.7 |
| 11.8 |
| 11.9 |
| 11.10 |
| 11.11 |
| 11.12 |
| 11.13 |
| 11.14 |
| 11.15 |
| 11.16 |
| 11.17 |
| 11.18 |
| 11.19 |
| 11.20 |
| 11.21 |
| 11.22 |
| 11.22-rds.20240418 |
| 11.22-rds.20240509 |
| 11.22-rds.20240808 |
| 12.2 |
| 12.3 |
| 12.4 |
| 12.5 |
| 12.6 |
| 12.7 |
| 12.8 |
| 12.9 |
| 12.10 |
| 12.11 |
| 12.12 |
| 12.13 |
| 12.14 |
| 12.15 |
| 12.16 |
| 12.17 |
| 12.18 |
| 12.19 |
| 12.20 |
| 12.21 |
| 13.1 |
| 13.2 |
| 13.3 |
| 13.4 |
| 13.5 |
| 13.6 |
| 13.7 |
| 13.8 |
| 13.9 |
| 13.10 |
| 13.11 |
| 13.12 |
| 13.13 |
| 13.14 |
| 13.17 |
| 13.19 |
| 14.1 |
| 14.2 |
| 14.3 |
| 14.4 |
| 14.5 |
| 14.6 |
| 14.7 |
| 14.8 |
| 14.9 |
| 14.10 |
| 14.11 |
| 14.14 |
| 14.16 |
| 15.2 |
| 15.3 |
| 15.4 |
| 15.5 |
| 15.6 |
| 15.9 |
| 15.11 |
| 16.1 |
| 16.2 |
| 16.5 |
| 16.7 |
| 17.1 |
| 17.3 |

</details>

<details>
<summary>PostgreSQL — Available Versions</summary>

| Version |
|---------|
| 11.22-rds.20241121 |
| 11.22-rds.20250220 |
| 11.22-rds.20250508 |
| 11.22-rds.20250814 |
| 11.22-rds.20251114 |
| 12.22 |
| 12.22-rds.20250220 |
| 12.22-rds.20250508 |
| 12.22-rds.20250814 |
| 12.22-rds.20251114 |
| 13.15 |
| 13.16 |
| 13.18 |
| 13.20 |
| 13.21 |
| 13.22 |
| 13.23 |
| 14.12 |
| 14.13 |
| 14.15 |
| 14.17 |
| 14.18 |
| 14.19 |
| 14.20 |
| 14.21 |
| 15.7 |
| 15.8 |
| 15.10 |
| 15.12 |
| 15.13 |
| 15.14 |
| 15.15 |
| 15.16 |
| 16.3 |
| 16.4 |
| 16.6 |
| 16.8 |
| 16.9 |
| 16.10 |
| 16.11 |
| 16.12 |
| 17.2 |
| 17.4 |
| 17.5 |
| 17.6 |
| 17.7 |
| 17.8 |
| 18.1 |
| 18.2 |

</details>

<details>
<summary>MySQL — Deprecated Versions</summary>

| Version |
|---------|
| 5.5.62 |
| 5.6.51 |
| 5.7.33 |
| 5.7.34 |
| 5.7.36 |
| 5.7.37 |
| 5.7.38 |
| 5.7.39 |
| 5.7.40 |
| 5.7.41 |
| 5.7.42 |
| 5.7.43 |
| 5.7.44 |
| 8.0.11 |
| 8.0.13 |
| 8.0.15 |
| 8.0.16 |
| 8.0.17 |
| 8.0.19 |
| 8.0.20 |
| 8.0.21 |
| 8.0.23 |
| 8.0.25 |
| 8.0.26 |
| 8.0.27 |
| 8.0.28 |
| 8.0.29 |
| 8.0.30 |
| 8.0.31 |
| 8.0.32 |
| 8.0.33 |
| 8.0.34 |
| 8.0.35 |
| 8.0.36 |
| 8.0.37 |
| 8.0.39 |

</details>

<details>
<summary>MySQL — Available Versions</summary>

| Version |
|---------|
| 5.7.44-rds.20240408 |
| 5.7.44-rds.20240529 |
| 5.7.44-rds.20240808 |
| 5.7.44-rds.20250103 |
| 5.7.44-rds.20250213 |
| 5.7.44-rds.20250508 |
| 5.7.44-rds.20250818 |
| 5.7.44-rds.20251212 |
| 8.0.40 |
| 8.0.41 |
| 8.0.42 |
| 8.0.43 |
| 8.0.44 |
| 8.0.45 |
| 8.4.3 |
| 8.4.4 |
| 8.4.5 |
| 8.4.6 |
| 8.4.7 |
| 8.4.8 |

</details>

<details>
<summary>MariaDB — Deprecated Versions</summary>

| Version |
|---------|
| 10.0.38 |
| 10.1.48 |
| 10.2.44 |
| 10.3.34 |
| 10.3.35 |
| 10.3.36 |
| 10.3.37 |
| 10.3.38 |
| 10.3.39 |
| 10.4.13 |
| 10.4.18 |
| 10.4.21 |
| 10.4.22 |
| 10.4.24 |
| 10.4.25 |
| 10.4.26 |
| 10.4.27 |
| 10.4.28 |
| 10.4.29 |
| 10.4.30 |
| 10.4.31 |
| 10.4.32 |
| 10.4.33 |
| 10.4.34 |
| 10.5.8 |
| 10.5.9 |
| 10.5.12 |
| 10.5.13 |
| 10.5.15 |
| 10.5.16 |
| 10.5.17 |
| 10.5.18 |
| 10.5.19 |
| 10.5.20 |
| 10.5.21 |
| 10.5.22 |
| 10.5.23 |
| 10.5.24 |
| 10.5.25 |
| 10.5.26 |
| 10.6.5 |
| 10.6.7 |
| 10.6.8 |
| 10.6.10 |
| 10.6.11 |
| 10.6.12 |
| 10.6.13 |
| 10.6.14 |
| 10.6.15 |
| 10.6.16 |
| 10.6.17 |
| 10.6.18 |
| 10.11.4 |
| 10.11.5 |
| 10.11.6 |
| 10.11.7 |
| 10.11.8 |
| 11.8.4 |

</details>

<details>
<summary>MariaDB — Available Versions</summary>

| Version |
|---------|
| 10.5.27 |
| 10.5.28 |
| 10.5.29 |
| 10.6.19 |
| 10.6.20 |
| 10.6.21 |
| 10.6.22 |
| 10.6.23 |
| 10.6.24 |
| 10.6.25 |
| 10.11.9 |
| 10.11.10 |
| 10.11.11 |
| 10.11.13 |
| 10.11.14 |
| 10.11.15 |
| 10.11.16 |
| 11.4.3 |
| 11.4.4 |
| 11.4.5 |
| 11.4.7 |
| 11.4.8 |
| 11.4.9 |
| 11.4.10 |
| 11.8.3 |
| 11.8.5 |
| 11.8.6 |

</details>

<details>
<summary>Aurora MySQL — Deprecated Versions</summary>

| Version |
|---------|
| 5.7.12 |
| 5.7.mysql_aurora.2.02.3 |
| 5.7.mysql_aurora.2.03.2 |
| 5.7.mysql_aurora.2.03.3 |
| 5.7.mysql_aurora.2.03.4 |
| 5.7.mysql_aurora.2.04.0 |
| 5.7.mysql_aurora.2.04.1 |
| 5.7.mysql_aurora.2.04.2 |
| 5.7.mysql_aurora.2.04.3 |
| 5.7.mysql_aurora.2.04.4 |
| 5.7.mysql_aurora.2.04.5 |
| 5.7.mysql_aurora.2.04.6 |
| 5.7.mysql_aurora.2.04.7 |
| 5.7.mysql_aurora.2.04.8 |
| 5.7.mysql_aurora.2.04.9 |
| 5.7.mysql_aurora.2.05.0 |
| 5.7.mysql_aurora.2.06.0 |
| 5.7.mysql_aurora.2.07.0 |
| 5.7.mysql_aurora.2.07.1 |
| 5.7.mysql_aurora.2.07.2 |
| 5.7.mysql_aurora.2.07.3 |
| 5.7.mysql_aurora.2.07.4 |
| 5.7.mysql_aurora.2.07.5 |
| 5.7.mysql_aurora.2.07.6 |
| 5.7.mysql_aurora.2.07.7 |
| 5.7.mysql_aurora.2.07.8 |
| 5.7.mysql_aurora.2.07.9 |
| 5.7.mysql_aurora.2.07.10 |
| 5.7.mysql_aurora.2.08.0 |
| 5.7.mysql_aurora.2.08.1 |
| 5.7.mysql_aurora.2.08.2 |
| 5.7.mysql_aurora.2.08.3 |
| 5.7.mysql_aurora.2.08.4 |
| 5.7.mysql_aurora.2.09.0 |
| 5.7.mysql_aurora.2.09.1 |
| 5.7.mysql_aurora.2.09.2 |
| 5.7.mysql_aurora.2.09.3 |
| 5.7.mysql_aurora.2.10.0 |
| 5.7.mysql_aurora.2.10.1 |
| 5.7.mysql_aurora.2.10.2 |
| 5.7.mysql_aurora.2.10.3 |
| 5.7.mysql_aurora.2.11.0 |
| 5.7.mysql_aurora.2.12.0.1 |
| 8.0.mysql_aurora.3.01.0 |
| 8.0.mysql_aurora.3.01.1 |
| 8.0.mysql_aurora.3.02.0 |
| 8.0.mysql_aurora.3.02.1 |
| 8.0.mysql_aurora.3.02.2 |
| 8.0.mysql_aurora.3.02.3 |
| 8.0.mysql_aurora.3.03.0 |
| 8.0.mysql_aurora.3.03.2 |
| 8.0.mysql_aurora.3.03.3 |
| 8.0.mysql_aurora.3.05.0 |
| 8.0.mysql_aurora.3.05.1 |
| 8.0.mysql_aurora.3.05.2 |
| 8.0.mysql_aurora.3.06.0 |
| 8.0.mysql_aurora.3.06.1 |
| 8.0.mysql_aurora.3.07.0 |
| 8.0.mysql_aurora.3.07.1 |

</details>

<details>
<summary>Aurora MySQL — Available Versions</summary>

| Version |
|---------|
| 5.7.mysql_aurora.2.11.1 |
| 5.7.mysql_aurora.2.11.2 |
| 5.7.mysql_aurora.2.11.3 |
| 5.7.mysql_aurora.2.11.4 |
| 5.7.mysql_aurora.2.11.5 |
| 5.7.mysql_aurora.2.11.6 |
| 5.7.mysql_aurora.2.12.0 |
| 5.7.mysql_aurora.2.12.1 |
| 5.7.mysql_aurora.2.12.2 |
| 5.7.mysql_aurora.2.12.3 |
| 5.7.mysql_aurora.2.12.4 |
| 5.7.mysql_aurora.2.12.5 |
| 8.0.mysql_aurora.3.04.0 |
| 8.0.mysql_aurora.3.04.1 |
| 8.0.mysql_aurora.3.04.2 |
| 8.0.mysql_aurora.3.04.3 |
| 8.0.mysql_aurora.3.04.4 |
| 8.0.mysql_aurora.3.04.6 |
| 8.0.mysql_aurora.3.08.0 |
| 8.0.mysql_aurora.3.08.1 |
| 8.0.mysql_aurora.3.08.2 |
| 8.0.mysql_aurora.3.09.0 |
| 8.0.mysql_aurora.3.10.0 |
| 8.0.mysql_aurora.3.10.1 |
| 8.0.mysql_aurora.3.10.2 |
| 8.0.mysql_aurora.3.10.3 |
| 8.0.mysql_aurora.3.11.0 |
| 8.0.mysql_aurora.3.11.1 |
| 8.0.mysql_aurora.3.12.0 |

</details>

<details>
<summary>Aurora PostgreSQL — Deprecated Versions</summary>

| Version |
|---------|
| 9.6.22 |
| 10.7 |
| 10.21 |
| 11.12 |
| 11.13 |
| 11.14 |
| 11.15 |
| 11.16 |
| 11.17 |
| 11.18 |
| 11.19 |
| 11.20 |
| 12.4 |
| 12.7 |
| 12.8 |
| 12.10 |
| 12.11 |
| 12.12 |
| 12.13 |
| 12.14 |
| 12.15 |
| 12.16 |
| 12.17 |
| 12.18 |
| 12.19 |
| 12.20 |
| 13.3 |
| 13.4 |
| 13.5 |
| 13.6 |
| 13.7 |
| 13.8 |
| 13.10 |
| 13.11 |
| 13.12 |
| 13.13 |
| 13.14 |
| 13.15 |
| 14.3 |
| 14.4 |
| 14.5 |
| 14.7 |
| 14.8 |
| 14.9 |
| 14.10 |
| 14.11 |
| 14.12 |
| 15.2 |
| 15.3 |
| 15.4 |
| 15.5 |
| 15.6 |
| 15.7 |
| 16.1 |
| 16.2 |
| 16.3 |

</details>

<details>
<summary>Aurora PostgreSQL — Available Versions</summary>

| Version |
|---------|
| 11.9 |
| 11.21 |
| 12.9 |
| 12.22 |
| 13.9 |
| 13.16 |
| 13.18 |
| 13.20 |
| 13.21 |
| 13.22 |
| 13.23 |
| 14.6 |
| 14.13 |
| 14.15 |
| 14.17 |
| 14.18 |
| 14.19 |
| 14.20 |
| 15.8 |
| 15.10 |
| 15.12 |
| 15.13 |
| 15.14 |
| 15.15 |
| 16.4 |
| 16.4-limitless |
| 16.6 |
| 16.6-limitless |
| 16.8 |
| 16.8-limitless |
| 16.9 |
| 16.9-limitless |
| 16.10 |
| 16.10-limitless |
| 16.11 |
| 16.11-limitless |
| 17.4 |
| 17.5 |
| 17.6 |
| 17.7 |

</details>

<details>
<summary>SQL Server EE — Deprecated Versions</summary>

| Version |
|---------|
| 11.00.2100.60.v1 |
| 11.00.5058.0.v1 |
| 11.00.6020.0.v1 |
| 11.00.6594.0.v1 |
| 11.00.7462.6.v1 |
| 11.00.7493.4.v1 |
| 12.00.5000.0.v1 |
| 12.00.5546.0.v1 |
| 12.00.5571.0.v1 |
| 12.00.6293.0.v1 |
| 12.00.6329.1.v1 |
| 12.00.6433.1.v1 |
| 12.00.6439.10.v1 |
| 12.00.6444.4.v1 |
| 12.00.6449.1.v1 |
| 13.00.2164.0.v1 |
| 13.00.4422.0.v1 |
| 13.00.4451.0.v1 |
| 13.00.4466.4.v1 |
| 13.00.4522.0.v1 |
| 13.00.5216.0.v1 |
| 13.00.5292.0.v1 |
| 13.00.5366.0.v1 |
| 13.00.5426.0.v1 |
| 13.00.5598.27.v1 |
| 13.00.5820.21.v1 |
| 13.00.5850.14.v1 |
| 13.00.5882.1.v1 |
| 13.00.6300.2.v1 |
| 13.00.6419.1.v1 |
| 13.00.6430.49.v1 |
| 13.00.6435.1.v1 |
| 13.00.6441.1.v1 |
| 13.00.6445.1.v1 |
| 13.00.6450.1.v1 |
| 13.00.6455.2.v1 |
| 13.00.6460.7.v1 |
| 13.00.6465.1.v1 |
| 13.00.6470.1.v1 |
| 13.00.6475.1.v1 |
| 14.00.1000.169.v1 |
| 14.00.3015.40.v1 |
| 14.00.3035.2.v1 |
| 14.00.3049.1.v1 |
| 14.00.3192.2.v1 |
| 14.00.3223.3.v1 |

</details>

<details>
<summary>SQL Server EE — Available Versions</summary>

| Version |
|---------|
| 14.00.3281.6.v1 |
| 14.00.3294.2.v1 |
| 14.00.3356.20.v1 |
| 14.00.3381.3.v1 |
| 14.00.3401.7.v1 |
| 14.00.3421.10.v1 |
| 14.00.3451.2.v1 |
| 14.00.3460.9.v1 |
| 14.00.3465.1.v1 |
| 14.00.3471.2.v1 |
| 14.00.3475.1.v1 |
| 14.00.3480.1.v1 |
| 14.00.3485.1.v1 |
| 14.00.3495.9.v1 |
| 14.00.3500.1.v1 |
| 14.00.3505.1.v1 |
| 14.00.3515.1.v1 |
| 15.00.4043.16.v1 |
| 15.00.4073.23.v1 |
| 15.00.4153.1.v1 |
| 15.00.4198.2.v1 |
| 15.00.4236.7.v1 |
| 15.00.4312.2.v1 |
| 15.00.4316.3.v1 |
| 15.00.4322.2.v1 |
| 15.00.4335.1.v1 |
| 15.00.4345.5.v1 |
| 15.00.4355.3.v1 |
| 15.00.4365.2.v1 |
| 15.00.4375.4.v1 |
| 15.00.4382.1.v1 |
| 15.00.4385.2.v1 |
| 15.00.4390.2.v1 |
| 15.00.4395.2.v1 |
| 15.00.4410.1.v1 |
| 15.00.4415.2.v1 |
| 15.00.4420.2.v1 |
| 15.00.4430.1.v1 |
| 15.00.4435.7.v1 |
| 15.00.4440.1.v1 |
| 15.00.4445.1.v1 |
| 15.00.4455.2.v1 |
| 16.00.4085.2.v1 |
| 16.00.4095.4.v1 |
| 16.00.4105.2.v1 |
| 16.00.4115.5.v1 |
| 16.00.4120.1.v1 |
| 16.00.4125.3.v1 |
| 16.00.4131.2.v1 |
| 16.00.4135.4.v1 |
| 16.00.4140.3.v1 |
| 16.00.4150.1.v1 |
| 16.00.4165.4.v1 |
| 16.00.4175.1.v1 |
| 16.00.4185.3.v1 |
| 16.00.4195.2.v1 |
| 16.00.4205.1.v1 |
| 16.00.4210.1.v1 |
| 16.00.4215.2.v1 |
| 16.00.4225.2.v1 |
| 16.00.4230.2.v1 |
| 16.00.4236.2.v1 |

</details>