### PR TITLE
feat(batch): switch default imageType to ECS_AL2023 for EC2 compute environments (under feature flag)

### DIFF
--- a/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
@@ -7,10 +7,11 @@ import type * as eks from '../../aws-eks';
 import * as iam from '../../aws-iam';
 import type { IRole } from '../../aws-iam';
 import type { Duration, ITaggable } from '../../core';
-import { ArnFormat, Lazy, Resource, Stack, TagManager, TagType, Token, ValidationError } from '../../core';
+import { ArnFormat, FeatureFlags, Lazy, Resource, Stack, TagManager, TagType, Token, ValidationError } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import * as cxapi from '../../cx-api';
 
 /**
  * Represents a Managed ComputeEnvironment. Batch will provision EC2 Instances to
@@ -254,7 +255,8 @@ export interface IManagedEc2EcsComputeEnvironment extends IManagedComputeEnviron
    * Leave this `undefined` to allow Batch to choose the latest AMIs it supports for each instance that it launches.
    *
    * @default
-   * - ECS_AL2 compatible AMI ids for non-GPU instances, ECS_AL2_NVIDIA compatible AMI ids for GPU instances
+   * - ECS_AL2 compatible AMI ids for non-GPU instances, ECS_AL2_NVIDIA compatible AMI ids for GPU instances.
+   * If the '@aws-cdk/aws-batch:defaultEcsAL2023' feature flag is set, ECS_AL2023 will be used instead of ECS_AL2.
    */
   readonly images?: EcsMachineImage[];
 
@@ -383,7 +385,8 @@ export interface EcsMachineImage extends MachineImage {
   /**
    * Tells Batch which instance type to launch this image on
    *
-   * @default - 'ECS_AL2' for non-gpu instances, 'ECS_AL2_NVIDIA' for gpu instances
+   * @default - 'ECS_AL2' for non-gpu instances, 'ECS_AL2_NVIDIA' for gpu instances.
+   * If the '@aws-cdk/aws-batch:defaultEcsAL2023' feature flag is set, 'ECS_AL2023' will be used instead of 'ECS_AL2'.
    */
   readonly imageType?: EcsMachineImageType;
 }
@@ -528,12 +531,15 @@ export interface ManagedEc2EcsComputeEnvironmentProps extends ManagedComputeEnvi
   /**
    * Configure which AMIs this Compute Environment can launch.
    * If you specify this property with only `image` specified, then the
-   * `imageType` will default to `ECS_AL2`. *If your image needs GPU resources,
+   * `imageType` will default to `ECS_AL2` (or `ECS_AL2023` if the
+   * `@aws-cdk/aws-batch:defaultEcsAL2023` feature flag is set).
+   * *If your image needs GPU resources,
    * specify `ECS_AL2_NVIDIA`; otherwise, the instances will not be able to properly
    * join the ComputeEnvironment*.
    *
    * @default
-   * - ECS_AL2 for non-GPU instances, ECS_AL2_NVIDIA for GPU instances
+   * - ECS_AL2 for non-GPU instances, ECS_AL2_NVIDIA for GPU instances.
+   * If the '@aws-cdk/aws-batch:defaultEcsAL2023' feature flag is set, ECS_AL2023 will be used instead of ECS_AL2.
    */
   readonly images?: EcsMachineImage[];
 
@@ -764,7 +770,11 @@ export class ManagedEc2EcsComputeEnvironment extends ManagedComputeEnvironmentBa
         ec2Configuration: this.images?.map((image) => {
           return {
             imageIdOverride: image.image?.getImage(this).imageId,
-            imageType: image.imageType ?? EcsMachineImageType.ECS_AL2,
+            imageType: image.imageType ?? (
+              FeatureFlags.of(this).isEnabled(cxapi.BATCH_DEFAULT_ECS_AL2023)
+                ? EcsMachineImageType.ECS_AL2023
+                : EcsMachineImageType.ECS_AL2
+            ),
           };
         }),
         placementGroup: props.placementGroup?.placementGroupRef.groupName,

--- a/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
+++ b/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
@@ -4,7 +4,8 @@ import { Template } from '../../assertions';
 import * as ec2 from '../../aws-ec2';
 import * as eks from '../../aws-eks';
 import { ArnPrincipal, Role, ServicePrincipal } from '../../aws-iam';
-import { Stack, Duration, Tags, CfnParameter } from '../../core';
+import { App, Stack, Duration, Tags, CfnParameter } from '../../core';
+import * as cxapi from '../../cx-api';
 import type { CfnComputeEnvironmentProps, ManagedEc2EcsComputeEnvironmentProps, ManagedEc2EksComputeEnvironmentProps } from '../lib';
 import { AllocationStrategy, ManagedEc2EcsComputeEnvironment, ManagedEc2EksComputeEnvironment, FargateComputeEnvironment, EcsMachineImageType, EksMachineImageType, DefaultInstanceClass } from '../lib';
 
