### PR TITLE
feat(core): support `PropertyMergeStrategy` to merge arbitrary CFN property objects

### DIFF
--- a/design/mixins-facades-traits.md
+++ b/design/mixins-facades-traits.md
@@ -320,6 +320,33 @@ Facades on the interface, and registering Traits. This glue code is necessary
 but should not contain any functionality of its own — all actual behavior lives
 in the building blocks.
 
+For simple L2 properties that pass values straight through to the L1 resource,
+use `CfnPropsMixin` to handle the mapping. This eliminates boilerplate and
+provides type-safe property application with configurable merge behavior:
+
+```ts
+// In an L2 constructor, instead of manually setting L1 properties:
+export class MyBucket extends Resource {
+  constructor(scope: Construct, id: string, props: MyBucketProps) {
+    super(scope, id);
+    const resource = new CfnBucket(this, 'Resource');
+
+    // Use CfnPropsMixin for simple property pass-through
+    if (props.versioned) {
+      resource.with(new CfnPropsMixin(CfnBucket, {
+        versioningConfiguration: { status: 'Enabled' },
+      }));
+    }
+  }
+}
+```
+
+`CfnPropsMixin` deep merges nested properties by default
+(`PropertyMergeStrategy.combine()`), or can replace them entirely
+(`PropertyMergeStrategy.override()`). This is preferable to setting L1
+properties directly, because it handles interactions with other mixins and
+existing configuration correctly.
+
 > [!NOTE]
 > If you find yourself writing logic in the L2 glue code that does more than
 > map props, apply defaults, and wire building blocks, that logic should be

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -243,7 +243,9 @@ When to use a Mixin:
   construct's props.
 
 Mixins are _not_ a replacement for construct properties. They cannot change the
-optionality of properties or change defaults.
+optionality of properties or change defaults. When an L2 property simply passes
+a value through to the L1 resource without additional logic, use `CfnPropsMixin`
+in the L2 glue code instead of writing a standalone mixin.
 
 For detailed implementation guidelines, see the
 [Mixins Design Guidelines](./MIXINS_DESIGN_GUIDELINES.md).

--- a/docs/MIXINS_DESIGN_GUIDELINES.md
+++ b/docs/MIXINS_DESIGN_GUIDELINES.md
@@ -83,7 +83,7 @@ service module in `aws-cdk-lib`. For services that are still in alpha (i.e.
 vended as `@aws-cdk/*-alpha` packages), mixins usually live in the alpha module
 instead. Some cross-cutting mixins may be exceptions to this rule.
 
-```
+```text
 aws-cdk-lib/
   aws-s3/
     lib/
@@ -208,17 +208,36 @@ When a mixin sets properties on an L1 resource, consider how the mixin
 interacts with existing configuration. L1 properties may already be set by the
 user, by the L2, or by another mixin.
 
-**Simple properties** (strings, booleans, numbers) can typically be overwritten.
-This is expected — later mixins override earlier ones:
+For mixins that need to set properties, use `CfnPropsMixin` with a
+`PropertyMergeStrategy` instead of modifying properties directly. This handles
+merge behavior correctly and consistently.
+
+When writing custom `applyTo()` logic that modifies properties directly, choose
+the right merge behavior:
+
+**`PropertyMergeStrategy.combine()` behavior** (deep merge) — nested objects
+are merged recursively. Primitives, arrays, and mismatched types are
+overridden by the new value. This is the default and correct choice for most
+cases:
 
 ```ts
-// Simple override is fine
-construct.versioningConfiguration = { status: 'Enabled' };
+// Existing: { blockPublicAcls: true }
+// Applied:  { ignorePublicAcls: true }
+// Result:   { blockPublicAcls: true, ignorePublicAcls: true }
 ```
 
-**Nested or array properties** require more care. Decide whether the mixin
-should replace or merge with existing values. For example, a mixin that adds
-lifecycle rules should append to existing rules, not replace them:
+**`PropertyMergeStrategy.override()` behavior** (full replacement) — the
+existing value is discarded entirely. Use this for properties where partial
+merging does not make sense, such as tags or ordered lists:
+
+```ts
+// Existing: [{ key: 'Old', value: 'Tag' }]
+// Applied:  [{ key: 'New', value: 'Tag' }]
+// Result:   [{ key: 'New', value: 'Tag' }]
+```
+
+When implementing merge logic manually (because the mixin has additional
+logic beyond property setting), follow the same patterns:
 
 ```ts
 // ❌ Replaces any existing rules
@@ -233,8 +252,8 @@ construct.lifecycleConfiguration = {
 };
 ```
 
-**Document the merge behavior** in the mixin's JSDoc. Users need to understand
-whether applying a mixin will replace or extend existing configuration.
+Document the merge behavior in the mixin's JSDoc. Users must understand
+whether applying a mixin replaces or extends existing configuration.
 
 ## Testing
 

