### PR TITLE
feat(mixins-preview): support custom merge strategies via IMergeStrategy

### DIFF
--- a/packages/@aws-cdk/mixins-preview/README.md
+++ b/packages/@aws-cdk/mixins-preview/README.md
@@ -180,16 +180,35 @@ new s3.Bucket(scope, "Bucket")
 Property mixins support two merge strategies:
 
 ```typescript
-// MERGE (default): Deep merges properties with existing values
+// COMBINE (default): Deep merges properties with existing values
 Mixins.of(bucket).apply(new CfnBucketPropsMixin(
   { versioningConfiguration: { status: "Enabled" } },
-  { strategy: PropertyMergeStrategy.merge() }
+  { strategy: PropertyMergeStrategy.combine() }
 ));
 
 // OVERRIDE: Replaces existing property values
 Mixins.of(bucket).apply(new CfnBucketPropsMixin(
   { versioningConfiguration: { status: "Enabled" } },
   { strategy: PropertyMergeStrategy.override() }
+));
+```
+
+You can also implement `IMergeStrategy` to define a custom strategy:
+
+```typescript
+class MyCustomStrategy implements IMergeStrategy {
+  public apply(target: object, source: object, allowedKeys: string[]) {
+    for (const key of allowedKeys) {
+      if (key in source) {
+        (target as any)[key] = (source as any)[key];
+      }
+    }
+  }
+}
+
+Mixins.of(bucket).apply(new CfnBucketPropsMixin(
+  { tags: [{ key: 'Extra', value: 'Tag' }] },
+  { strategy: new MyCustomStrategy() }
 ));
 ```
 

