### PR TITLE
fix(events): correct docs on schema discovery and CMK encryption

### DIFF
--- a/packages/aws-cdk-lib/aws-events/README.md
+++ b/packages/aws-cdk-lib/aws-events/README.md
@@ -360,8 +360,9 @@ const archive = new Archive(stack, 'Archive', {
 });
 ```
 
-To enable archives or schema discovery on an event bus, customers has the choice of using either an AWS owned key or a customer managed key.
-For more information, see [KMS key options for event bus encryption](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-at-rest-key-options.html).
+To enable archives on an event bus, customers have the choice of using either an AWS owned key or a customer managed key.
+Note that schema discovery is not supported for event buses encrypted using a customer managed key. To enable schema discovery on an event bus, choose to use an AWS owned key.
+For more information, see [KMS key options for event bus encryption](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-at-rest-key-options.html) and [Encrypting event buses with customer managed keys](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-event-bus-cmkey.html).
 
 ## Configuring logging
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The documentation for the `aws-events` module incorrectly stated that both archives and schema discovery could be enabled on an event bus using either an AWS owned key or a customer managed key (CMK). Per the [AWS EventBridge documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-event-bus-cmkey.html), schema discovery is not supported for event buses encrypted using a customer managed key.

### Description of changes

Updated the prose paragraph in `packages/aws-cdk-lib/aws-events/README.md` to reflect this behavior

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Documentation-only change. Verified the corrected statement aligns with the [official AWS EventBridge docs on CMK encryption](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-event-bus-cmkey.html).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*