--- a/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/mixins/property-mixins.ts
@@ -1,58 +1,6 @@
-import { deepMerge, shallowAssign } from '../util/property-mixins';
+import type { IMergeStrategy } from 'aws-cdk-lib/core';
 
-/**
- * Interface for applying properties to a target using a specific strategy
- */
-export interface IMergeStrategy {
-  /**
-   * Apply properties from source to target for the given keys
-   *
-   * @param target - The construct to apply properties to
-   * @param source - The property values to apply
-   * @param allowedKeys - Only properties whose names are in this list will be
-   * read from `source` and written to `target`. This acts as an allowlist
-   * to ensure only known CloudFormation resource properties are applied.
-   */
-  apply(target: object, source: object, allowedKeys: string[]): void;
-}
-
-/**
- * Strategy for handling nested properties in L1 property mixins
- */
-export class PropertyMergeStrategy {
-  /**
-   * Replaces existing property values on the target with the values from the source.
-   * Each allowed key is copied from source to target as-is, without
-   * inspecting nested objects. Any previous value on the target is discarded.
-   */
-  public static override(): IMergeStrategy {
-    return new OverrideStrategy();
-  }
-
-  /**
-   * Deep merges nested objects from source into target.
-   * When both the existing and new value for a key are plain objects,
-   * their properties are merged recursively. Primitives, arrays, and
-   * mismatched types are overridden by the source value.
-   */
-  public static combine(): IMergeStrategy {
-    return new CombineStrategy();
-  }
-
-  private constructor() {}
-}
-
-class CombineStrategy implements IMergeStrategy {
-  public apply(target: object, source: object, allowedKeys: string[]): void {
-    deepMerge(target, source, allowedKeys);
-  }
-}
-
-class OverrideStrategy implements IMergeStrategy {
-  public apply(target: object, source: object, allowedKeys: string[]): void {
-    shallowAssign(target, source, allowedKeys);
-  }
-}
+export { type IMergeStrategy, PropertyMergeStrategy } from 'aws-cdk-lib/core';
 
 /**
  * Options for applying CfnProperty mixins

--- a/packages/aws-cdk-lib/core/lib/cfn-resource.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-resource.ts
@@ -17,7 +17,8 @@ import { capitalizePropertyNames, ignoreEmpty, PostResolveToken } from './util';
 import { FeatureFlags } from './feature-flags';
 import type { ResolutionTypeHint } from './type-hints';
 import * as cxapi from '../../cx-api';
-import { AssumptionError, ValidationError } from './errors';
+import { ValidationError } from './errors';
+import { deepMerge } from './private/deep-merge';
 import type { ResourceEnvironment } from './environment';
 
 export interface CfnResourceProps {
@@ -631,131 +632,6 @@ export interface ICfnResourceOptions {
    * using construct.addMetadata(), but would not appear in the CloudFormation template automatically.
    */
   metadata?: { [key: string]: any };
