### PR TITLE
fix(custom-resources): replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/packages/@aws-cdk/custom-resource-handlers/lib/aws-iam/oidc-handler/external.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/aws-iam/oidc-handler/external.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 import type { X509Certificate } from 'node:crypto';
 import * as tls from 'tls';
-import * as url from 'url';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as sdk from '@aws-sdk/client-iam';
 
@@ -20,22 +19,22 @@ function defaultLogger(fmt: string, ...args: any[]) {
  */
 async function downloadThumbprint(issuerUrl: string, rejectUnauthorized: boolean) {
   return new Promise<string>((ok, ko) => {
-    const purl = url.parse(issuerUrl);
+    const purl = new URL(issuerUrl);
     const port = purl.port ? parseInt(purl.port, 10) : 443;
 
-    if (!purl.host) {
+    if (!purl.hostname) {
       return ko(new Error(`unable to determine host from issuer url ${issuerUrl}`));
     }
 
     external.log(`Fetching x509 certificate chain from issuer ${issuerUrl}`);
 
-    const socket = tls.connect(port, purl.host, { rejectUnauthorized, servername: purl.host });
+    const socket = tls.connect(port, purl.hostname, { rejectUnauthorized, servername: purl.hostname });
     socket.once('error', ko);
 
     socket.once('secureConnect', () => {
       let cert = socket.getPeerX509Certificate();
       if (!cert) {
-        throw new Error(`Unable to retrieve X509 certificate from host ${purl.host}`);
+        throw new Error(`Unable to retrieve X509 certificate from host ${purl.hostname}`);
       }
       while (cert.issuerCertificate) {
         printCertificate(cert);

--- a/packages/@aws-cdk/custom-resource-handlers/lib/aws-logs/log-retention-handler/index.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/aws-logs/log-retention-handler/index.ts
@@ -154,11 +154,10 @@ export async function handler(event: LogRetentionEvent, context: AWSLambda.Conte
 
     console.log('Responding', responseBody);
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const parsedUrl = require('url').parse(event.ResponseURL);
+    const parsedUrl = new URL(event.ResponseURL);
     const requestOptions = {
       hostname: parsedUrl.hostname,
-      path: parsedUrl.path,
+      path: parsedUrl.pathname + parsedUrl.search,
       method: 'PUT',
       headers: {
         'content-type': '',

--- a/packages/@aws-cdk/custom-resource-handlers/lib/core/nodejs-entrypoint-handler/index.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/core/nodejs-entrypoint-handler/index.ts
@@ -1,5 +1,4 @@
 import * as https from 'https';
-import * as url from 'url';
 
 // for unit tests
 export const external = {
@@ -106,14 +105,14 @@ async function submitResponse(status: 'SUCCESS' | 'FAILED', event: Response) {
     Data: event.Data,
   };
 
-  const parsedUrl = url.parse(event.ResponseURL);
+  const parsedUrl = new URL(event.ResponseURL);
   const loggingSafeUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}/${parsedUrl.pathname}?***`;
   external.log('submit response to cloudformation', loggingSafeUrl, json);
 
   const responseBody = JSON.stringify(json);
   const req = {
     hostname: parsedUrl.hostname,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     method: 'PUT',
     headers: {
       'content-type': '',

--- a/packages/@aws-cdk/custom-resource-handlers/lib/custom-resources/aws-custom-resource-handler/utils.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/custom-resources/aws-custom-resource-handler/utils.ts
@@ -70,11 +70,11 @@ export function respond(
     console.log('Responding', JSON.stringify(filteredResponseObject));
   }
 
-  const parsedUrl = require('url').parse(event.ResponseURL);
+  const parsedUrl = new URL(event.ResponseURL);
   const responseBody = JSON.stringify(responseObject);
   const requestOptions = {
     hostname: parsedUrl.hostname,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     method: 'PUT',
     headers: {
       'content-type': '',

--- a/packages/@aws-cdk/custom-resource-handlers/lib/nodejs-entrypoint.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/nodejs-entrypoint.ts
@@ -1,5 +1,4 @@
 import * as https from 'https';
-import * as url from 'url';
 
 // for unit tests
 export const external = {
@@ -106,14 +105,14 @@ async function submitResponse(status: 'SUCCESS' | 'FAILED', event: Response) {
     Data: event.Data,
   };
 
-  const parsedUrl = url.parse(event.ResponseURL);
+  const parsedUrl = new URL(event.ResponseURL);
   const loggingSafeUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}/${parsedUrl.pathname}?***`;
   external.log('submit response to cloudformation', loggingSafeUrl, json);
 
   const responseBody = JSON.stringify(json);
   const req = {
     hostname: parsedUrl.hostname,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     method: 'PUT',
     headers: {
       'content-type': '',

--- a/packages/@aws-cdk/custom-resource-handlers/test/core/nodejs-entrypoint-handler.test.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/test/core/nodejs-entrypoint-handler.test.ts
@@ -4,7 +4,6 @@ import type { OutgoingHttpHeaders } from 'http';
 import type * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
-import * as url from 'url';
 import * as entrypoint from '../../lib/core/nodejs-entrypoint-handler/index';
 
 describe('nodejs entrypoint', () => {
@@ -164,7 +163,7 @@ function makeEvent(req: Partial<AWSLambda.CloudFormationCustomResourceEvent>): A
     LogicalResourceId: '<LogicalResourceId>',
     RequestId: '<RequestId>',
     ResourceType: '<ResourceType>',
-    ResponseURL: '<ResponseURL>',
+    ResponseURL: 'https://localhost/response-mock',
     ServiceToken: '<ServiceToken>',
     StackId: '<StackId>',
     ResourceProperties: {
@@ -176,7 +175,7 @@ function makeEvent(req: Partial<AWSLambda.CloudFormationCustomResourceEvent>): A
 }
 
 async function invokeHandler(req: AWSLambda.CloudFormationCustomResourceEvent, userHandler: entrypoint.Handler) {
-  const parsedResponseUrl = url.parse(req.ResponseURL);
+  const parsedResponseUrl = new URL(req.ResponseURL);
 
   // stage entry point and user handler.
   const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-custom-resource-provider-handler-test-'));
@@ -198,7 +197,7 @@ async function invokeHandler(req: AWSLambda.CloudFormationCustomResourceEvent, u
   let actualRequest;
   entrypoint.external.sendHttpRequest = async (options: https.RequestOptions, responseBody: string): Promise<void> => {
     assert(options.hostname === parsedResponseUrl.hostname, 'request hostname expected to be based on response URL');
-    assert(options.path === parsedResponseUrl.path, 'request path expected to be based on response URL');
+    assert(options.path === parsedResponseUrl.pathname + parsedResponseUrl.search, 'request path expected to be based on response URL');
     assert(options.method === 'PUT', 'request method is expected to be PUT');
     actualResponse = responseBody;
     actualRequest = options;

--- a/packages/@aws-cdk/custom-resource-handlers/test/nodejs-entrypoint.test.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/test/nodejs-entrypoint.test.ts
@@ -4,7 +4,6 @@ import type { OutgoingHttpHeaders } from 'http';
 import type * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
-import * as url from 'url';
 import * as entrypoint from '../lib/nodejs-entrypoint';
 
 describe('nodejs entrypoint', () => {
@@ -164,7 +163,7 @@ function makeEvent(req: Partial<AWSLambda.CloudFormationCustomResourceEvent>): A
     LogicalResourceId: '<LogicalResourceId>',
     RequestId: '<RequestId>',
     ResourceType: '<ResourceType>',
-    ResponseURL: '<ResponseURL>',
+    ResponseURL: 'https://localhost/response-mock',
     ServiceToken: '<ServiceToken>',
     StackId: '<StackId>',
     ResourceProperties: {
@@ -176,7 +175,7 @@ function makeEvent(req: Partial<AWSLambda.CloudFormationCustomResourceEvent>): A
 }
 
 async function invokeHandler(req: AWSLambda.CloudFormationCustomResourceEvent, userHandler: entrypoint.Handler) {
-  const parsedResponseUrl = url.parse(req.ResponseURL);
+  const parsedResponseUrl = new URL(req.ResponseURL);
 
   // stage entry point and user handler.
   const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-custom-resource-provider-handler-test-'));
@@ -198,7 +197,7 @@ async function invokeHandler(req: AWSLambda.CloudFormationCustomResourceEvent, u
   let actualRequest;
   entrypoint.external.sendHttpRequest = async (options: https.RequestOptions, responseBody: string): Promise<void> => {
     assert(options.hostname === parsedResponseUrl.hostname, 'request hostname expected to be based on response URL');
-    assert(options.path === parsedResponseUrl.path, 'request path expected to be based on response URL');
+    assert(options.path === parsedResponseUrl.pathname + parsedResponseUrl.search, 'request path expected to be based on response URL');
     assert(options.method === 'PUT', 'request method is expected to be PUT');
     actualResponse = responseBody;
     actualRequest = options;

--- a/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/lambda-handler/base.ts
+++ b/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/lambda-handler/base.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
 import * as https from 'https';
-import * as url from 'url';
 import type { StartExecutionInput } from '@aws-sdk/client-sfn';
 import { SFN } from '@aws-sdk/client-sfn';
 
@@ -103,10 +102,10 @@ export abstract class CustomResourceHandler<Request extends object, Response ext
 
     console.log('Responding to CloudFormation', responseBody);
 
-    const parsedUrl = url.parse(this.event.ResponseURL);
+    const parsedUrl = new URL(this.event.ResponseURL);
     const requestOptions = {
       hostname: parsedUrl.hostname,
-      path: parsedUrl.path,
+      path: parsedUrl.pathname + parsedUrl.search,
       method: 'PUT',
       headers: {
         'content-type': '',

--- a/packages/aws-cdk-lib/custom-resources/lib/provider-framework/runtime/cfn-response.ts
+++ b/packages/aws-cdk-lib/custom-resources/lib/provider-framework/runtime/cfn-response.ts
@@ -1,5 +1,4 @@
 
-import * as url from 'url';
 import { httpRequest } from './outbound';
 import { log, withRetries } from './util';
 import type { OnEventResponse } from '../types';
@@ -35,7 +34,7 @@ export async function submitResponse(status: 'SUCCESS' | 'FAILED', event: CloudF
 
   const responseBody = JSON.stringify(json);
 
-  const parsedUrl = url.parse(event.ResponseURL);
+  const parsedUrl = new URL(event.ResponseURL);
   const loggingSafeUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}/${parsedUrl.pathname}?***`;
   if (options?.noEcho) {
     log('submit redacted response to cloudformation', loggingSafeUrl, redactDataFromPayload(json));
@@ -49,7 +48,7 @@ export async function submitResponse(status: 'SUCCESS' | 'FAILED', event: CloudF
   };
   await withRetries(retryOptions, httpRequest)({
     hostname: parsedUrl.hostname,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     method: 'PUT',
     headers: {
       'content-type': '',

--- a/packages/aws-cdk-lib/custom-resources/test/provider-framework/mocks.ts
+++ b/packages/aws-cdk-lib/custom-resources/test/provider-framework/mocks.ts
@@ -1,7 +1,6 @@
 
 import type { OutgoingHttpHeaders } from 'http';
 import type * as https from 'https';
-import { parse as urlparse } from 'url';
 import type { InvocationResponse, InvokeCommandInput } from '@aws-sdk/client-lambda';
 import type { StartExecutionCommandInput, StartExecutionInput } from '@aws-sdk/client-sfn';
 import * as consts from '../../lib/provider-framework/runtime/consts';
@@ -34,10 +33,10 @@ export function setup() {
 }
 
 export async function httpRequestMock(options: https.RequestOptions, body: string) {
-  const responseUrl = urlparse(MOCK_REQUEST.ResponseURL);
+  const responseUrl = new URL(MOCK_REQUEST.ResponseURL);
 
   expect(options.method).toEqual('PUT');
-  expect(options.path).toEqual(responseUrl.path);
+  expect(options.path).toEqual(responseUrl.pathname + responseUrl.search);
   expect(options.hostname).toEqual(responseUrl.hostname);
   const headers = options.headers || {};
   expect((headers as OutgoingHttpHeaders)['content-length']).toEqual(body.length);


### PR DESCRIPTION
## Summary
- Replace all `url.parse()` calls with the WHATWG `URL` constructor across 7 source files and 3 test files
- Resolves Node.js deprecation DEP0169 (pending runtime deprecation since v22.1.0, runtime deprecation in v23.0.0+)
- Use `.hostname` instead of `.host` in OIDC handler for correct TLS SNI behavior

## Property Mapping
- `.path` → `.pathname + .search` (WHATWG URL has no `.path` property)
- `.host` → `.hostname` in OIDC handler (strips port, correct for tls.connect)
- `.port`: returns `''` instead of `null` when absent, both falsy — no behavior change

## Test Plan
- [x] TypeScript compilation passes with `strict: true` and `noUnusedLocals: true`
- [x] 16/16 nodejs-entrypoint tests pass
- [x] 20/20 provider-framework runtime tests pass
- [x] Updated mock URLs from invalid `<ResponseURL>` to valid `https://localhost/response-mock`
- [ ] Integration test snapshots may need regeneration (handler bundles will change)

Closes #37005