### PR TITLE
docs(s3): fix addEventNotification docstring examples for correct Rosetta translation

### DIFF
--- a/packages/aws-cdk-lib/aws-s3/README.md
+++ b/packages/aws-cdk-lib/aws-s3/README.md
@@ -314,9 +314,8 @@ const bucket = s3.Bucket.fromBucketAttributes(this, 'ImportedBucket', {
 });
 
 // now you can just call methods on the bucket
-bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {
-  prefix: 'home/myusername/*',
-});
+const filter: s3.NotificationKeyFilter = { prefix: 'home/myusername/*' };
+bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), filter);
 ```
 
 Alternatively, short-hand factories are available as `Bucket.fromBucketName` and

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -371,7 +371,8 @@ export interface IBucket extends IResource, IBucketRef {
    *
    *    declare const myLambda: lambda.Function;
    *    const bucket = new s3.Bucket(this, 'MyBucket');
-   *    bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'})
+   *    const filter: s3.NotificationKeyFilter = { prefix: 'home/myusername/*' };
+   *    bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), filter);
    *
    * @see
    * https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
@@ -1003,7 +1004,8 @@ export abstract class BucketBase extends Resource implements IBucket, IEncrypted
    *
    *    declare const myLambda: lambda.Function;
    *    const bucket = new s3.Bucket(this, 'MyBucket');
-   *    bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'});
+   *    const filter: s3.NotificationKeyFilter = { prefix: 'home/myusername/*' };
+   *    bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), filter);
    *
    * @see
    * https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html


### PR DESCRIPTION
### Reason for this change

The Python API docs for `addEventNotification` showed an incorrect example where `prefix` was passed as a keyword argument. This happened because the TypeScript example used an inline struct literal `{prefix: 'home/myusername/*'}` which Rosetta mistranslated to Python as `prefix="home/myusername/*"` instead of wrapping it in a `NotificationKeyFilter`.

This caused a runtime `TypeError: BucketBase.add_event_notification() got an unexpected keyword argument 'prefix'` for users following the Python docs.

### Description of changes

Updated the `addEventNotification` examples in both `bucket.ts` (interface and class docstrings) and `README.md` to use an explicitly typed `NotificationKeyFilter` variable instead of an inline struct literal. This gives Rosetta the type information it needs to correctly translate to `s3.NotificationKeyFilter(prefix="home/myusername/*")` in Python and equivalent correct code in other languages.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Verified the fix using `jsii-rosetta snippet` to confirm correct Python translation output:

**Before (broken):**
```python
bucket.add_event_notification(s3.EventType.OBJECT_CREATED, s3n.LambdaDestination(my_lambda), prefix="home/myusername/*")
```

**After (correct):**
```python
filter = s3.NotificationKeyFilter(prefix="home/myusername/*")
bucket.add_event_notification(s3.EventType.OBJECT_CREATED, s3n.LambdaDestination(my_lambda), filter)
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*