-}
-
-/**
- * Object keys that deepMerge should not consider. Currently these include
- * CloudFormation intrinsics
- *
- * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
- */
-
-const MERGE_EXCLUDE_KEYS: string[] = [
-  'Ref',
-  'Fn::Base64',
-  'Fn::Cidr',
-  'Fn::FindInMap',
-  'Fn::GetAtt',
-  'Fn::GetAZs',
-  'Fn::ImportValue',
-  'Fn::Join',
-  'Fn::Select',
-  'Fn::Split',
-  'Fn::Sub',
-  'Fn::Transform',
-  'Fn::And',
-  'Fn::Equals',
-  'Fn::If',
-  'Fn::Not',
-  'Fn::Or',
-];
-
-/**
- * Merges `source` into `target`, overriding any existing values.
- * `null`s will cause a value to be deleted.
- */
-function deepMerge(target: any, ...sources: any[]) {
-  for (const source of sources) {
-    if (typeof(source) !== 'object' || typeof(target) !== 'object') {
-      throw new AssumptionError(`Invalid usage. Both source (${JSON.stringify(source)}) and target (${JSON.stringify(target)}) must be objects`);
-    }
-
-    for (const key of Object.keys(source)) {
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-        continue;
-      }
-
-      const value = source[key];
-      if (typeof(value) === 'object' && value != null && !Array.isArray(value)) {
-        // if the value at the target is not an object, override it with an
-        // object so we can continue the recursion
-        if (typeof(target[key]) !== 'object') {
-          target[key] = {};
-
-          /**
-           * If we have something that looks like:
-           *
-           *   target: { Type: 'MyResourceType', Properties: { prop1: { Ref: 'Param' } } }
-           *   sources: [ { Properties: { prop1: [ 'Fn::Join': ['-', 'hello', 'world'] ] } } ]
-           *
-           * Eventually we will get to the point where we have
-           *
-           *   target: { prop1: { Ref: 'Param' } }
-           *   sources: [ { prop1: { 'Fn::Join': ['-', 'hello', 'world'] } } ]
-           *
-           * We need to recurse 1 more time, but if we do we will end up with
-           *   { prop1: { Ref: 'Param', 'Fn::Join': ['-', 'hello', 'world'] } }
-           * which is not what we want.
-           *
-           * Instead we check to see whether the `target` value (i.e. target.prop1)
-           * is an object that contains a key that we don't want to recurse on. If it does
-           * then we essentially drop it and end up with:
-           *
-           *   { prop1: { 'Fn::Join': ['-', 'hello', 'world'] } }
-           */
-        } else if (Object.keys(target[key]).length === 1) {
-          if (MERGE_EXCLUDE_KEYS.includes(Object.keys(target[key])[0])) {
-            target[key] = {};
-          }
-        }
-
-        /**
-         * There might also be the case where the source is an intrinsic
-         *
-         *    target: {
-         *      Type: 'MyResourceType',
-         *      Properties: {
-         *        prop1: { subprop: { name: { 'Fn::GetAtt': 'abc' } } }
-         *      }
-         *    }
-         *    sources: [ {
-         *      Properties: {
-         *        prop1: { subprop: { 'Fn::If': ['SomeCondition', {...}, {...}] }}
-         *      }
-         *    } ]
-         *
-         * We end up in a place that is the reverse of the above check, the source
-         * becomes an intrinsic before the target
-         *
-         *   target: { subprop: { name: { 'Fn::GetAtt': 'abc' } } }
-         *   sources: [{
-         *     'Fn::If': [ 'MyCondition', {...}, {...} ]
-         *   }]
-         */
-        if (Object.keys(value).length === 1) {
-          if (MERGE_EXCLUDE_KEYS.includes(Object.keys(value)[0])) {
-            target[key] = {};
-          }
-        }
-
-        deepMerge(target[key], value);
-
-        // if the result of the merge is an empty object, it's because the
-        // eventual value we assigned is `undefined`, and there are no
-        // sibling concrete values alongside, so we can delete this tree.
-        const output = target[key];
-        if (typeof(output) === 'object' && Object.keys(output).length === 0) {
-          delete target[key];
-        }
-      } else if (value === undefined) {
-        delete target[key];
-      } else {
-        target[key] = value;
-      }
-    }
-  }
-
-  return target;
 }
 
 /**

--- a/packages/aws-cdk-lib/core/lib/helpers-internal/cfn-props-mixin.ts
+++ b/packages/aws-cdk-lib/core/lib/helpers-internal/cfn-props-mixin.ts
@@ -1,11 +1,10 @@
 import type { IConstruct, IMixin } from 'constructs';
-import { CfnResource } from '../../cfn-resource';
-import type { IMergeStrategy } from '../property-merge-strategy';
-import { PropertyMergeStrategy } from '../property-merge-strategy';
+import { CfnResource } from '../cfn-resource';
+import type { IMergeStrategy } from '../mixins/property-merge-strategy';
+import { PropertyMergeStrategy } from '../mixins/property-merge-strategy';
 
 /**
  * Options for CfnPropsMixin
- * @internal
  */
 export interface CfnPropsMixinOptions {
   /**
@@ -44,7 +43,6 @@ type CfnWritableProps<T extends CfnResource> = {
  *     versioningConfiguration: { status: 'Enabled' },
  *   }));
  * ```
- * @internal
  */
 export class CfnPropsMixin<T extends CfnResource> implements IMixin {
   private readonly cfnResourceType: string;

--- a/packages/aws-cdk-lib/core/lib/helpers-internal/index.ts
+++ b/packages/aws-cdk-lib/core/lib/helpers-internal/index.ts
@@ -10,3 +10,4 @@ export { constructAnalyticsFromScope } from '../private/stack-metadata';
 export * from './memoize';
 export * from './reflections';
 export * from './traits';
+export { CfnPropsMixin, type CfnPropsMixinOptions } from '../mixins/private/cfn-props-mixin';

--- a/packages/aws-cdk-lib/core/lib/helpers-internal/index.ts
+++ b/packages/aws-cdk-lib/core/lib/helpers-internal/index.ts
@@ -10,4 +10,4 @@ export { constructAnalyticsFromScope } from '../private/stack-metadata';
 export * from './memoize';
 export * from './reflections';
 export * from './traits';
-export { CfnPropsMixin, type CfnPropsMixinOptions } from '../mixins/private/cfn-props-mixin';
+export { CfnPropsMixin, type CfnPropsMixinOptions } from './cfn-props-mixin';

--- a/packages/aws-cdk-lib/core/lib/mixins/index.ts
+++ b/packages/aws-cdk-lib/core/lib/mixins/index.ts
@@ -1,3 +1,4 @@
 export * from './mixins';
 export * from './selectors';
 export * from './applicator';
+export * from './property-merge-strategy';

--- a/packages/aws-cdk-lib/core/lib/mixins/private/cfn-props-mixin.ts
+++ b/packages/aws-cdk-lib/core/lib/mixins/private/cfn-props-mixin.ts
@@ -1,0 +1,75 @@
+import type { IConstruct, IMixin } from 'constructs';
+import { CfnResource } from '../../cfn-resource';
+import type { IMergeStrategy } from '../property-merge-strategy';
+import { PropertyMergeStrategy } from '../property-merge-strategy';
+
+/**
+ * Options for CfnPropsMixin
+ * @internal
+ */
+export interface CfnPropsMixinOptions {
+  /**
+   * Strategy for merging properties
+   *
+   * @default - PropertyMergeStrategy.combine()
+   */
+  readonly strategy?: IMergeStrategy;
+}
+
+/**
+ * Recursively makes all properties optional.
+ */
+type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
+
+/**
+ * Extract writable, non-function own properties from a CfnResource subclass.
+ * Excludes inherited CfnResource/CfnElement/CfnRefElement members and readonly attributes.
+ */
+type CfnWritableProps<T extends CfnResource> = {
+  [K in keyof T as
+  K extends keyof CfnResource ? never :
+    T[K] extends Function ? never :
+      K extends `attr${string}` ? never :
+        K extends 'cdkTagManager' ? never :
+          K]: T[K];
+};
+
+/**
+ * A generic, type-safe mixin for applying L1 CloudFormation properties.
+ *
+ * Usage:
+ * ```ts
+ * new s3.Bucket(this, 'Bucket')
+ *   .with(new CfnPropsMixin(s3.CfnBucket, {
+ *     versioningConfiguration: { status: 'Enabled' },
+ *   }));
+ * ```
+ * @internal
+ */
+export class CfnPropsMixin<T extends CfnResource> implements IMixin {
+  private readonly cfnResourceType: string;
+  private readonly props: DeepPartial<CfnWritableProps<T>>;
+  private readonly propertyKeys: string[];
+  private readonly strategy: IMergeStrategy;
+
+  public constructor(
+    resourceClass: (abstract new (...args: any[]) => T) & { readonly CFN_RESOURCE_TYPE_NAME: string },
+    props: DeepPartial<CfnWritableProps<T>>,
+    options: CfnPropsMixinOptions = {},
+  ) {
+    this.cfnResourceType = resourceClass.CFN_RESOURCE_TYPE_NAME;
+    this.props = props;
+    this.propertyKeys = Object.keys(props);
+    this.strategy = options.strategy ?? PropertyMergeStrategy.combine();
+  }
+
+  public supports(construct: IConstruct): boolean {
+    return CfnResource.isCfnResource(construct) && construct.cfnResourceType === this.cfnResourceType;
+  }
+
+  public applyTo(construct: IConstruct): void {
+    if (this.supports(construct)) {
+      this.strategy.apply(construct, this.props, this.propertyKeys);
+    }
+  }
+}

--- a/packages/aws-cdk-lib/core/lib/mixins/property-merge-strategy.ts
+++ b/packages/aws-cdk-lib/core/lib/mixins/property-merge-strategy.ts
@@ -1,0 +1,81 @@
+import { deepMerge as deepMergeCopy } from '../private/deep-merge';
+
+/**
+ * Interface for applying properties to a target using a specific strategy
+ */
+export interface IMergeStrategy {
+  /**
+   * Apply properties from source to target for the given keys
+   *
+   * @param target - The construct to apply properties to
+   * @param source - The property values to apply
+   * @param allowedKeys - Only properties whose names are in this list will be
+   * read from `source` and written to `target`. This acts as an allowlist
+   * to ensure only known CloudFormation resource properties are applied.
+   */
+  apply(target: object, source: object, allowedKeys: string[]): void;
+}
+
+/**
+ * Strategy for handling nested properties in L1 property mixins
+ */
+export class PropertyMergeStrategy {
+  /**
+   * Replaces existing property values on the target with the values from the source.
+   * Each allowed key is copied from source to target as-is, without
+   * inspecting nested objects. Any previous value on the target is discarded.
+   */
+  public static override(): IMergeStrategy {
+    return new OverrideStrategy();
+  }
+
+  /**
+   * Deep merges nested objects from source into target.
+   * When both the existing and new value for a key are plain objects,
+   * their properties are merged recursively. Primitives, arrays, and
+   * mismatched types are overridden by the source value.
+   */
+  public static combine(): IMergeStrategy {
+    return new CombineStrategy();
+  }
+
+  private constructor() {}
+}
+
+class CombineStrategy implements IMergeStrategy {
+  public apply(target: object, source: object, allowedKeys: string[]): void {
+    for (const key of allowedKeys) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue;
+      }
+
+      if (!(key in source)) {
+        continue;
+      }
+
+      const sourceValue = (source as any)[key];
+      const targetValue = (target as any)[key];
+
+      if (typeof sourceValue === 'object' && sourceValue != null && !Array.isArray(sourceValue) &&
+          typeof targetValue === 'object' && targetValue != null && !Array.isArray(targetValue)) {
+        (target as any)[key] = deepMergeCopy(Object.create(null), targetValue, sourceValue);
+      } else {
+        (target as any)[key] = sourceValue;
+      }
+    }
+  }
+}
+
+class OverrideStrategy implements IMergeStrategy {
+  public apply(target: object, source: object, allowedKeys: string[]): void {
+    for (const key of allowedKeys) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue;
+      }
+
+      if (key in source) {
+        (target as any)[key] = (source as any)[key];
+      }
+    }
+  }
+}

