### PR TITLE
feat(s3): `BucketEncryption` Mixin for S3 server-side encryption

### DIFF
--- a/packages/aws-cdk-lib/aws-s3/README.md
+++ b/packages/aws-cdk-lib/aws-s3/README.md
@@ -1181,3 +1181,18 @@ new s3.CfnBucketPolicy(this, 'Policy', {
   }),
 ]));
 ```
+
+### BucketEncryption
+
+Configures server-side encryption on an S3 bucket. Accepts KMS keys via `IKeyRef`, `IAliasRef`, or a string ARN/ID and automatically resolves the reference:
+
+```ts
+new s3.CfnBucket(this, 'Bucket')
+  .with(new s3.mixins.BucketEncryption({
+    serverSideEncryptionByDefault: {
+      sseAlgorithm: s3.mixins.BucketEncryption.SSEAlgorithm.AWS_KMS,
+      kmsMasterKeyId: new kms.Key(this, 'Key'),
+    },
+    bucketKeyEnabled: true,
+  }));
+```

--- a/packages/aws-cdk-lib/aws-s3/lib/mixins/index.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/mixins/index.ts
@@ -1,2 +1,3 @@
 export * from './bucket';
 export * from './bucket-policy';
+export * from './bucket-encryption.generated';

--- a/packages/aws-cdk-lib/aws-s3/test/bucket-encryption-mixin.test.ts
+++ b/packages/aws-cdk-lib/aws-s3/test/bucket-encryption-mixin.test.ts
@@ -1,0 +1,139 @@
+import { Construct } from 'constructs';
+import { Template } from '../../assertions';
+import * as kms from '../../aws-kms';
+import * as cdk from '../../core';
+import * as s3 from '../lib';
+import { BucketEncryption } from '../lib/mixins';
+
+describe('BucketEncryption Mixin', () => {
+  let stack: cdk.Stack;
+
+  beforeEach(() => {
+    stack = new cdk.Stack(new cdk.App(), 'TestStack');
+  });
+
+  test('supports CfnBucket', () => {
+    const bucket = new s3.CfnBucket(stack, 'Bucket');
+    const mixin = new BucketEncryption({
+      serverSideEncryptionByDefault: { sseAlgorithm: BucketEncryption.SSEAlgorithm.AES256 },
+    });
+
+    expect(mixin.supports(bucket)).toBe(true);
+  });
+
+  test('does not support non-S3 constructs', () => {
+    const construct = new Construct(stack, 'Other');
+    const mixin = new BucketEncryption({
+      serverSideEncryptionByDefault: { sseAlgorithm: BucketEncryption.SSEAlgorithm.AES256 },
+    });
+
+    expect(mixin.supports(construct)).toBe(false);
+  });
+
+  test('applies AES256 encryption to L1 bucket', () => {
+    new s3.CfnBucket(stack, 'Bucket').with(
+      new BucketEncryption({
+        serverSideEncryptionByDefault: { sseAlgorithm: BucketEncryption.SSEAlgorithm.AES256 },
+      }),
+    );
+
+    Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [{
+          ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' },
+        }],
+      },
+    });
+  });
+
+  test('applies KMS encryption with string key ID', () => {
+    new s3.CfnBucket(stack, 'Bucket').with(
+      new BucketEncryption({
+        serverSideEncryptionByDefault: {
+          sseAlgorithm: BucketEncryption.SSEAlgorithm.AWS_KMS,
+          kmsMasterKeyId: 'arn:aws:kms:us-east-1:123456789012:key/my-key-id',
+        },
+      }),
+    );
+
+    Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [{
+          ServerSideEncryptionByDefault: {
+            SSEAlgorithm: 'aws:kms',
+            KMSMasterKeyID: 'arn:aws:kms:us-east-1:123456789012:key/my-key-id',
+          },
+        }],
+      },
+    });
+  });
+
+  test('applies KMS encryption with IKeyRef', () => {
+    const key = new kms.Key(stack, 'Key');
+
+    new s3.CfnBucket(stack, 'Bucket').with(
+      new BucketEncryption({
+        serverSideEncryptionByDefault: {
+          sseAlgorithm: BucketEncryption.SSEAlgorithm.AWS_KMS,
+          kmsMasterKeyId: key,
+        },
+      }),
+    );
+
+    Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [{
+          ServerSideEncryptionByDefault: {
+            SSEAlgorithm: 'aws:kms',
+            KMSMasterKeyID: { 'Fn::GetAtt': ['Key961B73FD', 'Arn'] },
+          },
+        }],
+      },
+    });
+  });
+
+  test('applies with bucket key enabled', () => {
+    new s3.CfnBucket(stack, 'Bucket').with(
+      new BucketEncryption({
+        serverSideEncryptionByDefault: { sseAlgorithm: BucketEncryption.SSEAlgorithm.AWS_KMS },
+        bucketKeyEnabled: true,
+      }),
+    );
+
+    Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [{
+          ServerSideEncryptionByDefault: { SSEAlgorithm: 'aws:kms' },
+          BucketKeyEnabled: true,
+        }],
+      },
+    });
+  });
+
+  test('applies to L2 bucket via .with()', () => {
+    new s3.Bucket(stack, 'Bucket').with(
+      new BucketEncryption({
+        serverSideEncryptionByDefault: { sseAlgorithm: BucketEncryption.SSEAlgorithm.AES256 },
+      }),
+    );
+
+    Template.fromStack(stack).hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [{
+          ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' },
+        }],
+      },
+    });
+  });
+
+  test('enum values are correct', () => {
+    expect(BucketEncryption.SSEAlgorithm.AES256).toBe('AES256');
+    expect(BucketEncryption.SSEAlgorithm.AWS_KMS).toBe('aws:kms');
+    expect(BucketEncryption.SSEAlgorithm.AWS_KMS_DSSE).toBe('aws:kms:dsse');
+  });
+
+  test('EncryptionType enum values are correct', () => {
+    expect(BucketEncryption.EncryptionType.NONE).toBe('NONE');
+    expect(BucketEncryption.EncryptionType.SSE_C).toBe('SSE-C');
+  });
+});

--- a/packages/awslint/lib/rules/core-types.ts
+++ b/packages/awslint/lib/rules/core-types.ts
@@ -99,6 +99,18 @@ export class CoreTypes {
   }
 
   /**
+   * Return true if the type lives inside a generated mixin.
+   * Checks the jsii namespace, source file location, and stability.
+   */
+  public static isGeneratedMixinType(interfaceType: reflect.Type) {
+    const loc = interfaceType.locationInModule;
+    return interfaceType.namespace?.split('.').at(1) === 'mixins' &&
+      loc != null &&
+      loc.filename.endsWith('.generated.ts') &&
+      interfaceType.docs.docs.stability === 'external';
+  }
+
+  /**
    * Return true if the given interface type is a CFN class, prop type or interface
    */
   public static isCfnType(interfaceType: reflect.Type): boolean {

--- a/packages/awslint/lib/rules/docs.ts
+++ b/packages/awslint/lib/rules/docs.ts
@@ -56,6 +56,10 @@ docsLinter.add({
     if (CoreTypes.isCfnType(e.ctx.containingType) || CoreTypes.isCfnNestedType(e.ctx.containingType)) {
       return;
     }
+    // this rule does not apply to generated mixin types
+    if (CoreTypes.isGeneratedMixinType(e.ctx.containingType)) {
+      return;
+    }
 
     const property = e.ctx.documentable;
     e.assert(!property.optional || property.docs.docs.default !== undefined, e.ctx.errorKey);

--- a/tools/@aws-cdk/spec2cdk/bin/gen-cdk.ts
+++ b/tools/@aws-cdk/spec2cdk/bin/gen-cdk.ts
@@ -6,6 +6,7 @@ import generateServiceSubmoduleFiles from '../lib/cfn2ts/submodules';
 import type { ModuleMap } from '../lib/module-topology';
 import { writeModuleMap, moduleMapPath } from '../lib/module-topology';
 import * as naming from '../lib/naming/index';
+import { generateTypeMixins, BucketEncryptionMixin } from '../lib/type-mixins';
 
 const libDir = process.cwd();
 const isStable = libDir.endsWith('aws-cdk-lib');
@@ -39,6 +40,18 @@ async function main() {
       delete generated[nss];
     }
     await generateServiceSubmoduleFiles(generated, libDir);
+
+    // Generate type-based mixins
+    await generateTypeMixins({
+      outputPath: libDir,
+      moduleFqn: 'aws-cdk-lib/aws-s3/mixins',
+      requests: [{
+        resourceType: 'AWS::S3::Bucket',
+        typeName: 'ServerSideEncryptionRule',
+        outputFile: 'aws-s3/lib/mixins/bucket-encryption.generated.ts',
+        mixinClass: BucketEncryptionMixin,
+      }],
+    });
   }
 }
 

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/cdk.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/cdk.ts
@@ -106,6 +106,7 @@ export class CdkInternalHelpers extends ExternalModule {
   public readonly FromCloudFormation = $T(Type.fromName(this, 'FromCloudFormation'));
   public readonly FromCloudFormationPropertyObject = Type.fromName(this, 'FromCloudFormationPropertyObject');
   public readonly TemplateString = Type.fromName(this, 'TemplateString');
+  public readonly CfnPropsMixin = Type.fromName(this, 'CfnPropsMixin');
 
   constructor(parent: CdkCore) {
     super(`${parent.fqn}/core/lib/helpers-internal`);

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/type-converter.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/type-converter.ts
@@ -9,7 +9,7 @@ import type {
 import {
   RichProperty,
 } from '@aws-cdk/service-spec-types';
-import type { ClassType, StructType, TypeDeclaration } from '@cdklabs/typewriter';
+import type { ClassType, IScope, StructType, TypeDeclaration } from '@cdklabs/typewriter';
 import { Module, PrimitiveType, RichScope, Type } from '@cdklabs/typewriter';
 import { CDK_CORE } from './cdk';
 import type { RelationshipDecider } from './relationship-decider';
@@ -26,6 +26,14 @@ export interface TypeConverterOptions {
    * @default false
    * */
   readonly isEventBridgeType?: boolean;
+  /**
+   * Callback to convert a string type with allowedValues into an enum type.
+   * When set, string properties with allowedValues will use the returned type
+   * as a union with string (e.g. `MyEnum | string`).
+   *
+   * @default - allowedValues are ignored, string type is used
+   */
+  readonly enumConverter?: (allowedValues: string[]) => Type | undefined;
 }
 
 /**
@@ -42,6 +50,19 @@ export interface TypeConverterForResourceOptions extends Omit<TypeConverterOptio
   readonly resource: Resource;
   readonly resourceClass: ClassType;
   readonly relationshipDecider: RelationshipDecider;
+}
+
+export interface TypeConverterForSingleTypeOptions extends TypeConverterForResourceOptions {
+  /**
+   * Custom naming function for generated struct types.
+   * @default structNameFromTypeDefinition (appends 'Property' suffix)
+   */
+  readonly structNamer?: (typeDef: TypeDefinition) => string;
+  /**
+   * Scope to place generated types in.
+   * @default resourceClass
+   */
+  readonly scope?: IScope;
 }
 
 /**
@@ -124,11 +145,60 @@ export class TypeConverter {
     });
   }
 
+  /**
+   * Make a type converter that generates a single type definition and its transitive dependencies.
+   *
+   * Generated structs have all properties optional, no CFN producer/parser, and use a custom naming function.
+   *
+   * Usage:
+   * ```
+   * const converter = TypeConverter.forSingleType({ ...opts, structNamer: (td) => td.name });
+   * const typeDef = db.follow('usesType', resource).map(x => x.entity).find(td => td.name === 'MyType');
+   * converter.convertTypeDefinitionType(typeDef); // generates MyType and all transitive deps
+   * ```
+   */
+  public static forSingleType(opts: TypeConverterForSingleTypeOptions) {
+    const namer = opts.structNamer ?? structNameFromTypeDefinition;
+    const scope = opts.scope ?? opts.resourceClass;
+    return new TypeConverter({
+      ...opts,
+      typeDefinitionConverter: (typeDefinition, converter) => {
+        const existing = new RichScope(scope).tryFindTypeByName(
+          namer(typeDefinition),
+        );
+        if (existing) {
+          return {
+            structType: existing as StructType,
+            build: () => {},
+          };
+        }
+
+        const structType = new PartialTypeDefinitionStruct({
+          resource: opts.resource,
+          resourceClass: opts.resourceClass,
+          converter,
+          typeDefinition,
+          relationshipDecider: opts.relationshipDecider,
+          cfnProducer: false,
+          cfnParser: false,
+          structNamer: namer,
+          scope,
+        });
+
+        return {
+          structType: structType,
+          build: () => structType.build(),
+        };
+      },
+    });
+  }
+
   public readonly db: SpecDatabase;
   public readonly module: Module;
   private readonly typeDefinitionConverter: TypeDefinitionConverter;
   private readonly typeDefCache = new Map<TypeDefinition, StructType>();
   private readonly isEventBridgeType;
+  private readonly enumConverter?: (allowedValues: string[]) => Type | undefined;
 
   /** Reverse mapping so we can find the original type back for every generated Type */
   private readonly originalTypes = new WeakMap<Type, PropertyType>();
@@ -138,6 +208,7 @@ export class TypeConverter {
     this.typeDefinitionConverter = options.typeDefinitionConverter;
     this.module = Module.of(options.resourceClass);
     this.isEventBridgeType = options.isEventBridgeType;
+    this.enumConverter = options.enumConverter;
   }
 
   /**
@@ -173,6 +244,12 @@ export class TypeConverter {
     const converted = ((): Type => {
       switch (type?.type) {
         case 'string':
+          if (type.allowedValues?.length && this.enumConverter) {
+            const enumType = this.enumConverter(type.allowedValues);
+            if (enumType) {
+              return enumType;
+            }
+          }
           return Type.STRING;
         case 'number':
         case 'integer':

--- a/tools/@aws-cdk/spec2cdk/lib/cdk/typedefinition-struct.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/cdk/typedefinition-struct.ts
@@ -1,5 +1,5 @@
 import type { Resource, TypeDefinition } from '@aws-cdk/service-spec-types';
-import type { ClassType, Expression, PropertySpec } from '@cdklabs/typewriter';
+import type { ClassType, Expression, IScope, PropertySpec } from '@cdklabs/typewriter';
 import { expr, FreeFunction, Module, Stability, stmt, StructType, Type } from '@cdklabs/typewriter';
 import { CloudFormationMapping } from './cloudformation-mapping';
 import type { RelationshipDecider } from './relationship-decider';
@@ -28,6 +28,16 @@ export interface TypeDefinitionStructOptions {
    * @default true
    */
   readonly cfnParser?: boolean;
+  /**
+   * Custom naming function for the struct type.
+   * @default structNameFromTypeDefinition
+   */
+  readonly structNamer?: (typeDef: TypeDefinition) => string;
+  /**
+   * Scope to place the struct in.
+   * @default resourceClass
+   */
+  readonly scope?: IScope;
 }
 
 /**
@@ -44,9 +54,10 @@ export class TypeDefinitionStruct extends StructType {
   private readonly options: TypeDefinitionStructOptions;
 
   constructor(options: TypeDefinitionStructOptions) {
-    super(options.resourceClass, {
+    const namer = options.structNamer ?? structNameFromTypeDefinition;
+    super(options.scope ?? options.resourceClass, {
       export: true,
-      name: structNameFromTypeDefinition(options.typeDefinition),
+      name: namer(options.typeDefinition),
       docs: {
         ...splitDocumentation(options.typeDefinition.documentation),
         stability: Stability.External,

--- a/tools/@aws-cdk/spec2cdk/lib/index.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/index.ts
@@ -4,3 +4,4 @@ export * as naming from './naming';
 export * as topo from './module-topology';
 export { generateAll } from './cfn2ts/index';
 export * as cfnPropMixins from './cfn-prop-mixins';
+export * as typeMixins from './type-mixins';

--- a/tools/@aws-cdk/spec2cdk/lib/type-mixins/bucket-encryption.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/type-mixins/bucket-encryption.ts
@@ -1,0 +1,75 @@
+import type { Resource, SpecDatabase, TypeDefinition } from '@aws-cdk/service-spec-types';
+import { ExternalModule, Stability, Type, expr, stmt, $this, $T, ThingSymbol, type Module } from '@cdklabs/typewriter';
+import { CDK_CORE, CONSTRUCTS } from '../cdk/cdk';
+import { naming } from '../index';
+import { TypeMixin } from './generate';
+
+/**
+ * Generated mixin for configuring server-side encryption on S3 buckets.
+ *
+ * Extends ClassType following the same pattern as L1PropsMixin.
+ */
+export class BucketEncryptionMixin extends TypeMixin {
+  constructor(scope: Module, resource: Resource, db: SpecDatabase, rootType: TypeDefinition) {
+    super(scope, resource, db, rootType, {
+      export: true,
+      name: 'BucketEncryption',
+      extends: CDK_CORE.Mixin,
+      docs: {
+        summary: 'Mixin for configuring server-side encryption on S3 buckets.',
+        stability: Stability.External,
+      },
+    });
+  }
+
+  public build() {
+    this.convertTypes();
+
+    const rootStruct = this.findRootStruct();
+    if (!rootStruct) return;
+
+    const module = this.scope as Module;
+    const service = this.db.incoming('hasResource', this.resource).only().entity;
+    const constructLibModule = new ExternalModule(`aws-cdk-lib/${service.name}`);
+    constructLibModule.import(module, 'service');
+    CONSTRUCTS.import(module, 'constructs');
+    CDK_CORE.helpers.import(module, 'internal', { fromLocation: '../../../core/lib/helpers-internal' });
+
+    const cfnClassName = naming.classNameFromResource(this.resource);
+    const cfnType = Type.fromName(constructLibModule, cfnClassName);
+    const flattenFunctionName = `flatten${this.name}${this.rootType.name}`;
+
+    this.makeConstructor(rootStruct);
+    this.makeSupportsMethod(cfnType, cfnClassName);
+    this.makeApplyToMethod(cfnClassName, flattenFunctionName);
+  }
+
+  private makeConstructor(rootStruct: Type) {
+    this.addProperty({ name: 'rule', type: rootStruct, immutable: true, protected: true });
+    const init = this.addInitializer({});
+    const ruleParam = init.addParameter({ name: 'rule', type: rootStruct });
+    init.addBody(
+      expr.sym(new ThingSymbol('super', this.scope)).call(),
+      stmt.assign($this.rule, ruleParam),
+    );
+  }
+
+  private makeSupportsMethod(cfnType: Type, cfnClassName: string) {
+    const supports = this.addMethod({
+      name: 'supports',
+      returnType: Type.ambient(`construct is service.${cfnType.symbol}`),
+    });
+    const construct = supports.addParameter({ name: 'construct', type: CONSTRUCTS.IConstruct });
+    supports.addBody(
+      stmt.ret($T(cfnType)[`is${cfnClassName}`](construct)),
+    );
+  }
+
+  private makeApplyToMethod(cfnClassName: string, flattenFunctionName: string) {
+    const applyTo = this.addMethod({ name: 'applyTo', returnType: Type.VOID });
+    applyTo.addParameter({ name: 'construct', type: CONSTRUCTS.IConstruct });
+    applyTo.addBody(
+      expr.directCode(`new internal.CfnPropsMixin(service.${cfnClassName}, { bucketEncryption: { serverSideEncryptionConfiguration: [${flattenFunctionName}(this.rule)] } }, { strategy: cdk.PropertyMergeStrategy.override() }).applyTo(construct)`),
+    );
+  }
+}

--- a/tools/@aws-cdk/spec2cdk/lib/type-mixins/generate.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/type-mixins/generate.ts
@@ -1,0 +1,166 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Resource, SpecDatabase, TypeDefinition } from '@aws-cdk/service-spec-types';
+import { EnumType, Module, ClassType, Type, TypeScriptRenderer, RichScope } from '@cdklabs/typewriter';
+import { CDK_CORE } from '../cdk/cdk';
+import { RelationshipDecider } from '../cdk/relationship-decider';
+import { TypeConverter } from '../cdk/type-converter';
+import { loadPatchedSpec } from '../generate';
+
+/**
+ * Options for generating a type-based mixin.
+ */
+export interface TypeMixinGenerationRequest {
+  /** CloudFormation resource type, e.g. 'AWS::S3::Bucket' */
+  readonly resourceType: string;
+  /** TypeDefinition name to generate (plus transitive deps) */
+  readonly typeName: string;
+  /** Output file path relative to outputPath */
+  readonly outputFile: string;
+  /** The TypeMixin class to instantiate and build */
+  readonly mixinClass: new (scope: Module, resource: Resource, db: SpecDatabase, rootType: TypeDefinition) => TypeMixin;
+}
+
+export interface GenerateTypeMixinsOptions {
+  readonly outputPath: string;
+  readonly requests: TypeMixinGenerationRequest[];
+  /** Module FQN for the generated output, e.g. 'aws-cdk-lib/aws-s3/mixins' */
+  readonly moduleFqn?: string;
+}
+
+/**
+ * Base class for type-based mixins generated from the CloudFormation spec.
+ *
+ * Subclasses extend ClassType and populate themselves in `build()`,
+ * following the same pattern as `L1PropsMixin` and `ResourceClass`.
+ */
+export abstract class TypeMixin extends ClassType {
+  protected readonly rootType: TypeDefinition;
+  protected readonly resource: Resource;
+  protected readonly db: SpecDatabase;
+  protected converter!: TypeConverter;
+
+  constructor(
+    scope: Module,
+    resource: Resource,
+    db: SpecDatabase,
+    rootType: TypeDefinition,
+    classSpec: ConstructorParameters<typeof ClassType>[1],
+  ) {
+    super(scope, classSpec);
+    this.resource = resource;
+    this.db = db;
+    this.rootType = rootType;
+  }
+
+  /**
+   * Initialize the type converter and convert the root type definition.
+   * Call this at the start of `build()`.
+   */
+  protected convertTypes() {
+    const relationshipDecider = new RelationshipDecider(this.resource, this.db, {
+      enableRelationships: true,
+      enableNestedRelationships: true,
+      refsImportLocation: 'aws-cdk-lib/interfaces',
+    });
+
+    const enumCache = new Map<string, Type>();
+    this.converter = TypeConverter.forSingleType({
+      db: this.db,
+      resource: this.resource,
+      resourceClass: this,
+      relationshipDecider,
+      structNamer: (td) => td.name,
+      scope: this,
+      enumConverter: (allowedValues) => {
+        const key = allowedValues.join(',');
+        if (enumCache.has(key)) return enumCache.get(key)!;
+
+        const enumName = deriveEnumName(this.rootType, allowedValues, this.db);
+        const enumType = new EnumType(this, {
+          export: true,
+          name: enumName,
+          docs: { summary: `Allowed values for \`${enumName}\`.` },
+        });
+        for (const value of allowedValues) {
+          enumType.addMember({ name: toEnumMemberName(value), value, docs: value });
+        }
+
+        const unionType = Type.unionOf(enumType.type, Type.STRING);
+        enumCache.set(key, unionType);
+        return unionType;
+      },
+    });
+
+    this.converter.convertTypeDefinitionType(this.rootType);
+  }
+
+  /**
+   * Find the generated root struct type after `convertTypes()`.
+   */
+  protected findRootStruct(): Type | undefined {
+    return new RichScope(this).tryFindTypeByName(this.rootType.name)?.type;
+  }
+
+  /**
+   * Build the class body: types, constructor, supports, applyTo.
+   */
+  public abstract build(): void;
+}
+
+/**
+ * Generate type-based mixins from the CloudFormation spec.
+ */
+export async function generateTypeMixins(options: GenerateTypeMixinsOptions) {
+  const db = await loadPatchedSpec();
+  const renderer = new TypeScriptRenderer();
+
+  for (const req of options.requests) {
+    const resource = db.lookup('resource', 'cloudFormationType', 'equals', req.resourceType).only();
+    const typeDefs = db.follow('usesType', resource).map(x => x.entity);
+    const rootType = typeDefs.find(td => td.name === req.typeName);
+    if (!rootType) {
+      throw new Error(`TypeDefinition '${req.typeName}' not found for resource '${req.resourceType}'`);
+    }
+
+    const moduleFqn = options.moduleFqn ?? 'aws-cdk-lib/generated';
+    const module = new Module(moduleFqn);
+    CDK_CORE.import(module, 'cdk');
+
+    const mixin = new req.mixinClass(module, resource, db, rootType);
+    mixin.build();
+
+    const output = renderer.render(module);
+    const filePath = path.join(options.outputPath, req.outputFile);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, output);
+  }
+}
+
+function deriveEnumName(rootType: any, allowedValues: string[], db: any): string {
+  const visited = new Set<string>();
+  return findPropName(rootType, allowedValues, visited, db) ?? 'AllowedValues';
+}
+
+function findPropName(td: any, allowedValues: string[], visited: Set<string>, db: any): string | undefined {
+  if (visited.has(td.name)) return undefined;
+  visited.add(td.name);
+  for (const [propName, prop] of Object.entries(td.properties) as any) {
+    if (matchAllowedValues(prop.type, allowedValues)) return propName;
+    if (prop.type.type === 'ref') {
+      const found = findPropName(db.get('typeDefinition', prop.type.reference.$ref), allowedValues, visited, db);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function matchAllowedValues(type: any, allowedValues: string[]): boolean {
+  if (type.type === 'string' && type.allowedValues) return type.allowedValues.join(',') === allowedValues.join(',');
+  if (type.type === 'array') return matchAllowedValues(type.element, allowedValues);
+  return false;
+}
+
+function toEnumMemberName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/g, '_').replace(/^(\d)/, '_$1').toUpperCase();
+}

--- a/tools/@aws-cdk/spec2cdk/lib/type-mixins/index.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/type-mixins/index.ts
@@ -1,0 +1,3 @@
+export { generateTypeMixins, TypeMixin } from './generate';
+export type { GenerateTypeMixinsOptions, TypeMixinGenerationRequest } from './generate';
+export { BucketEncryptionMixin } from './bucket-encryption';

--- a/tools/@aws-cdk/spec2cdk/test/__snapshots__/type-mixins.test.ts.snap
+++ b/tools/@aws-cdk/spec2cdk/test/__snapshots__/type-mixins.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BucketEncryptionMixin 1`] = `
+"/* eslint-disable prettier/prettier, @stylistic/max-len */
+import * as cdk from "aws-cdk-lib/core";
+import * as service from "aws-cdk-lib/aws-s3";
+import * as constructs from "constructs";
+import * as internal from "../../../core/lib/helpers-internal";
+
+/**
+ * Mixin for configuring server-side encryption on S3 buckets.
+ *
+ * @stability external
+ */
+export class BucketEncryption extends cdk.Mixin {
+  protected readonly rule: BucketEncryption.ServerSideEncryptionRule;
+
+  public constructor(rule: BucketEncryption.ServerSideEncryptionRule) {
+    super();
+    this.rule = rule;
+  }
+
+  public supports(construct: constructs.IConstruct): construct is service.CfnBucket {
+    return service.CfnBucket.isCfnBucket(construct);
+  }
+
+  public applyTo(construct: constructs.IConstruct): void {
+    new internal.CfnPropsMixin(service.CfnBucket, { bucketEncryption: { serverSideEncryptionConfiguration: [flattenBucketEncryptionServerSideEncryptionRule(this.rule)] } }, { strategy: cdk.PropertyMergeStrategy.override() }).applyTo(construct);
+  }
+}
+
+export namespace BucketEncryption {
+  /**
+   * @struct
+   * @stability external
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html
+   */
+  export interface ServerSideEncryptionRule {
+    /**
+     * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html#cfn-s3-bucket-serversideencryptionrule-bucketkeyenabled
+     */
+    readonly bucketKeyEnabled?: boolean | cdk.IResolvable;
+
+    /**
+     * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html#cfn-s3-bucket-serversideencryptionrule-serversideencryptionbydefault
+     */
+    readonly serverSideEncryptionByDefault?: cdk.IResolvable | BucketEncryption.ServerSideEncryptionByDefault;
+  }
+
+  /**
+   * @struct
+   * @stability external
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html
+   */
+  export interface ServerSideEncryptionByDefault {
+    /**
+     * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-kmsmasterkeyid
+     */
+    readonly kmsMasterKeyId?: string;
+
+    /**
+     * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm
+     */
+    readonly sseAlgorithm?: cdk.IResolvable | BucketEncryption.SSEAlgorithm | string;
+  }
+
+  /**
+   * Allowed values for \`SSEAlgorithm\`.
+   */
+  export enum SSEAlgorithm {
+    /** aws:kms */
+    AWS_KMS = "aws:kms",
+    /** AES256 */
+    AES256 = "AES256",
+    /** aws:kms:dsse */
+    AWS_KMS_DSSE = "aws:kms:dsse",
+  }
+}"
+`;

--- a/tools/@aws-cdk/spec2cdk/test/type-mixins.test.ts
+++ b/tools/@aws-cdk/spec2cdk/test/type-mixins.test.ts
@@ -1,0 +1,63 @@
+import type { SpecDatabase, Service } from '@aws-cdk/service-spec-types';
+import { emptyDatabase } from '@aws-cdk/service-spec-types';
+import { ref } from '@cdklabs/tskb';
+import { Module, TypeScriptRenderer } from '@cdklabs/typewriter';
+import { CDK_CORE } from '../lib/cdk/cdk';
+import { BucketEncryptionMixin } from '../lib/type-mixins/bucket-encryption';
+
+const renderer = new TypeScriptRenderer();
+let db: SpecDatabase;
+let service: Service;
+
+beforeEach(() => {
+  db = emptyDatabase();
+  service = db.allocate('service', {
+    name: 'aws-s3',
+    shortName: 's3',
+    capitalized: 'S3',
+    cloudFormationNamespace: 'AWS::S3',
+  });
+});
+
+test('BucketEncryptionMixin', () => {
+  const sseByDefault = db.allocate('typeDefinition', {
+    name: 'ServerSideEncryptionByDefault',
+    properties: {
+      SSEAlgorithm: {
+        type: { type: 'string', allowedValues: ['aws:kms', 'AES256', 'aws:kms:dsse'] },
+      },
+      KMSMasterKeyID: {
+        type: { type: 'string' },
+      },
+    },
+  });
+
+  const sseRule = db.allocate('typeDefinition', {
+    name: 'ServerSideEncryptionRule',
+    properties: {
+      BucketKeyEnabled: { type: { type: 'boolean' } },
+      ServerSideEncryptionByDefault: { type: { type: 'ref', reference: ref(sseByDefault) } },
+    },
+  });
+
+  const resource = db.allocate('resource', {
+    name: 'Bucket',
+    primaryIdentifier: ['BucketName'],
+    properties: {
+      BucketName: { type: { type: 'string' } },
+    },
+    attributes: {},
+    cloudFormationType: 'AWS::S3::Bucket',
+  });
+
+  db.link('hasResource', service, resource);
+  db.link('usesType', resource, sseRule);
+  db.link('usesType', resource, sseByDefault);
+
+  const rootType = db.follow('usesType', resource).map(x => x.entity).find(td => td.name === 'ServerSideEncryptionRule')!;
+  const module = new Module('aws-cdk-lib/aws-s3/mixins');
+  CDK_CORE.import(module, 'cdk');
+  new BucketEncryptionMixin(module, resource, db, rootType).build();
+
+  expect(renderer.render(module)).toMatchSnapshot();
+});


### PR DESCRIPTION
### Reason for this change

The mixin codegen for specialized type-based mixins was living in `mixins-preview`, which is being phased out. This type of codegen needs to live in `spec2cdk` and generate output directly into `aws-cdk-lib` service modules.

The first mixin generated this way is `BucketEncryption` for S3, which provides a type-safe way to configure server-side encryption with full KMS key relationship resolution.

### Description of changes

Introduces a new `type-mixins` codegen system in `spec2cdk` that generates specialized mixins from CloudFormation type definitions. Unlike the existing `cfn-prop-mixins` (which generate a mixin per resource with all properties), type-mixins focus on a single complex type and generate a dedicated mixin class with nested types, enums, and relationship-resolving flatten functions.

The codegen follows the same class-based pattern as `L1PropsMixin` and `ResourceClass` — a `TypeMixin` base class extends `ClassType` with a `build()` method. `BucketEncryptionMixin` is the first concrete implementation.

The generated `BucketEncryption` mixin delegates property assignment to the internal `CfnPropsMixin` with an override merge strategy, keeping the generated code thin while reusing existing infrastructure.

An `isGeneratedMixinType` check was added to awslint's `CoreTypes` to generically skip `props-default-doc` for types in the `mixins` namespace that come from `.generated.ts` files with `@stability external`. This avoids per-property exclusions in `awslint.json`.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

9 unit tests covering `BucketEncryption` mixin: supports/rejects constructs, AES256, KMS with string key, KMS with `IKeyRef`, bucket key enabled, L2 `.with()`, enum values. All pass. Full `yarn build` of spec2cdk, awslint, and aws-cdk-lib passes with 0 errors.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
