### PR TITLE
docs(cloudfront): fix misleading HttpVersion documentation

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -196,9 +196,10 @@ export interface DistributionProps {
   readonly geoRestriction?: GeoRestriction;
 
   /**
-   * Specify the maximum HTTP version that you want viewers to use to communicate with CloudFront.
+   * Specify the HTTP version(s) that you want viewers to use to communicate with CloudFront.
    *
-   * For viewers and CloudFront to use HTTP/2, viewers must support TLS 1.2 or later, and must support server name identification (SNI).
+   * For viewers and CloudFront to use HTTP/2, viewers must support TLS 1.2 or later, and must support Server Name Indication (SNI).
+   * For viewers and CloudFront to use HTTP/3, viewers must support TLS 1.3 and Server Name Indication (SNI).
    *
    * @default HttpVersion.HTTP2
    */
@@ -870,15 +871,15 @@ export class Distribution extends Resource implements IDistribution {
   }
 }
 
-/** Maximum HTTP version to support */
+/** The HTTP version(s) to enable for viewers communicating with CloudFront */
 export enum HttpVersion {
-  /** HTTP 1.1 */
+  /** HTTP 1.1 only */
   HTTP1_1 = 'http1.1',
-  /** HTTP 2 */
+  /** HTTP 2 only */
   HTTP2 = 'http2',
   /** HTTP 2 and HTTP 3 */
   HTTP2_AND_3 = 'http2and3',
-  /** HTTP 3 */
+  /** HTTP 3 only */
   HTTP3 = 'http3',
 }
 

--- a/packages/aws-cdk-lib/aws-cloudfront/lib/web-distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/web-distribution.ts
@@ -621,7 +621,7 @@ export interface CloudFrontWebDistributionProps {
   readonly enableIpV6?: boolean;
 
   /**
-   * The max supported HTTP Versions.
+   * The HTTP version(s) to enable for viewers communicating with CloudFront.
    *
    * @default HttpVersion.HTTP2
    */


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37092.

### Reason for this change

The JSDoc for `HttpVersion` enum and `httpVersion` property uses "maximum HTTP version" phrasing, which is misleading. Setting `HttpVersion.HTTP3` does **not** include HTTP/2 — it enables HTTP/3 only. The "maximum" wording implies all versions up to and including that version are enabled, but CloudFront treats each enum value as a specific set of enabled protocols.

### Description of changes

Updated JSDoc in 3 locations across 2 files to align with official AWS CloudFormation and CloudFront API documentation:

1. **`distribution.ts` — `DistributionProps.httpVersion`**: "maximum HTTP version" → "HTTP version(s)", fixed "server name identification" → "Server Name Indication", added HTTP/3 TLS 1.3 requirement note.
2. **`distribution.ts` — `enum HttpVersion`**: "Maximum HTTP version to support" → "The HTTP version(s) to enable for viewers communicating with CloudFront". Added "only" to HTTP1_1, HTTP2, HTTP3 member descriptions.
3. **`web-distribution.ts` — `CloudFrontWebDistributionProps.httpVersion`**: "The max supported HTTP Versions." → "The HTTP version(s) to enable for viewers communicating with CloudFront."

### Description of how you validated changes

Documentation-only change. No runtime behavior or API surface changes.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
- [x] Is this a breaking change (changing existing behavior or removing APIs)? **No**
- [x] Does this change require a change to the docs? **This IS the docs change**

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*