--- a/packages/aws-cdk-lib/core/lib/private/deep-merge.ts
+++ b/packages/aws-cdk-lib/core/lib/private/deep-merge.ts
@@ -1,34 +1,4 @@
-import { AssumptionError } from 'aws-cdk-lib/core';
-
-/**
- * Deep merge utility for nested objects
- * @param target The target object to merge into
- * @param source The source object to merge from
- * @param mergeOnly The explicit list of property keys to copy from source
- */
-export function deepMerge(target: any, source: any, mergeOnly: string[]): any {
-  for (const key of mergeOnly) {
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-      continue;
-    }
-
-    if (!(key in source)) {
-      continue;
-    }
-
-    const sourceValue = source[key];
-    const targetValue = target[key];
-
-    if (typeof sourceValue === 'object' && sourceValue != null && !Array.isArray(sourceValue) &&
-        typeof targetValue === 'object' && targetValue != null && !Array.isArray(targetValue)) {
-      target[key] = deepMergeCopy(Object.create(null), targetValue, sourceValue);
-    } else {
-      target[key] = sourceValue;
-    }
-  }
-
-  return target;
-}
+import { AssumptionError } from '../errors';
 
 /**
  * Object keys that deepMerge should not consider. Currently these include
@@ -36,7 +6,6 @@ export function deepMerge(target: any, source: any, mergeOnly: string[]): any {
  *
  * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
  */
