### PR TITLE
docs: sharpen Mixin vs Facade distinction in design guidelines

### DIFF
--- a/design/mixins-facades-traits.md
+++ b/design/mixins-facades-traits.md
@@ -23,7 +23,7 @@ graph TD
         M["<b>Mixins</b><br/>Inward-looking features<br/><i>BucketVersioning, AutoDeleteObjects</i>"]
         CFN(["<b>CFN Resource<br/>Construct</b>"])
         T["<b>Traits</b><br/>Outward advertisement of contracts<br/><i>Encryptable, HasResourcePolicy</i>"]
-        F["<b>Facades</b><br/>Simplified interfaces for integrations<br/><i>Grants, Metrics, Reflections</i>"]
+        F["<b>Facades</b><br/>Simplified interfaces for external consumers<br/><i>Grants, Metrics, Reflections</i>"]
 
         M --- CFN
         CFN --- T
@@ -63,14 +63,24 @@ the right Trait, and build custom L2s by composing these building blocks.
 
 ### Mixins
 
-Mixins are **inward-looking features** that modify a resource's own
-configuration. They are composable abstractions applied to constructs via the
-`.with()` method from the `constructs` library.
+Mixins are **inward-looking features** that extend a resource's own behavior.
+They are composable abstractions applied to constructs via the `.with()` method
+from the `constructs` library.
 
-Mixins operate on a single primary resource. While a mixin can create auxiliary
-resources (like custom resource handlers) or accept other constructs as props,
-it is not designed for integrations between two equally important resources
-(e.g. connecting an SNS Topic to an SQS Queue). For those, use a Facade.
+A Mixin is a feature *of* the target resource. The defining question is: "is
+this feature about the target resource?" If yes, it is a Mixin — regardless of
+whether it sets properties on the L1, creates auxiliary resources, or both.
+
+Mixins operate on a single primary resource. A Mixin may set properties on the
+L1 resource directly (e.g. enabling versioning), create auxiliary resources that
+serve the primary resource (e.g. a custom resource handler for auto-deletion, or
+a delivery source for vended logs), or accept other constructs as props (e.g. a
+destination log group or S3 bucket). What matters is that the feature is *about*
+the target resource — the auxiliary resources and props exist to support it.
+
+Mixins are not designed for integrations between two equally important resources
+where neither is subordinate to the other (e.g. granting a role access to a
+bucket). For those, use a Facade.
 
 Mixins target L1 (`Cfn*`) resources. When applied to an L2 construct via
 `.with()`, the mixin framework automatically delegates to the L1 default child.
@@ -90,14 +100,19 @@ Mixins target L1 (`Cfn*`) resources. When applied to an L2 construct via
 
 **When to use:**
 
-- A feature modifies the resource's own configuration.
+- The feature is *about* the target resource — it extends the resource's own
+  behavior or lifecycle.
+- The feature sets properties on the L1 resource (e.g. enabling versioning).
+- The feature creates auxiliary resources that serve the primary resource (e.g.
+  custom resource handlers, delivery sources, policy resources).
 - The feature should work with both L1 and L2 constructs.
-- The feature involves creating auxiliary resources (custom resources, policies).
 - Users should be able to compose features independently of L2 props.
 
 **When not to use:**
 
-- The feature integrates the resource with something external (use a Facade).
+- The feature serves an external consumer, not the target resource (use a
+  Facade). For example, granting a role access to a bucket is about the
+  role's needs, not the bucket's behavior.
 - The feature advertises a capability to other constructs (use a Trait).
 - You need to change the optionality of properties or change defaults (Mixins
   cannot do this).
@@ -108,8 +123,15 @@ For detailed implementation guidelines, see
 ### Facades
 
 Facades are **resource-specific simplified interfaces that provide
-integrations** for a resource with other things. They are standalone classes
-with a static factory method that accepts a resource reference interface.
+integrations** for a resource with external consumers. They are standalone
+classes with a static factory method that accepts a resource reference interface.
+
+The defining characteristic of a Facade is directionality: a Facade serves an
+*external consumer*, not the target resource. For example, `BucketGrants`
+exists to serve the grantee (a role that needs access), not the bucket. The
+bucket doesn't care about the grant — the grant exists because the consumer
+needs it. Compare this to a Mixin like `BucketAutoDeleteObjects`, which is a
+feature *of* the bucket regardless of any external consumer.
 
 Facades are always specific to a particular resource type — that is why it is
 `BucketGrants` and not just `Grants`. While Facades for different resources look