@@ -1049,6 +1050,60 @@ describe('ManagedEc2EcsComputeEnvironment', () => {
         }),
       });
     }).toThrow(/Managed ComputeEnvironment 'MyCE' specifies 'spotFleetRole' without specifying 'spot'/);
+  });
+
+  test('default imageType is ECS_AL2 when feature flag is not set', () => {
+    // WHEN
+    new ManagedEc2EcsComputeEnvironment(stack, 'MyCE', {
+      ...defaultEcsProps,
+      vpc,
+      images: [
+        {
+          image: ec2.MachineImage.latestAmazonLinux2(),
+        },
+      ],
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+      ComputeResources: {
+        Ec2Configuration: [
+          {
+            ImageType: EcsMachineImageType.ECS_AL2,
+          },
+        ],
+      },
+    });
+  });
+
+  test('default imageType is ECS_AL2023 when feature flag is set', () => {
+    // GIVEN
+    const app = new App({
+      context: { [cxapi.BATCH_DEFAULT_ECS_AL2023]: true },
+    });
+    const flagStack = new Stack(app, 'FlagStack');
+    const flagVpc = new ec2.Vpc(flagStack, 'vpc');
+
+    // WHEN
+    new ManagedEc2EcsComputeEnvironment(flagStack, 'MyCE', {
+      vpc: flagVpc,
+      images: [
+        {
+          image: ec2.MachineImage.latestAmazonLinux2(),
+        },
+      ],
+    });
+
+    // THEN
+    Template.fromStack(flagStack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+      ComputeResources: {
+        Ec2Configuration: [
+          {
+            ImageType: EcsMachineImageType.ECS_AL2023,
+          },
+        ],
+      },
+    });
   });
 });
 

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -111,6 +111,7 @@ Flags come in three types:
 | [@aws-cdk/aws-route53-patterns:useDistribution](#aws-cdkaws-route53-patternsusedistribution) | Use the `Distribution` resource instead of `CloudFrontWebDistribution` | 2.233.0 | new default |
 | [@aws-cdk/aws-eks:useNativeOidcProvider](#aws-cdkaws-eksusenativeoidcprovider) | When enabled, EKS V2 clusters will use the native OIDC provider resource AWS::IAM::OIDCProvider instead of creating the OIDCProvider with a custom resource (iam.OpenIDConnectProvider). | 2.237.0 | fix |
 | [@aws-cdk/core:automaticL1Traits](#aws-cdkcoreautomaticl1traits) | Automatically use the default L1 traits for L1 constructs` | 2.239.0 | new default |
+| [@aws-cdk/aws-batch:defaultEcsAL2023](#aws-cdkaws-batchdefaultecsal2023) | Use ECS_AL2023 as the default imageType for EC2 Batch compute environments instead of the deprecated ECS_AL2 | V2NEXT | fix |
 
 <!-- END table -->
 
@@ -203,7 +204,8 @@ The following json shows the current recommended set of flags, as `cdk init` wou
     "@aws-cdk/aws-lambda:useCdkManagedLogGroup": true,
     "@aws-cdk/aws-elasticloadbalancingv2:networkLoadBalancerWithSecurityGroupByDefault": true,
     "@aws-cdk/aws-ecs-patterns:uniqueTargetGroupId": true,
-    "@aws-cdk/aws-route53-patterns:useDistribution": true
+    "@aws-cdk/aws-route53-patterns:useDistribution": true,
+    "@aws-cdk/aws-batch:defaultEcsAL2023": true
   }
 }
 ```
@@ -2344,8 +2346,8 @@ When this feature flag is enabled, EKS clusters will use the native AWS::IAM::OI
 
 Flag type: New default behavior
 
-When enabled, the construct library will apply default L1 traits for types that 
-have no traits defined yet. Traits regulate behaviors such as how to create 
+When enabled, the construct library will apply default L1 traits for types that
+have no traits defined yet. Traits regulate behaviors such as how to create
 resource policies, or how to find an encryption key for a given L1 construct.
 
 
@@ -2355,6 +2357,24 @@ resource policies, or how to find an encryption key for a given L1 construct.
 | 2.239.0 | `true` | `true` |
 
 **Compatibility with old behavior:** Register traits explicitly for each resource type
+
+
+### @aws-cdk/aws-batch:defaultEcsAL2023
+
+*Use ECS_AL2023 as the default imageType for EC2 Batch compute environments instead of the deprecated ECS_AL2*
+
+Flag type: Backwards incompatible bugfix
+
+When enabled, EC2 Batch compute environments that do not specify an `imageType` will default
+to `ECS_AL2023` instead of the deprecated `ECS_AL2` (Amazon Linux 2, reaching EOL June 2026).
+
+When disabled, the default `imageType` remains `ECS_AL2` for backward compatibility.
+
+
+| Since | Unset behaves like | Recommended value |
+| ----- | ----- | ----- |
+| (not in v1) |  |  |
+| V2NEXT | `false` | `true` |
 
 
 <!-- END details -->

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -773,3 +773,20 @@ _cdk.json_
   }
 }
 ```
+
+* `@aws-cdk/aws-batch:defaultEcsAL2023`
+
+When enabled, EC2 Batch compute environments that do not specify an `imageType` will default
+to `ECS_AL2023` instead of the deprecated `ECS_AL2` (Amazon Linux 2, reaching EOL June 2026).
+
+When disabled, the default `imageType` remains `ECS_AL2` for backward compatibility.
+
+_cdk.json_
+
+```json
+{
+  "context": {
+    "@aws-cdk/aws-batch:defaultEcsAL2023": true
+  }
+}
+```

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -151,6 +151,7 @@ export const USE_CDK_MANAGED_LAMBDA_LOGGROUP = '@aws-cdk/aws-lambda:useCdkManage
 export const NETWORK_LOAD_BALANCER_WITH_SECURITY_GROUP_BY_DEFAULT = '@aws-cdk/aws-elasticloadbalancingv2:networkLoadBalancerWithSecurityGroupByDefault';
 export const STEPFUNCTIONS_TASKS_HTTPINVOKE_DYNAMIC_JSONPATH_ENDPOINT = '@aws-cdk/aws-stepfunctions-tasks:httpInvokeDynamicJsonPathEndpoint';
 export const AUTOMATIC_L1_TRAITS = '@aws-cdk/core:automaticL1Traits';
+export const BATCH_DEFAULT_ECS_AL2023 = '@aws-cdk/aws-batch:defaultEcsAL2023';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1769,14 +1770,28 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.ApiDefault,
     summary: 'Automatically use the default L1 traits for L1 constructs`',
     detailsMd: `
-      When enabled, the construct library will apply default L1 traits for types that 
-      have no traits defined yet. Traits regulate behaviors such as how to create 
+      When enabled, the construct library will apply default L1 traits for types that
+      have no traits defined yet. Traits regulate behaviors such as how to create
       resource policies, or how to find an encryption key for a given L1 construct.
       `,
     introducedIn: { v2: '2.239.0' },
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: true },
     compatibilityWithOldBehaviorMd: 'Register traits explicitly for each resource type',
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [BATCH_DEFAULT_ECS_AL2023]: {
+    type: FlagType.BugFix,
+    summary: 'Use ECS_AL2023 as the default imageType for EC2 Batch compute environments instead of the deprecated ECS_AL2',
+    detailsMd: `
+      When enabled, EC2 Batch compute environments that do not specify an \`imageType\` will default
+      to \`ECS_AL2023\` instead of the deprecated \`ECS_AL2\` (Amazon Linux 2, reaching EOL June 2026).
+
+      When disabled, the default \`imageType\` remains \`ECS_AL2\` for backward compatibility.`,
+    introducedIn: { v2: 'V2NEXT' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
   },
 };
 

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -53,6 +53,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.SIGNER_PROFILE_NAME_PASSED_TO_CFN]: false,
     [feats.ECS_PATTERNS_SEC_GROUPS_DISABLES_IMPLICIT_OPEN_LISTENER]: false,
     [feats.AUTOMATIC_L1_TRAITS]: true,