-
 const MERGE_EXCLUDE_KEYS: string[] = [
   'Ref',
   'Fn::Base64',
@@ -58,13 +27,10 @@ const MERGE_EXCLUDE_KEYS: string[] = [
 ];
 
 /**
- * This is an unchanged copy from packages/aws-cdk-lib/core/lib/cfn-resource.ts
- * The intention will be to use this function from core once the package is merged.
- *
  * Merges `source` into `target`, overriding any existing values.
  * `null`s will cause a value to be deleted.
  */
-function deepMergeCopy(target: any, ...sources: any[]) {
+export function deepMerge(target: any, ...sources: any[]) {
   for (const source of sources) {
     if (typeof(source) !== 'object' || typeof(target) !== 'object') {
       throw new AssumptionError(`Invalid usage. Both source (${JSON.stringify(source)}) and target (${JSON.stringify(target)}) must be objects`);
@@ -138,7 +104,7 @@ function deepMergeCopy(target: any, ...sources: any[]) {
           }
         }
 
-        deepMergeCopy(target[key], value);
+        deepMerge(target[key], value);
 
         // if the result of the merge is an empty object, it's because the
         // eventual value we assigned is `undefined`, and there are no
@@ -155,24 +121,5 @@ function deepMergeCopy(target: any, ...sources: any[]) {
     }
   }
 
-  return target;
-}
-
-/**
- * Shallow assign utility that explicitly assigns each property
- * @param target The target object to assign properties to
- * @param source The source object to read properties from
- * @param assignOnly The explicit list of property keys that are allowed to be assigned
- */
-export function shallowAssign(target: any, source: any, assignOnly: string[]): any {
-  for (const key of assignOnly) {
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-      continue;
-    }
-
-    if (key in source) {
-      target[key] = source[key];
-    }
-  }
   return target;
 }

--- a/packages/aws-cdk-lib/core/test/helpers-internal/cfn-props-mixin.test.ts
+++ b/packages/aws-cdk-lib/core/test/helpers-internal/cfn-props-mixin.test.ts
@@ -1,9 +1,8 @@
 import { Construct } from 'constructs';
 import { CfnBucket } from '../../../aws-s3';
 import { CfnQueue } from '../../../aws-sqs';
-import { Stack } from '../../lib';
-import { CfnPropsMixin } from '../../lib/mixins/private/cfn-props-mixin';
-import { PropertyMergeStrategy } from '../../lib/mixins/property-merge-strategy';
+import { Stack, PropertyMergeStrategy } from '../../lib';
+import { CfnPropsMixin } from '../../lib/helpers-internal/cfn-props-mixin';
 
 describe('CfnPropsMixin', () => {
   let stack: Stack;

--- a/packages/aws-cdk-lib/core/test/mixins/cfn-props-mixin.test.ts
+++ b/packages/aws-cdk-lib/core/test/mixins/cfn-props-mixin.test.ts
@@ -1,0 +1,119 @@
+import { Construct } from 'constructs';
+import { CfnBucket } from '../../../aws-s3';
+import { CfnQueue } from '../../../aws-sqs';
+import { Stack } from '../../lib';
+import { CfnPropsMixin } from '../../lib/mixins/private/cfn-props-mixin';
+import { PropertyMergeStrategy } from '../../lib/mixins/property-merge-strategy';
+
+describe('CfnPropsMixin', () => {
+  let stack: Stack;
+
+  beforeEach(() => {
+    stack = new Stack();
+  });
+
+  test('applies properties to matching resource', () => {
+    const bucket = new CfnBucket(stack, 'Bucket');
+
+    bucket.with(new CfnPropsMixin(CfnBucket, {
+      bucketName: 'my-bucket',
+    }));
+
+    expect(bucket.bucketName).toBe('my-bucket');
+  });
+
+  test('applies multiple properties', () => {
+    const bucket = new CfnBucket(stack, 'Bucket');
+
+    bucket.with(new CfnPropsMixin(CfnBucket, {
+      bucketName: 'my-bucket',
+      versioningConfiguration: { status: 'Enabled' },
+    }));
+
+    expect(bucket.bucketName).toBe('my-bucket');
+    expect(bucket.versioningConfiguration).toEqual({ status: 'Enabled' });
+  });
+
+  test('does not apply to non-matching resource type', () => {
+    const queue = new CfnQueue(stack, 'Queue');
+
+    queue.with(new CfnPropsMixin(CfnBucket, {
+      bucketName: 'my-bucket',
+    }));
+
+    expect((queue as any).bucketName).toBeUndefined();
+  });
+
+  test('supports returns true for matching resource', () => {
+    const bucket = new CfnBucket(stack, 'Bucket');
+    const mixin = new CfnPropsMixin(CfnBucket, { bucketName: 'my-bucket' });
+
+    expect(mixin.supports(bucket)).toBe(true);
+  });
+
+  test('supports returns false for non-matching resource', () => {
+    const queue = new CfnQueue(stack, 'Queue');
+    const mixin = new CfnPropsMixin(CfnBucket, { bucketName: 'my-bucket' });
+
+    expect(mixin.supports(queue)).toBe(false);
+  });
+
+  test('supports returns false for non-CfnResource constructs', () => {
+    const construct = new Construct(stack, 'Plain');
+    const mixin = new CfnPropsMixin(CfnBucket, { bucketName: 'my-bucket' });
+
+    expect(mixin.supports(construct)).toBe(false);
+  });
+
+  test('deep merges nested objects by default (combine strategy)', () => {
+    const bucket = new CfnBucket(stack, 'Bucket', {
+      publicAccessBlockConfiguration: {
+        blockPublicAcls: true,
+        blockPublicPolicy: true,
+      },
+    });
+
+    expect(bucket.publicAccessBlockConfiguration).toEqual({
+      blockPublicAcls: true,
+      blockPublicPolicy: true,
+    });
+
+    bucket.with(new CfnPropsMixin(CfnBucket, {
+      publicAccessBlockConfiguration: {
+        ignorePublicAcls: true,
+        restrictPublicBuckets: true,
+      },
+    }));
+
+    expect(bucket.publicAccessBlockConfiguration).toEqual({
+      blockPublicAcls: true,
+      blockPublicPolicy: true,
+      ignorePublicAcls: true,
+      restrictPublicBuckets: true,
+    });
+  });
+
+  test('override strategy replaces values', () => {
+    const bucket = new CfnBucket(stack, 'Bucket');
+    bucket.tagsRaw = [{ key: 'Existing', value: 'Tag' }];
+
+    bucket.with(new CfnPropsMixin(CfnBucket, {
+      tagsRaw: [{ key: 'New', value: 'Tag' }],
+    }, { strategy: PropertyMergeStrategy.override() }));
+
+    expect(bucket.tagsRaw).toEqual([{ key: 'New', value: 'Tag' }]);
+  });
+
+  test('only applies keys present in props', () => {
+    const bucket = new CfnBucket(stack, 'Bucket');
+    bucket.bucketName = 'original';
+    bucket.versioningConfiguration = { status: 'Enabled' };
+
+    bucket.with(new CfnPropsMixin(CfnBucket, {
+      bucketName: 'updated',
+    }));
+
+    expect(bucket.bucketName).toBe('updated');
+    expect(bucket.versioningConfiguration).toEqual({ status: 'Enabled' });
+  });
+});

--- a/packages/aws-cdk-lib/core/test/mixins/property-merge-strategy.test.ts
+++ b/packages/aws-cdk-lib/core/test/mixins/property-merge-strategy.test.ts
@@ -1,12 +1,14 @@
-import { deepMerge, shallowAssign } from '../../lib/util/property-mixins';
+import { PropertyMergeStrategy } from '../../lib/mixins/property-merge-strategy';
 
-describe('Property Mixins', () => {
-  describe('deepMerge', () => {
+describe('PropertyMergeStrategy', () => {
+  describe('combine', () => {
+    const strategy = PropertyMergeStrategy.combine();
+
     test('merges simple properties', () => {
       const target = { a: 1, b: 2 };
       const source = { b: 3, c: 4 };
 
-      deepMerge(target, source, ['b', 'c']);
+      strategy.apply(target, source, ['b', 'c']);
 
       expect(target).toEqual({ a: 1, b: 3, c: 4 });
     });
@@ -15,7 +17,7 @@ describe('Property Mixins', () => {
       const target = { config: { x: 1, y: 2 } };
       const source = { config: { y: 3, z: 4 } };
 
-      deepMerge(target, source, ['config']);
+      strategy.apply(target, source, ['config']);
 
       expect(target).toEqual({ config: { x: 1, y: 3, z: 4 } });
     });
@@ -24,7 +26,7 @@ describe('Property Mixins', () => {
       const target = { a: 1, b: 2 };
       const source = { b: 3, c: 4 };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 3 });
     });
@@ -33,7 +35,7 @@ describe('Property Mixins', () => {
       const target = { a: 1 };
       const source = { b: 2 };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
     });
@@ -42,7 +44,7 @@ describe('Property Mixins', () => {
       const target = { a: 1, b: 2 };
       const source = { c: 3 };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
     });
@@ -51,7 +53,7 @@ describe('Property Mixins', () => {
       const target = { items: [1, 2] };
       const source = { items: [3, 4] };
 
-      deepMerge(target, source, ['items']);
+      strategy.apply(target, source, ['items']);
 
       expect(target).toEqual({ items: [3, 4] });
     });
@@ -60,16 +62,16 @@ describe('Property Mixins', () => {
       const target = { a: { b: { c: 1, d: 2 } } };
       const source = { a: { b: { d: 3, e: 4 } } };
 
-      deepMerge(target, source, ['a']);
+      strategy.apply(target, source, ['a']);
 
       expect(target).toEqual({ a: { b: { c: 1, d: 3, e: 4 } } });
     });
 
     test('handles undefined values', () => {
-      const target = { a: 1, b: 2 };
+      const target: any = { a: 1, b: 2 };
       const source = { b: undefined };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: undefined });
     });
@@ -78,16 +80,16 @@ describe('Property Mixins', () => {
       const target = { a: 1, b: 2, c: 3 };
       const source = { b: 20 };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 20, c: 3 });
     });
 
     test('does not copy keys not in allowedKeys', () => {
-      const target = { a: 1 };
+      const target: any = { a: 1 };
       const source = { b: 2, c: 3 };
 
-      deepMerge(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
       expect('c' in target).toBe(false);
@@ -98,7 +100,7 @@ describe('Property Mixins', () => {
       target.node.parent = target;
       const source = { b: 2 };
 
-      expect(() => deepMerge(target, source, ['b'])).not.toThrow();
+      expect(() => strategy.apply(target, source, ['b'])).not.toThrow();
       expect(target).toEqual({ a: 1, b: 2, node: { parent: target } });
     });
 
@@ -108,7 +110,7 @@ describe('Property Mixins', () => {
       target.circular.deep = { ref: target };
       const source = { prop1: 'updated', prop2: 'new' };
 
-      expect(() => deepMerge(target, source, ['prop1', 'prop2'])).not.toThrow();
+      expect(() => strategy.apply(target, source, ['prop1', 'prop2'])).not.toThrow();
       expect(target.prop1).toBe('updated');
       expect(target.prop2).toBe('new');
       expect(target.circular.ref).toBe(target);
@@ -118,19 +120,21 @@ describe('Property Mixins', () => {
       const target = { a: 1 };
       const source = { b: 2 };
 
-      deepMerge(target, source, ['__proto__', 'constructor', 'prototype', 'b']);
+      strategy.apply(target, source, ['__proto__', 'constructor', 'prototype', 'b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
       expect(Object.prototype).not.toHaveProperty('polluted');
     });
   });
 
-  describe('shallowAssign', () => {
+  describe('override', () => {
+    const strategy = PropertyMergeStrategy.override();
+
     test('assigns simple properties', () => {
       const target = { a: 1, b: 2 };
       const source = { b: 3, c: 4 };
 
-      shallowAssign(target, source, ['b', 'c']);
+      strategy.apply(target, source, ['b', 'c']);
 
       expect(target).toEqual({ a: 1, b: 3, c: 4 });
     });
@@ -139,7 +143,7 @@ describe('Property Mixins', () => {
       const target = { a: 1, b: 2 };
       const source = { b: 3, c: 4 };
 
-      shallowAssign(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 3 });
     });
@@ -148,7 +152,7 @@ describe('Property Mixins', () => {
       const target = { config: { x: 1, y: 2 } };
       const source = { config: { y: 3, z: 4 } };
 
-      shallowAssign(target, source, ['config']);
+      strategy.apply(target, source, ['config']);
 
       expect(target).toEqual({ config: { y: 3, z: 4 } });
     });
@@ -157,17 +161,17 @@ describe('Property Mixins', () => {
       const target = { a: 1, b: 2 };
       const source = { c: 3 };
 
-      shallowAssign(target, source, ['b']);
+      strategy.apply(target, source, ['b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
     });
 
     test('assigns arrays by reference', () => {
-      const target = { items: [1, 2] };
+      const target: any = { items: [1, 2] };
       const arr = [3, 4];
       const source = { items: arr };
 
-      shallowAssign(target, source, ['items']);
+      strategy.apply(target, source, ['items']);
 
       expect(target.items).toBe(arr);
     });
@@ -176,7 +180,7 @@ describe('Property Mixins', () => {
       const target = { a: 1 };
       const source = { b: 2 };
 
-      shallowAssign(target, source, ['__proto__', 'constructor', 'prototype', 'b']);
+      strategy.apply(target, source, ['__proto__', 'constructor', 'prototype', 'b']);
 
       expect(target).toEqual({ a: 1, b: 2 });
       expect(Object.prototype).not.toHaveProperty('polluted');


### PR DESCRIPTION
### Reason for this change

`PropertyMergeStrategy` and `IMergeStrategy` were initially developed in `@aws-cdk/mixins-preview` as part of the L1 property mixins feature. Now that the API has stabilized, these types need to be available from `aws-cdk-lib/core` so they can be used internally. The public-facing CFN property mixin feature in `mixins-preview` will be published as a separate package and cannot be used within `aws-cdk-lib` itself for dependency reasons. This means `aws-cdk-lib` needs its own internal implementation to apply CFN properties through the mixin system.

`CfnPropsMixin` fills that gap. It is not the same feature set as the public-facing version in `mixins-preview`, but it provides a close enough internal equivalent that other `aws-cdk-lib` modules can use to apply L1 CloudFormation properties in a type-safe way through the mixin API.

### Description of changes

The `PropertyMergeStrategy` class and `IMergeStrategy` interface are moved from `@aws-cdk/mixins-preview` into `aws-cdk-lib/core/lib/mixins/`. The `mixins-preview` package now re-exports these types from core, so existing consumers are not broken.

As part of this move, the `deepMerge` function that was previously duplicated between `cfn-resource.ts` and the preview package is consolidated into a single shared implementation at `core/lib/private/deep-merge.ts`. The copy in `cfn-resource.ts` is removed and replaced with an import from the new shared module. The preview package had an explicit comment noting this duplication and the intent to resolve it once the code moved to core — this change fulfills that intent.

The `CombineStrategy` implementation now delegates to the same `deepMerge` that `CfnResource` uses for `addOverride`, which means both code paths share identical merge semantics for CloudFormation intrinsics handling. The `OverrideStrategy` (previously `shallowAssign`) is inlined directly into the strategy class since it's trivial and doesn't benefit from being a standalone utility.

A new internal `CfnPropsMixin` class is introduced in `core/lib/mixins/private/`. This is an internal-only implementation that provides a type-safe way to apply L1 CloudFormation properties to matching `CfnResource` instances. It accepts a resource class and a partial set of writable properties, using TypeScript's type system to filter out inherited members, readonly attributes, and functions. The mixin delegates to `PropertyMergeStrategy` for configurable merge behavior, defaulting to `combine()`. It is exported through `helpers-internal` so other `aws-cdk-lib` modules can use it without it being part of the public API.

Tests for `PropertyMergeStrategy` are moved from the preview package to `core/test/mixins/` and updated to exercise the public API rather than the internal utility functions directly. Comprehensive tests for `CfnPropsMixin` cover property application, resource type matching, deep merge behavior, override strategy, and edge cases.

### Describe any new or updated permissions being added

No new IAM permissions.

### Description of how you validated changes

Existing unit tests were moved and adapted to cover the `PropertyMergeStrategy.combine()` and `PropertyMergeStrategy.override()` APIs. The `deepMerge` function used by `CfnResource` is unchanged in behavior and covered by existing core tests. New tests for `CfnPropsMixin` verify correct property application, type-based resource matching, merge strategy delegation, and non-matching resource handling.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
