### PR TITLE
chore(synthetics): add syn-nodejs-playwright-5.1 and syn-nodejs-puppeteer-13.1 runtime definitions

### DIFF
--- a/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
+++ b/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
@@ -316,6 +316,20 @@ export class Runtime {
   public static readonly SYNTHETICS_NODEJS_PUPPETEER_13_0 = new Runtime('syn-nodejs-puppeteer-13.0', RuntimeFamily.NODEJS);
 
   /**
+   * `syn-nodejs-puppeteer-13.1` includes the following:
+   * - Lambda runtime Node.js 22.x
+   * - Puppeteer-core version 24.25.0
+   * - Chromium version 142.x
+   * - Firefox version 145.x
+   *
+   * New Features:
+   * - Applied security patches and updated Puppeteer and browser versions.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-13.1
+   */
+  public static readonly SYNTHETICS_NODEJS_PUPPETEER_13_1 = new Runtime('syn-nodejs-puppeteer-13.1', RuntimeFamily.NODEJS);
+
+  /**
    * `syn-nodejs-playwright-1.0` includes the following:
    * - Lambda runtime Node.js 20.x
    * - Playwright version 1.45
@@ -387,6 +401,21 @@ export class Runtime {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_playwright.html#Synthetics_runtimeversion-syn-nodejs-playwright-5.0
    */
   public static readonly SYNTHETICS_NODEJS_PLAYWRIGHT_5_0 = new Runtime('syn-nodejs-playwright-5.0', RuntimeFamily.NODEJS);
+
+  /**
+   * `syn-nodejs-playwright-5.1` includes the following:
+   * - Lambda runtime Node.js 22.x
+   * - Playwright version 1.57.0
+   * - Chromium version 143.0.7499.169
+   * - Firefox version 142.0.1
+   *
+   * New Features:
+   * - Synthetics runtime namespace migration from `@amzn/synthetics-playwright` to `@aws/synthetics-playwright`.
+   *   Type definitions are now available in the npm registry.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_playwright.html#Synthetics_runtimeversion-syn-nodejs-playwright-5.1
+   */
+  public static readonly SYNTHETICS_NODEJS_PLAYWRIGHT_5_1 = new Runtime('syn-nodejs-playwright-5.1', RuntimeFamily.NODEJS);
 
   /**
    * `syn-nodejs-3.0` includes the following:

--- a/packages/aws-cdk-lib/aws-synthetics/test/canaries/canary.js
+++ b/packages/aws-cdk-lib/aws-synthetics/test/canaries/canary.js
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import { synthetics } from '@amzn/synthetics-playwright';
+import { synthetics } from '@aws/synthetics-playwright';
 
 const loadBlueprints = async function () {
     const urls = [process.env.URL];

--- a/packages/aws-cdk-lib/aws-synthetics/test/canaries/playwright/canary.js
+++ b/packages/aws-cdk-lib/aws-synthetics/test/canaries/playwright/canary.js
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import { synthetics } from '@amzn/synthetics-playwright';
+import { synthetics } from '@aws/synthetics-playwright';
 
 const loadBlueprints = async function () {
     const urls = [process.env.URL];

--- a/packages/aws-cdk-lib/aws-synthetics/test/canary.test.ts
+++ b/packages/aws-cdk-lib/aws-synthetics/test/canary.test.ts
@@ -1348,3 +1348,11 @@ describe('Browser configurations', () => {
     }).toThrow('Firefox browser is not supported with Python Selenium runtimes. Use Chrome instead or switch to a Node.js runtime with Puppeteer or Playwright.');
   });
 });
+
+test.each([
+  [synthetics.Runtime.SYNTHETICS_NODEJS_PLAYWRIGHT_5_1, 'syn-nodejs-playwright-5.1'],
+  [synthetics.Runtime.SYNTHETICS_NODEJS_PUPPETEER_13_1, 'syn-nodejs-puppeteer-13.1'],
+])('Runtime constant %s has correct name and family', (runtime, expectedName) => {
+  expect(runtime.name).toBe(expectedName);
+  expect(runtime.family).toBe(synthetics.RuntimeFamily.NODEJS);
+});


### PR DESCRIPTION
### Issue # (if applicable)

Closes #35183.

### Reason for this change

AWS CloudWatch Synthetics released two new runtime versions that were missing from the CDK `Runtime` class:

- `syn-nodejs-playwright-5.1` — the latest Playwright runtime, and the first to use the new public `@aws/synthetics-playwright` npm package
- `syn-nodejs-puppeteer-13.1` — the latest Puppeteer runtime (Node.js 22.x)

Without these constants, users must fall back to the error-prone string constructor (`new Runtime('syn-nodejs-playwright-5.1', RuntimeFamily.NODEJS)`) with no IDE autocomplete or type safety.

**Why the `@amzn/synthetics-playwright` → `@aws/synthetics-playwright` fixture update?**

The original `@amzn/synthetics-playwright` package was never publicly available on npm — it was an internal Amazon-scoped package. This meant CDK users writing Playwright canaries could not `npm install` the type definitions locally, breaking IDE support and local development.

Starting with `syn-nodejs-playwright-5.1`, AWS officially migrated to `@aws/synthetics-playwright` (Apache-2.0), a proper public package under the `@aws` scope (same as `@aws-sdk/*` and `@aws-cdk/*`). The [official AWS runtime docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_playwright.html) explicitly state:

> **Important**: Starting `syn-nodejs-playwright-5.1` and later, Synthetics runtime uses the new namespace. Please migrate the canary script to use the new namespace. Legacy namespace will be deprecated in a future release.
> `@amzn/synthetics-playwright` → `@aws/synthetics-playwright`

The test fixture files (`test/canaries/canary.js`, `test/canaries/playwright/canary.js`) serve as reference examples for users. Leaving `@amzn/` in those files would mislead anyone using them as a starting point for a `5.1` canary — their `npm install` would fail since `@amzn/synthetics-playwright` is not on the public registry.

### Description of changes

```
  lib/runtime.ts
  ┌─────────────────────────────────────────────────────────────────┐
  │  ...                                                            │
  │  SYNTHETICS_NODEJS_PUPPETEER_13_0   (existing)                  │
  │  SYNTHETICS_NODEJS_PUPPETEER_13_1   <-- NEW                     │
  │                                                                 │
  │  SYNTHETICS_NODEJS_PLAYWRIGHT_5_0   (existing)                  │
  │  SYNTHETICS_NODEJS_PLAYWRIGHT_5_1   <-- NEW                     │
  │    note: @amzn/synthetics-playwright -> @aws/synthetics-playwright│
  │  ...                                                            │
  └─────────────────────────────────────────────────────────────────┘

  test/canary.test.ts
  ┌─────────────────────────────────────────────────────────────────┐
  │  + test.each([                                                  │
  │      [SYNTHETICS_NODEJS_PLAYWRIGHT_5_1, 'syn-nodejs-            │
  │                                          playwright-5.1'],      │
  │      [SYNTHETICS_NODEJS_PUPPETEER_13_1, 'syn-nodejs-            │
  │                                          puppeteer-13.1'],      │
  │    ])('Runtime constant has correct name and family', ...)      │
  └─────────────────────────────────────────────────────────────────┘

  test/canaries/canary.js
  test/canaries/playwright/canary.js
  ┌─────────────────────────────────────────────────────────────────┐
  │  - import { synthetics } from '@amzn/synthetics-playwright'     │
  │  + import { synthetics } from '@aws/synthetics-playwright'      │
  └─────────────────────────────────────────────────────────────────┘

  lib/canary.ts   <-- no changes needed
  (dryRunAndUpdate regex is version-agnostic; 5.1 and 13.1 pass automatically)
```

### Describe any new or updated permissions being added

None. Runtime constants are plain value objects that pass through to the CloudFormation `RuntimeVersion` property. No IAM or policy changes.

### Description of how you validated changes

Added a `test.each` smoke test in `test/canary.test.ts` covering both new constants, asserting the correct `.name` string and `.family` (`RuntimeFamily.NODEJS`). All 71 unit tests pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