+    [feats.BATCH_DEFAULT_ECS_AL2023]: false,
 
   });
 });

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -80,5 +80,6 @@
   "@aws-cdk/aws-lambda:useCdkManagedLogGroup": true,
   "@aws-cdk/aws-elasticloadbalancingv2:networkLoadBalancerWithSecurityGroupByDefault": true,
   "@aws-cdk/aws-ecs-patterns:uniqueTargetGroupId": true,
-  "@aws-cdk/aws-route53-patterns:useDistribution": true
+  "@aws-cdk/aws-route53-patterns:useDistribution": true,
+  "@aws-cdk/aws-batch:defaultEcsAL2023": true
 }


### PR DESCRIPTION
**Closes #37205**

### Reason for this change

Amazon Linux 2 (AL2) is reaching EOL in June 2026. AWS Batch compute environments that do not explicitly specify `imageType` currently default to `ECS_AL2`, which is deprecated. New environments should use `ECS_AL2023` by default.

### Description of changes

Introduced a new feature flag `@aws-cdk/aws-batch:defaultEcsAL2023` that switches the default `imageType` fallback from `ECS_AL2` to `ECS_AL2023` in `ManagedEc2EcsComputeEnvironment`.

- Added feature flag `BATCH_DEFAULT_ECS_AL2023` in `cx-api/lib/features.ts`
- Updated the fallback logic in `managed-compute-environment.ts` to use `ECS_AL2023` when the flag is enabled
- Updated JSDoc `@default` comments on `images` and `imageType` properties
- Auto-generated `FEATURE_FLAGS.md` and `recommended-feature-flags.json` updated via build

A feature flag is used instead of a direct default change to avoid breaking existing stacks (behavior change in CloudFormation template).

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- Added two unit tests in `managed-compute-environment.test.ts`:
  - Feature flag OFF: verifies default imageType remains `ECS_AL2` (backward compat)
  - Feature flag ON: verifies default imageType becomes `ECS_AL2023`
- All 232 existing aws-batch tests pass
Note: global coverage threshold failure is a pre-existing issue in the repository, unrelated to this change.