--- a/packages/@aws-cdk/mixins-preview/README.md
+++ b/packages/@aws-cdk/mixins-preview/README.md
@@ -183,13 +183,13 @@ Property mixins support two merge strategies:
 // MERGE (default): Deep merges properties with existing values
 Mixins.of(bucket).apply(new CfnBucketPropsMixin(
   { versioningConfiguration: { status: "Enabled" } },
-  { strategy: PropertyMergeStrategy.MERGE }
+  { strategy: PropertyMergeStrategy.merge() }
 ));
 
 // OVERRIDE: Replaces existing property values
 Mixins.of(bucket).apply(new CfnBucketPropsMixin(
   { versioningConfiguration: { status: "Enabled" } },
-  { strategy: PropertyMergeStrategy.OVERRIDE }
+  { strategy: PropertyMergeStrategy.override() }
 ));
 ```
 

--- a/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
@@ -1,15 +1,22 @@
 /**
  * Strategy for handling nested properties in L1 property mixins
  */
-export enum PropertyMergeStrategy {
+export class PropertyMergeStrategy {
   /**
    * Override all properties
    */
-  OVERRIDE = 'override',
+  public static override() {
+    return new PropertyMergeStrategy({ strategy: 'override' });
+  }
+
   /**
    * Deep merge nested objects, override primitives and arrays
    */
-  MERGE = 'merge',
+  public static merge() {
+    return new PropertyMergeStrategy({ strategy: 'merge' });
+  }
+
+  private constructor(public readonly value: { readonly strategy: 'merge' | 'override' }) {}
 }
 
 /**
@@ -19,7 +26,7 @@ export interface CfnPropertyMixinOptions {
   /**
    * Strategy for merging nested properties
    *
-   * @default - PropertyMergeStrategy.MERGE
+   * @default - PropertyMergeStrategy.merge()
    */
   readonly strategy?: PropertyMergeStrategy;
 }

--- a/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
@@ -1,22 +1,57 @@
+import { deepMerge, shallowAssign } from '../util/property-mixins';
+
+/**
+ * Interface for applying properties to a target using a specific strategy
+ */
+export interface IMergeStrategy {
+  /**
+   * Apply properties from source to target for the given keys
+   *
+   * @param target - The construct to apply properties to
+   * @param source - The property values to apply
+   * @param allowedKeys - Only properties whose names are in this list will be
+   * read from `source` and written to `target`. This acts as an allowlist
+   * to ensure only known CloudFormation resource properties are applied.
+   */
+  apply(target: object, source: object, allowedKeys: string[]): void;
+}
+
 /**
  * Strategy for handling nested properties in L1 property mixins
  */
 export class PropertyMergeStrategy {
   /**
-   * Override all properties
+   * Replaces existing property values on the target with the values from the source.
+   * Each allowed key is copied from source to target as-is, without
+   * inspecting nested objects. Any previous value on the target is discarded.
    */
-  public static override() {
-    return new PropertyMergeStrategy({ strategy: 'override' });
+  public static override(): IMergeStrategy {
+    return new OverrideStrategy();
   }
 
   /**
-   * Deep merge nested objects, override primitives and arrays
+   * Deep merges nested objects from source into target.
+   * When both the existing and new value for a key are plain objects,
+   * their properties are merged recursively. Primitives, arrays, and
+   * mismatched types are overridden by the source value.
    */
-  public static merge() {
-    return new PropertyMergeStrategy({ strategy: 'merge' });
+  public static combine(): IMergeStrategy {
+    return new CombineStrategy();
   }
 
-  private constructor(public readonly value: { readonly strategy: 'merge' | 'override' }) {}
+  private constructor() {}
+}
+
+class CombineStrategy implements IMergeStrategy {
+  public apply(target: object, source: object, allowedKeys: string[]): void {
+    deepMerge(target, source, allowedKeys);
+  }
+}
+
+class OverrideStrategy implements IMergeStrategy {
+  public apply(target: object, source: object, allowedKeys: string[]): void {
+    shallowAssign(target, source, allowedKeys);
+  }
 }
 
 /**
@@ -26,7 +61,7 @@ export interface CfnPropertyMixinOptions {
   /**
    * Strategy for merging nested properties
    *
-   * @default - PropertyMergeStrategy.merge()
+   * @default - PropertyMergeStrategy.combine()
    */
-  readonly strategy?: PropertyMergeStrategy;
+  readonly strategy?: IMergeStrategy;
 }

--- a/packages/@aws-cdk/mixins-preview/rosetta/default.ts-fixture
+++ b/packages/@aws-cdk/mixins-preview/rosetta/default.ts-fixture
@@ -10,7 +10,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { Mixins, Mixin, IConstructSelector } from 'aws-cdk-lib/core';
 import { IMixin } from 'constructs';
-import { PropertyMergeStrategy } from '@aws-cdk/mixins-preview/mixins';
+import { PropertyMergeStrategy, IMergeStrategy } from '@aws-cdk/mixins-preview/mixins';
 import { CfnBucketPropsMixin } from '@aws-cdk/mixins-preview/aws-s3/mixins';
 
 // for testing purposes, ensure these imports work

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
@@ -245,7 +245,7 @@ class L1PropsMixin extends ClassType {
       stmt.assign($this.props, flattenFunction
         ? expr.object(expr.splat(props), expr.splat(CallableProxy.fromName(flattenFunction.name, this.scope).invoke(props)))
         : props),
-      stmt.assign($this.strategy, expr.binOp(options?.prop('strategy'), '??', MIXINS_COMMON.PropertyMergeStrategy.MERGE)),
+      stmt.assign($this.strategy, expr.binOp(options?.prop('strategy'), '??', MIXINS_COMMON.PropertyMergeStrategy.merge())),
     );
   }
 
@@ -301,7 +301,7 @@ class L1PropsMixin extends ClassType {
         .then(
           stmt.block(
             stmt
-              .if_(expr.eq($this.strategy, MIXINS_COMMON.PropertyMergeStrategy.MERGE))
+              .if_(expr.eq($this.strategy.value.strategy, expr.lit('merge')))
               .then(
                 stmt.block(
                   MIXINS_UTILS.deepMerge(construct, $this.props, CFN_PROPERTY_KEYS),

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/builder.ts
@@ -7,7 +7,7 @@ import { RelationshipDecider } from '@aws-cdk/spec2cdk/lib/cdk/relationship-deci
 import { ResolverBuilder } from '@aws-cdk/spec2cdk/lib/cdk/resolver-builder';
 import type { Expression, Method } from '@cdklabs/typewriter';
 import { ExternalModule, FreeFunction, Module, ClassType, Stability, StructType, Type, expr, stmt, $T, ThingSymbol, $this, CallableProxy } from '@cdklabs/typewriter';
-import { MIXINS_COMMON, MIXINS_UTILS } from './helpers';
+import { MIXINS_COMMON } from './helpers';
 import type { AddServiceProps, LibraryBuilderProps } from '@aws-cdk/spec2cdk/lib/cdk/library-builder';
 import { LibraryBuilder } from '@aws-cdk/spec2cdk/lib/cdk/library-builder';
 import type { LocatedModule, ServiceSubmoduleProps } from '@aws-cdk/spec2cdk/lib/cdk/service-submodule';
@@ -59,7 +59,6 @@ export class MixinsBuilder extends LibraryBuilder<MixinsServiceModule> {
     CDK_CORE.import(module, 'cdk');
     CONSTRUCTS.import(module, 'constructs');
     MIXINS_COMMON.import(module, 'mixins', { fromLocation: '../../mixins' });
-    MIXINS_UTILS.import(module, 'helpers', { fromLocation: '../../util/property-mixins' });
     submodule.constructLibModule.import(module, 'service');
 
     return { module, filePath };
@@ -215,7 +214,7 @@ class L1PropsMixin extends ClassType {
 
     this.addProperty({
       name: 'strategy',
-      type: MIXINS_COMMON.PropertyMergeStrategy,
+      type: MIXINS_COMMON.IMergeStrategy,
       protected: true,
       immutable: true,
     });
@@ -245,7 +244,7 @@ class L1PropsMixin extends ClassType {
       stmt.assign($this.props, flattenFunction
         ? expr.object(expr.splat(props), expr.splat(CallableProxy.fromName(flattenFunction.name, this.scope).invoke(props)))
         : props),
-      stmt.assign($this.strategy, expr.binOp(options?.prop('strategy'), '??', MIXINS_COMMON.PropertyMergeStrategy.merge())),
+      stmt.assign($this.strategy, expr.binOp(options?.prop('strategy'), '??', MIXINS_COMMON.PropertyMergeStrategy.combine())),
     );
   }
 
@@ -300,18 +299,7 @@ class L1PropsMixin extends ClassType {
         .if_(CallableProxy.fromMethod(supports).invoke(construct))
         .then(
           stmt.block(
-            stmt
-              .if_(expr.eq($this.strategy.value.strategy, expr.lit('merge')))
-              .then(
-                stmt.block(
-                  MIXINS_UTILS.deepMerge(construct, $this.props, CFN_PROPERTY_KEYS),
-                ),
-              )
-              .else(
-                stmt.block(
-                  MIXINS_UTILS.shallowAssign(construct, $this.props, CFN_PROPERTY_KEYS),
-                ),
-              ),
+            $this.strategy.callMethod('apply', construct, $this.props, CFN_PROPERTY_KEYS),
           ),
         ),
     );

--- a/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/helpers.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2mixins/helpers.ts
@@ -1,14 +1,9 @@
-import { Type, ExternalModule, $T, $E, expr, ThingSymbol } from '@cdklabs/typewriter';
+import { Type, ExternalModule, $T } from '@cdklabs/typewriter';
 
 class MixinsCommon extends ExternalModule {
   public readonly PropertyMergeStrategy = $T(Type.fromName(this, 'PropertyMergeStrategy'));
+  public readonly IMergeStrategy = Type.fromName(this, 'IMergeStrategy');
   public readonly CfnPropertyMixinOptions = Type.fromName(this, 'CfnPropertyMixinOptions');
 }
 
-class MixinsUtils extends ExternalModule {
-  public readonly deepMerge = $E(expr.sym(new ThingSymbol('deepMerge', this)));
-  public readonly shallowAssign = $E(expr.sym(new ThingSymbol('shallowAssign', this)));
-}
-
 export const MIXINS_COMMON = new MixinsCommon('@aws-cdk/mixins-preview/mixins');
-export const MIXINS_UTILS = new MixinsUtils('@aws-cdk/mixins-preview/util/property-mixins');

--- a/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/resources.test.ts.snap
+++ b/packages/@aws-cdk/mixins-preview/test/codegen/__snapshots__/resources.test.ts.snap
@@ -5,7 +5,6 @@ exports[`L1 property mixin for a standard-issue resource 1`] = `
 import * as cdk from "aws-cdk-lib/core";
 import * as constructs from "constructs";
 import * as mixins from "../../mixins";
