### PR TITLE
fix(amplify): `enableAutoSubdomain` not working when using `addDomain…

### DIFF
--- a/packages/@aws-cdk/aws-amplify-alpha/lib/app.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/lib/app.ts
@@ -384,7 +384,7 @@ export class App extends Resource implements IApp, iam.IGrantable {
     return new Domain(this, id, {
       ...options,
       app: this,
-      autoSubDomainIamRole: this.grantPrincipal as iam.IRole,
+      autoSubDomainIamRole: options.autoSubDomainIamRole ?? this.grantPrincipal as iam.IRole,
     });
   }
 }

--- a/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
@@ -47,6 +47,13 @@ export interface DomainOptions {
    * @default - Amplify uses the default certificate that it provisions and manages for you
    */
   readonly customCertificate?: acm.ICertificate;
+
+  /**
+   * The IAM role with access to Route53 when using enableAutoSubdomain
+   *
+   * @default - the IAM role from App.grantPrincipal
+   */
+  readonly autoSubDomainIamRole?: iam.IRole;
 }
 
 /**
@@ -57,12 +64,6 @@ export interface DomainProps extends DomainOptions {
    * The application to which the domain must be connected
    */
   readonly app: IApp;
-
-  /**
-   * The IAM role with access to Route53 when using enableAutoSubdomain
-   * @default - the IAM role from App.grantPrincipal
-   */
-  readonly autoSubDomainIamRole?: iam.IRole;
 }
 
 /**

--- a/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
@@ -353,3 +353,37 @@ test('auto subdomain with IAM role', () => {
     },
   });
 });
+
+test('auto subdomain with custom IAM role via addDomain', () => {
+  // GIVEN
+  const stack = new Stack();
+  const app = new amplify.App(stack, 'App', {
+    sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
+      owner: 'aws',
+      repository: 'aws-cdk',
+      oauthToken: SecretValue.unsafePlainText('secret'),
+    }),
+  });
+  const prodBranch = app.addBranch('main');
+  const customRole = new iam.Role(stack, 'CustomDomainRole', {
+    assumedBy: new iam.ServicePrincipal('amplify.amazonaws.com'),
+  });
+
+  // WHEN
+  const domain = app.addDomain('amazon.com', {
+    enableAutoSubdomain: true,
+    autoSubDomainIamRole: customRole,
+  });
+  domain.mapRoot(prodBranch);
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::Amplify::Domain', {
+    EnableAutoSubDomain: true,
+    AutoSubDomainIAMRole: {
+      'Fn::GetAtt': [
+        'CustomDomainRoleB8521CEC',
+        'Arn',
+      ],
+    },
+  });
+});


### PR DESCRIPTION
### Issue 

Closes aws-amplify/amplify-hosting#3102

### Reason for this change

`enableAutoSubdomain` silently fails when domains are created via `app.addDomain()`. The `DomainOptions` interface does not expose `autoSubDomainIamRole`, so users cannot provide a Route53-capable IAM role through the most common API path. The domain falls back to the App's default `grantPrincipal` role which typically has no Route53 permissions, causing Amplify to silently fail when auto-creating subdomains for new branches.

### Description of changes

- Moved `autoSubDomainIamRole` from `DomainProps` to `DomainOptions` (since `DomainProps extends DomainOptions`, the `Domain` constructor still receives it — no breaking change)
- Updated `App.addDomain()` to use the caller-provided `autoSubDomainIamRole` if specified, falling back to `this.grantPrincipal` as before
- Added unit test verifying a custom IAM role passed via `addDomain()` is used in the synthesized template

### Describe any new or updated permissions being added

No new permissions. This change exposes an existing IAM role parameter (`autoSubDomainIamRole`) through the `DomainOptions` interface so users can provide their own Route53-capable role when using `app.addDomain()`.

### Description of how you validated changes

- All 46 existing unit tests pass
- New unit test (`auto subdomain with custom IAM role via addDomain`) passes
- jsii compilation successful (Errors: 0)
- Manually reproduced and verified the fix with deployed Amplify apps (buggy app `d2ax4j8135v9i9` vs fixed app `d2y1hnir97lrxs`)

```
BuggyApp (using app.addDomain()):

App ID: d2ax4j8135v9i9
Domain: buggy-test.akz.people.aws.dev
IAM Role: Empty (no policies)
Created branch feature-test → NO subdomain created ❌
FixedApp (using workaround):

App ID: d2y1hnir97lrxs
Domain: fixed-test.akz.people.aws.dev
IAM Role: AmazonRoute53FullAccess
Created branch feature-test → Subdomain auto-created ✅

```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*