@@ -130,16 +152,15 @@ provide their own Facades for any resource without modifying `aws-cdk-lib`.
 - Accept the resource reference interface (`IBucketRef`), enabling use with
   both L1 and L2 constructs.
 - Exposed as properties on the construct interface (e.g. `readonly grants`).
-- Do not modify the resource's own configuration.
 
 **Examples:** `BucketGrants`, `TopicGrants`, `BucketMetrics`, `BucketReflection`
 
 **When to use:**
 
-- The feature provides an integration between a specific resource and something
-  external (IAM permissions, CloudWatch metrics, event patterns).
+- The feature serves an external consumer, not the target resource (e.g. IAM
+  permissions serve the grantee, CloudWatch metrics serve the operator).
 - The feature should work with both L1 and L2 constructs.
-- The feature does not modify the resource itself.
+- The feature is not *about* the target resource's own behavior.
 
 ### Traits
 

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -213,11 +213,19 @@ distinct role and can be used independently of an L2.
 
 ### Mixins
 
-Mixins are **inward-looking features** that modify a resource's own
-configuration. They are composable abstractions applied to constructs via the
-`.with()` method. Mixins usually operate on a single primary resource and can be
-applied to L1s, L2s, or custom constructs alike. They are not designed for
-integrations between two equally important resources — use a
+Mixins are **inward-looking features** that extend a resource's own behavior.
+They are composable abstractions applied to constructs via the `.with()` method.
+
+A Mixin is a feature *of* the target resource. The defining question is: "is
+this feature about the target resource?" If yes, it is a Mixin — regardless of
+whether it sets properties on the L1, creates auxiliary resources (e.g. custom
+resource handlers, delivery sources), or both. Mixins may accept other
+constructs as props (e.g. a destination log group), but the feature remains
+about the target resource.
+
+Mixins usually operate on a single primary resource and can be applied to L1s,
+L2s, or custom constructs alike. They are not designed for features that serve
+an external consumer rather than the target resource — use a
 [Facade](#facades) for that.
 
 Examples: `BucketVersioning`, `BucketAutoDeleteObjects`, `BucketBlockPublicAccess`.
@@ -235,10 +243,12 @@ new s3.Bucket(this, 'Bucket', { removalPolicy: RemovalPolicy.DESTROY })
 
 When to use a Mixin:
 
-- A feature can be expressed as a modification to an L1 resource.
+- The feature is *about* the target resource — it extends the resource's own
+  behavior or lifecycle.
+- The feature sets properties on the L1 resource (e.g. enabling versioning).
+- The feature creates auxiliary resources that serve the primary resource (e.g.
+  custom resource handlers, delivery sources, policy resources).
 - The same feature should be applicable to both L1 and L2 constructs.
-- A feature involves creating auxiliary resources (e.g., custom resources,
-  policies) that support the primary resource.
 - You want to allow users to compose features independently of the L2
   construct's props.
 
@@ -253,10 +263,16 @@ For detailed implementation guidelines, see the
 ### Facades
 
 Facades are **resource-specific simplified interfaces that provide
-integrations** for a resource with other things. They are standalone classes
-with a static factory method (e.g., `fromBucket()` or `of()`) that accepts a
-resource reference interface. Facades are exposed as properties on the construct
-interface.
+integrations** for a resource with external consumers. They are standalone
+classes with a static factory method (e.g., `fromBucket()` or `of()`) that
+accepts a resource reference interface. Facades are exposed as properties on the
+construct interface.
+
+The defining characteristic of a Facade is directionality: a Facade serves an
+*external consumer*, not the target resource. For example, `BucketGrants`
+exists to serve the grantee (a role that needs access), not the bucket. Compare
+this to a Mixin like `BucketAutoDeleteObjects`, which is a feature *of* the
+bucket regardless of any external consumer.
 
 Facades are always specific to a particular resource type — that is why it is
 `BucketGrants` and not just `Grants`. While Facades for different resources look
@@ -284,10 +300,10 @@ grants.read(role);
 
 When to use a Facade:
 
-- The feature provides an integration between a specific resource and something
-  external (e.g., IAM permissions, CloudWatch metrics, event patterns).
+- The feature serves an external consumer, not the target resource (e.g., IAM
+  permissions serve the grantee, CloudWatch metrics serve the operator).
 - The feature should work with both L1 and L2 constructs.
-- The feature does not modify the resource's own configuration.
+- The feature is not *about* the target resource's own behavior.
 
 The [Grants](#grants) section below describes the most common Facade in detail.
 
@@ -318,8 +334,8 @@ interact with directly.
 
 | Question                                         | Mixin                           | Facade           | Trait            |
 | ------------------------------------------------ | ------------------------------- | ---------------- | ---------------- |
-| Does it modify the resource itself?              | yes                             | no               |                  |
-| Does it integrate with external things?          | no                              | yes              | yes              |
+| Is the feature *about* the target resource?      | yes                             | no               |                  |
+| Does it serve an external consumer?              | no                              | yes              | yes              |
 | Does it advertise a service-agnostic capability? | cross-service Mixins            | no               | yes              |
 | Is it specific to one resource type?             | yes                             | yes              | no               |
 | Should it work with L1 constructs?               | yes                             | yes              | yes              |

--- a/docs/MIXINS_DESIGN_GUIDELINES.md
+++ b/docs/MIXINS_DESIGN_GUIDELINES.md
@@ -13,13 +13,19 @@ For an overview of how Mixins relate to Facades and Traits, see the
 
 Mixins are appropriate when:
 
-- A feature can be expressed as a modification to an L1 resource (e.g.,
-  enabling versioning on a bucket).
+- The feature is *about* the target resource — it extends the resource's own
+  behavior or lifecycle.
+- The feature sets properties on the L1 resource (e.g., enabling versioning on
+  a bucket).
+- The feature creates auxiliary resources that serve the primary resource (e.g.,
+  custom resource handlers, delivery sources, policy resources).
 - The same feature should be applicable to both L1 and L2 constructs.
-- A feature involves creating auxiliary resources (e.g., custom resources,
-  policies) that support the primary resource.
 - You want to allow users to compose features independently of the L2
   construct's props.
+
+Mixins are _not_ appropriate when the feature serves an external consumer rather
+than the target resource (use a Facade). For example, granting a role access to
+a bucket is about the role's needs, not the bucket's behavior.
 
 Mixins are _not_ a replacement for construct properties. They cannot change the
 optionality of properties or change defaults.


### PR DESCRIPTION
### Reason for this change

The existing design docs use "modifies a resource's own configuration" as the primary criterion for choosing a Mixin over a Facade. This framing is too narrow — it implies that Mixins must set properties on the L1 resource, which excludes valid Mixins like `BucketAutoDeleteObjects` and vended logs delivery that create auxiliary resources without touching the L1 at all.

This led to confusion when classifying features like vended logs delivery, where the Mixin creates a `DeliverySource`, `DeliveryDestination`, and `Delivery` alongside the target resource. Under the old framing, this looks like a Facade because it "doesn't modify the resource." But it's clearly a feature *of* the target resource — the delivery pipeline exists to serve it.

### Description of changes

The core reframing across all three docs is from "does it modify the resource?" to "is this feature *about* the target resource?"

In `design/mixins-facades-traits.md`, `docs/DESIGN_GUIDELINES.md`, and `docs/MIXINS_DESIGN_GUIDELINES.md`:

The Mixin definition changes from "inward-looking features that modify a resource's own configuration" to "inward-looking features that extend a resource's own behavior." The auxiliary resource pattern (custom resource handlers, delivery sources, policy resources) is elevated from a parenthetical aside to a first-class Mixin pattern with concrete examples.

The Facade definition now emphasizes directionality as the defining characteristic: a Facade serves an *external consumer*, not the target resource. The `BucketGrants` example makes this concrete — the grant serves the grantee, not the bucket.

The decision table replaces "Does it modify the resource itself?" / "Does it integrate with external things?" with "Is the feature about the target resource?" / "Does it serve an external consumer?"

### Description of how you validated changes

Tested the updated docs by giving a separate AI model the classification task with 10 edge-case scenarios (including vended logs delivery, auto-delete objects, S3 notifications with external destination props). The model correctly classified all 10 using the updated heuristics.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