-import * as helpers from "../../util/property-mixins";
 import * as service from "aws-cdk-lib/aws-some";
 
 /**
@@ -19,7 +18,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
 
   protected readonly props: CfnThingMixinProps;
 
-  protected readonly strategy: mixins.PropertyMergeStrategy;
+  protected readonly strategy: mixins.IMergeStrategy;
 
   /**
    * Create a mixin to apply properties to \`AWS::Some::Resource\`.
@@ -30,7 +29,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
   public constructor(props: CfnThingMixinProps, options: mixins.CfnPropertyMixinOptions = {}) {
     super();
     this.props = props;
-    this.strategy = (options.strategy ?? mixins.PropertyMergeStrategy.MERGE);
+    this.strategy = (options.strategy ?? mixins.PropertyMergeStrategy.combine());
   }
 
   /**
@@ -45,11 +44,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
    */
   public applyTo(construct: constructs.IConstruct): void {
     if (this.supports(construct)) {
-      if ((this.strategy === mixins.PropertyMergeStrategy.MERGE)) {
-        helpers.deepMerge(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
-      } else {
-        helpers.shallowAssign(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
-      }
+      this.strategy.apply(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
     }
   }
 }
@@ -107,7 +102,6 @@ exports[`L1 property mixin with deeply nested relationship properties 1`] = `
 import * as cdk from "aws-cdk-lib/core";
 import * as constructs from "constructs";
 import * as mixins from "../../mixins";
-import * as helpers from "../../util/property-mixins";
 import * as service from "aws-cdk-lib/aws-some";
 import { aws_other as otherRefs } from "aws-cdk-lib/interfaces";
 
@@ -122,7 +116,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
 
   protected readonly props: CfnThingMixinProps;
 
-  protected readonly strategy: mixins.PropertyMergeStrategy;
+  protected readonly strategy: mixins.IMergeStrategy;
 
   /**
    * Create a mixin to apply properties to \`AWS::Some::Resource\`.
@@ -136,7 +130,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
       ...props,
       ...flattenCfnThingMixinProps(props)
     };
-    this.strategy = (options.strategy ?? mixins.PropertyMergeStrategy.MERGE);
+    this.strategy = (options.strategy ?? mixins.PropertyMergeStrategy.combine());
   }
 
   /**
@@ -151,11 +145,7 @@ export class CfnThingPropsMixin extends cdk.Mixin implements constructs.IMixin {
    */
   public applyTo(construct: constructs.IConstruct): void {
     if (this.supports(construct)) {
-      if ((this.strategy === mixins.PropertyMergeStrategy.MERGE)) {
-        helpers.deepMerge(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
-      } else {
-        helpers.shallowAssign(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
-      }
+      this.strategy.apply(construct, this.props, CfnThingPropsMixin.CFN_PROPERTY_KEYS);
     }
   }
 }

--- a/packages/@aws-cdk/mixins-preview/test/services/aws-s3/s3-mixins.test.ts
+++ b/packages/@aws-cdk/mixins-preview/test/services/aws-s3/s3-mixins.test.ts
@@ -70,7 +70,7 @@ describe('S3 Mixins', () => {
 
       const mixin = new s3Mixins.CfnBucketPropsMixin(
         { versioningConfiguration: { mfaDelete: 'Disabled' } as any },
-        { strategy: PropertyMergeStrategy.OVERRIDE },
+        { strategy: PropertyMergeStrategy.override() },
       );
       mixin.applyTo(bucket);
 


### PR DESCRIPTION
### Reason for this change

`PropertyMergeStrategy` is currently a TypeScript enum, which makes it impossible to extend individual strategies with additional configuration options in the future. For example, if we wanted to let users configure array handling behavior for the `combine` strategy, we'd have no way to do that without a breaking change. It also prevents users from implementing their own custom merge strategies.

By converting it to a factory class that returns `IMergeStrategy` instances, we enable both future extensibility and custom implementations. This follows the same pattern used by `ConstructSelector` in `aws-cdk-lib/core`.

As an example, a future extension could look like this:

```ts
// Today (no options, works unchanged)
PropertyMergeStrategy.combine()

// Future (add optional options bag, non-breaking)
PropertyMergeStrategy.combine({ arrays: true })
```

### Description of changes

`PropertyMergeStrategy` is now a pure factory class with static methods `combine()` and `override()` that return `IMergeStrategy` instances. The merge logic that was previously inlined in every generated mixin class (an if/else choosing between `deepMerge` and `shallowAssign`) is now encapsulated in private strategy implementations behind the `IMergeStrategy` interface. This simplifies the generated code to a single `this.strategy.apply()` call and removes the `helpers` import from generated files entirely.

The strategy was renamed from `merge()` to `combine()` to avoid a tautology with the `IMergeStrategy` interface name. Users can now implement `IMergeStrategy` to define custom merge behavior, which is documented with an example in the README.

### Describe any new or updated permissions being added

No new permissions.

### Description of how you validated changes

`yarn build+test+extract` passes. All 155 unit tests pass, codegen snapshots updated, 8 integration tests unchanged, rosetta extract clean.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

BREAKING CHANGE: `PropertyMergeStrategy` is no longer a TypeScript enum. `PropertyMergeStrategy.MERGE` and `PropertyMergeStrategy.OVERRIDE` have been replaced with `PropertyMergeStrategy.combine()` and `PropertyMergeStrategy.override()` factory methods that return `IMergeStrategy`. The `CfnPropertyMixinOptions.strategy` property type changed from `PropertyMergeStrategy` to `IMergeStrategy`.
