### PR TITLE
docs(lambda): add durable function policy suggestion.

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function.ts
@@ -241,8 +241,8 @@ export interface FunctionOptions extends EventInvokeConfigOptions {
    * The default Role automatically has permissions granted for Lambda execution. If you
    * provide a Role, you must add the relevant AWS managed policies yourself.
    *
-   * The relevant managed policies are "service-role/AWSLambdaBasicExecutionRole" and
-   * "service-role/AWSLambdaVPCAccessExecutionRole".
+   * The relevant managed policies are "service-role/AWSLambdaBasicExecutionRole",
+   * "service-role/AWSLambdaVPCAccessExecutionRole" and "service-role/AWSLambdaBasicDurableExecutionRolePolicy".
    *
    * @default - A unique role will be generated for this lambda function.
    * Both supplied and generated roles can always be changed by calling `addToRolePolicy`.


### PR DESCRIPTION
### Issue # N/A

Closes # N/A.

### Reason for this change

Lambda Durable Functions added a new managed policy when a durable config is used:
https://github.com/aws/aws-cdk/blob/23d48fc7fb4de6a948318ce547ba4bbf5571956a/packages/aws-cdk-lib/aws-lambda/lib/function.ts#L1011-L1015

### Description of changes

This change updates in-line docs to reference the additional managed policy

### Describe any new or updated permissions being added

None, docs only.

### Description of how you validated changes

Ran basic build and `yarn test aws-lambda`

```
Test Suites: 38 passed, 38 total
Tests:       829 passed, 829 total
Snapshots:   1 passed, 1 total
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
