### PR TITLE
chore(mixins-preview): enum name must be a valid typescript identifier

### DIFF
--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
@@ -636,8 +636,13 @@ class LogsMixin extends ClassType {
 }
 
 function populateRecordFieldsEnum(fieldArray: string[], recordFields: EnumType) {
-  for (const field of fieldArray) {
-    // field names cannot have parentheses () or dashes - and must be all uppper case, value has the actual string value for the field
-    recordFields.addMember({ name: field.split(/[\-()./]+/).join('_').toUpperCase(), value: field });
+  for (let field of fieldArray) {
+    let fieldName = field;
+    // field names must be valid typescript identifiers, which means they cannot have a number as their first character and the only special character they can have are $ or _
+    const leadingNumbers = field.match(/^(\d+)/);
+    if(leadingNumbers) {
+      fieldName = field.slice(leadingNumbers[0].length) + leadingNumbers[0];
+    }
+    recordFields.addMember({ name: fieldName.split(/[^a-zA-Z0-9$_]+/).join('_').toUpperCase(), value: field });
   }
 }

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
@@ -639,7 +639,7 @@ function populateRecordFieldsEnum(fieldArray: string[], recordFields: EnumType) 
   for (let field of fieldArray) {
     // field names must be valid typescript identifiers, which means they cannot have a number as their first character and the only special character they can have are $ or _
     const leadingNumbers = field.match(/^(\d+)/);
-    const fieldName = leadingNumbers ? field.slice(leadingNumbers[0].length) : field;
+    const fieldName = leadingNumbers ? '_' + field.slice(leadingNumbers[0].length) : field;
     recordFields.addMember({ name: fieldName.split(/[^a-zA-Z0-9$_]+/).join('_').toUpperCase(), value: field });
   }
 }

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
@@ -638,8 +638,7 @@ class LogsMixin extends ClassType {
 function populateRecordFieldsEnum(fieldArray: string[], recordFields: EnumType) {
   for (let field of fieldArray) {
     // field names must be valid typescript identifiers, which means they cannot have a number as their first character and the only special character they can have are $ or _
-    const leadingNumbers = field.match(/^(\d+)/);
-    const fieldName = leadingNumbers ? '_' + field.slice(leadingNumbers[0].length) : field;
+    const fieldName = field.match(/^(\d+)/) ? '_' + field : field;
     recordFields.addMember({ name: fieldName.split(/[^a-zA-Z0-9$_]+/).join('_').toUpperCase(), value: field });
   }
 }

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/builder.ts
@@ -637,12 +637,9 @@ class LogsMixin extends ClassType {
 
 function populateRecordFieldsEnum(fieldArray: string[], recordFields: EnumType) {
   for (let field of fieldArray) {
-    let fieldName = field;
     // field names must be valid typescript identifiers, which means they cannot have a number as their first character and the only special character they can have are $ or _
     const leadingNumbers = field.match(/^(\d+)/);
-    if(leadingNumbers) {
-      fieldName = field.slice(leadingNumbers[0].length) + leadingNumbers[0];
-    }
+    const fieldName = leadingNumbers ? field.slice(leadingNumbers[0].length) : field;
     recordFields.addMember({ name: fieldName.split(/[^a-zA-Z0-9$_]+/).join('_').toUpperCase(), value: field });
   }
 }

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
@@ -316,8 +316,8 @@ export enum CfnThingAccessLogsRecordFields {
   ACCOUNT_ID = "account.id",
   TRACE_ID = "trace/id",
   SPAN_ID = "span*id",
-  _PHASE_STATE = "1phase_state",
-  _VERSION = "200version",
+  _1PHASE_STATE = "1phase_state",
+  _200VERSION = "200version",
   RESOURCE_ID = "resource-id",
   BODY = "body",
 }

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
@@ -234,6 +234,7 @@ export enum CfnThingApplicationLogsRecordFields {
   RESOURCE_ID = "resource_id",
   ACCOUNT_ID = "account_id",
   EVENT_TYPE = "event_type",
+  PHASE1_STATE = "phase1_state",
 }
 
 export interface CfnThingApplicationLogsS3Props {
@@ -314,7 +315,9 @@ export namespace CfnThingAccessLogsOutputFormat {
 export enum CfnThingAccessLogsRecordFields {
   ACCOUNT_ID = "account.id",
   TRACE_ID = "trace/id",
-  SPANID = "spanid",
+  SPAN_ID = "span*id",
+  PHASE_STATE1 = "1phase_state",
+  VERSION200 = "200version",
   RESOURCE_ID = "resource-id",
   BODY = "body",
 }

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/logs-delivery.test.ts.snap
@@ -316,8 +316,8 @@ export enum CfnThingAccessLogsRecordFields {
   ACCOUNT_ID = "account.id",
   TRACE_ID = "trace/id",
   SPAN_ID = "span*id",
-  PHASE_STATE1 = "1phase_state",
-  VERSION200 = "200version",
+  _PHASE_STATE = "1phase_state",
+  _VERSION = "200version",
   RESOURCE_ID = "resource-id",
   BODY = "body",
 }

--- a/packages/@aws-cdk/mixins-preview/test/codegen/logs-delivery.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/logs-delivery.test.ts
@@ -56,7 +56,7 @@ test('Logs Delivery Mixin for a resource', () => {
             outputFormats: ['json', 'raw', 'plain'],
           },
         ],
-        optionalFields: ['resource_id', 'account_id', 'event_type'],
+        optionalFields: ['resource_id', 'account_id', 'event_type', 'phase1_state'],
       },
       {
         permissionsVersion: 'V2',
@@ -76,7 +76,7 @@ test('Logs Delivery Mixin for a resource', () => {
           },
         ],
         mandatoryFields: ['resource-id', 'body'],
-        optionalFields: ['account.id', 'trace/id', 'span\id'],
+        optionalFields: ['account.id', 'trace/id', 'span*id', '1phase_state', '200version'],
       },
     ],
   });


### PR DESCRIPTION
### Reason for this change

<!--What is the bug or use case behind this change?-->
Follow up to this PR: https://github.com/aws/aws-cdk/pull/37096
Instead of maintaining a list of disallowed characters, we instead maintain a list of allowed characters (which we know more concretely). 

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->
Switch regex of disallowed characters to regex of allowed characters and if a `recordField` starts with numbers, we add an  `_` in front of them.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->
N/A

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Expanded test coverage

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
