### PR TITLE
fix(ec2): vpc interface endpoint not attaching to selected subnets (#…

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-endpoint-cfn-subnet.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-endpoint-cfn-subnet.ts
@@ -1,0 +1,38 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+
+const app = new cdk.App();
+
+class VpcEndpointCfnSubnetStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const vpc = new ec2.Vpc(this, 'MyVpc', {
+            subnetConfiguration: [
+                {
+                    cidrMask: 24,
+                    name: 'Public',
+                    subnetType: ec2.SubnetType.PUBLIC,
+                },
+            ]
+        });
+
+        const cfnSubnet = new ec2.CfnSubnet(this, 'CfnSubnet', {
+            vpcId: vpc.vpcId,
+            cidrBlock: '10.0.100.0/24',
+            availabilityZone: 'us-east-1a'
+        });
+
+        vpc.addInterfaceEndpoint('SecretsManagerEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+            subnets: { subnets: [cfnSubnet as unknown as ec2.ISubnet] },
+        });
+    }
+}
+
+const stack = new VpcEndpointCfnSubnetStack(app, 'aws-cdk-ec2-vpc-endpoint-cfn-subnet');
+
+new IntegTest(app, 'VpcEndpointCfnSubnetTest', {
+    testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -654,13 +654,14 @@ abstract class VpcBase extends Resource implements IVpc {
     if (selection.subnets !== undefined) {
       return selection.subnets.map(s => {
         if (s instanceof CfnSubnet) {
-          const wrapperId = `WrappedSubnet${s.node.addr}`;
+          const cfnSubnet = s as CfnSubnet;
+          const wrapperId = `WrappedSubnet${cfnSubnet.node.addr}`;
           let wrappedSubnet = this.node.tryFindChild(wrapperId) as ISubnet;
           if (!wrappedSubnet) {
             wrappedSubnet = Subnet.fromSubnetAttributes(this, wrapperId, {
-              subnetId: s.ref,
-              availabilityZone: s.availabilityZone,
-              ipv4CidrBlock: s.cidrBlock,
+              subnetId: cfnSubnet.ref,
+              availabilityZone: cfnSubnet.availabilityZone,
+              ipv4CidrBlock: cfnSubnet.cidrBlock,
             });
           }
           return wrappedSubnet;

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -652,7 +652,21 @@ abstract class VpcBase extends Resource implements IVpc {
     selection = this.reifySelectionDefaults(selection);
 
     if (selection.subnets !== undefined) {
-      return selection.subnets;
+      return selection.subnets.map(s => {
+        if (s instanceof CfnSubnet) {
+          const wrapperId = `WrappedSubnet${s.node.addr}`;
+          let wrappedSubnet = this.node.tryFindChild(wrapperId) as ISubnet;
+          if (!wrappedSubnet) {
+            wrappedSubnet = Subnet.fromSubnetAttributes(this, wrapperId, {
+              subnetId: s.ref,
+              availabilityZone: s.availabilityZone,
+              ipv4CidrBlock: s.cidrBlock,
+            });
+          }
+          return wrappedSubnet;
+        }
+        return s;
+      });
     }
 
     let subnets;
@@ -1403,7 +1417,7 @@ export class Vpc extends VpcBase {
       throw new ValidationError('All arguments to Vpc.fromLookup() must be concrete (no Tokens)', scope);
     }
 
-    const filter: {[key: string]: string} = makeTagFilter(options.tags);
+    const filter: { [key: string]: string } = makeTagFilter(options.tags);
 
     // We give special treatment to some tags
     if (options.vpcId) { filter['vpc-id'] = options.vpcId; }
@@ -1413,7 +1427,7 @@ export class Vpc extends VpcBase {
       filter.isDefault = options.isDefault ? 'true' : 'false';
     }
 
-    const overrides: {[key: string]: string} = {};
+    const overrides: { [key: string]: string } = {};
     if (options.region) {
       overrides.region = options.region;
     }
@@ -1642,7 +1656,7 @@ export class Vpc extends VpcBase {
       // If given AZs and stack AZs are both resolved, then validate their compatibility.
       const resolvedStackAzs = this.resolveStackAvailabilityZones(stack.availabilityZones);
       const areGivenAzsSubsetOfStack = resolvedStackAzs.length === 0 ||
-        props.availabilityZones.every(az => Token.isUnresolved(az) ||resolvedStackAzs.includes(az));
+        props.availabilityZones.every(az => Token.isUnresolved(az) || resolvedStackAzs.includes(az));
       if (!areGivenAzsSubsetOfStack) {
         throw new ValidationError(`Given VPC 'availabilityZones' ${props.availabilityZones} must be a subset of the stack's availability zones ${resolvedStackAzs}`, this);
       }
@@ -1829,7 +1843,7 @@ export class Vpc extends VpcBase {
   private createSubnets() {
     const requestedSubnets: RequestedSubnet[] = [];
 
-    this.subnetConfiguration.forEach((configuration)=> (
+    this.subnetConfiguration.forEach((configuration) => (
       this.availabilityZones.forEach((az, index) => {
         requestedSubnets.push({
           availabilityZone: az,

--- a/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
@@ -13,6 +13,8 @@ import {
   SubnetFilter,
   SubnetType,
   Vpc,
+  CfnSubnet,
+  ISubnet,
   VpcEndpointDnsRecordIpType,
   VpcEndpointIpAddressType,
 } from '../lib';
@@ -639,6 +641,40 @@ describe('vpc endpoint', () => {
           subnets: [],
         }),
       })).toThrow();
+    });
+    test('endpoint selection works with L1 CfnSubnet passed as ISubnet', () => {
+      // GIVEN
+      const stack = new Stack();
+      const vpc = new Vpc(stack, 'VPC', {
+        subnetConfiguration: [
+          {
+            cidrMask: 24,
+            name: 'Public',
+            subnetType: SubnetType.PUBLIC,
+          },
+        ]
+      });
+
+      const cfnSubnet = new CfnSubnet(stack, 'CfnSubnet', {
+        vpcId: vpc.vpcId,
+        cidrBlock: '10.0.100.0/24',
+        availabilityZone: 'us-east-1a'
+      });
+
+      // WHEN
+      vpc.addInterfaceEndpoint('YourService', {
+        service: InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+        subnets: { subnets: [cfnSubnet as unknown as ISubnet] },
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        SubnetIds: [
+          {
+            Ref: 'CfnSubnet',
+          },
+        ],
+      });
     });
     test('test vpc interface endpoint with cn.com.amazonaws prefix can be created correctly in cn-north-1', () => {
       // GIVEN


### PR DESCRIPTION
fix(ec2): vpc interface endpoint not attaching to selected subnets (#37144)

CfnSubnet objects passed within SubnetSelection are now automatically wrapped with Subnet.fromSubnetAttributes to ensure they can be used for things like interface endpoint SubnetIds.

### Issue # (if applicable)

Closes #37144

### Reason for this change

When creating a VPC interface endpoint and passing `CfnSubnet` objects directly into the `subnets` array of [SubnetSelection](cci:2://file:///A:/Desktop/AWS/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts:351:0-423:1), the generated CloudFormation template results in an empty `SubnetIds` array. This is because `CfnSubnet` is an L1 construct and does not implement the full [ISubnet](cci:2://file:///A:/Desktop/AWS/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts:87:0-120:1) interface, specifically lacking the `.subnetId` property that the endpoint selection logic relies on, causing it to fail silently.

### Description of changes

- Updated `Vpc.selectSubnetObjects` in `@aws-cdk/aws-ec2` to intercept `SubnetSelection.subnets` arrays.
- It now checks if any explicitly provided subnets are instances of `CfnSubnet`. 
- If found, it automatically wraps them in a singleton wrapper using `Subnet.fromSubnetAttributes(this, id, { subnetId: s.ref, ... })`, retaining their availability zone and CIDR block properties if available.
- This allows `vpc-endpoint` constructs (and anything else utilizing [selectSubnetObjects](cci:1://file:///A:/Desktop/AWS/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts:647:2-684:3)) to extract the proper routing IDs during CloudFormation synthesis.

### Describe any new or updated permissions being added

N/A - No new permissions or IAM updates are required for this construct logical fix.

### Description of how you validated changes

- Added a new unit test `endpoint selection works with L1 CfnSubnet passed as ISubnet` in [packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts](cci:7://file:///A:/Desktop/AWS/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts:0:0-0:0).
- The test explicitly verifies that passing a `CfnSubnet` to `vpc.addInterfaceEndpoint()` properly populates the `SubnetIds` property with the [Ref](cci:1://file:///A:/Desktop/AWS/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts:529:2-533:3) of the CloudFormation subnet in the synthesized output.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
