### PR TITLE
fix(ecs): rename `fromEcrRepository` parameter from `tag` to `tagOrDigest`

### DIFF
--- a/allowed-breaking-changes.txt
+++ b/allowed-breaking-changes.txt
@@ -4164,3 +4164,8 @@ removed:aws-cdk-lib.aws_lambda.MetricType.KAFKAMETRICS
 # Never intended to be mutable, not usefully mutable
 removed-mutability:aws-cdk-lib.aws_s3.Bucket.grants
 removed-mutability:aws-cdk-lib.aws_s3.BucketBase.grants
+
+# Renamed parameter `tag` to `tagOrDigest` in ContainerImage.fromEcrRepository
+# to be consistent with the underlying EcrImage constructor and
+# ecr.IRepository.repositoryUriForTagOrDigest.
+incompatible-argument:aws-cdk-lib.aws_ecs.ContainerImage.fromEcrRepository

--- a/packages/aws-cdk-lib/aws-ecs/lib/container-image.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/container-image.ts
@@ -20,10 +20,10 @@ export abstract class ContainerImage {
   /**
    * Reference an image in an ECR repository
    *
-   * @param tag If you don't specify this parameter, `latest` is used as default.
+   * @param tagOrDigest Image tag or digest (default `latest`). Digests must start with `sha256:`.
    */
-  public static fromEcrRepository(repository: ecr.IRepository, tag: string = 'latest') {
-    return new EcrImage(repository, tag);
+  public static fromEcrRepository(repository: ecr.IRepository, tagOrDigest: string = 'latest') {
+    return new EcrImage(repository, tagOrDigest);
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-task-definition.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-task-definition.test.ts
@@ -660,6 +660,30 @@ describe('ec2 task definition', () => {
       });
     });
 
+    test('fromEcrRepository tagOrDigest parameter accepts both tags and digests', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const repo = new Repository(stack, 'Repo');
+
+      // WHEN - tag
+      const tagImage = ecs.ContainerImage.fromEcrRepository(repo, 'my-tag');
+      // WHEN - digest
+      const digestImage = ecs.ContainerImage.fromEcrRepository(repo, 'sha256:94afd1f2e64d908bc90dbca0035a5b567EXAMPLE');
+
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+      taskDefinition.addContainer('tag', { image: tagImage, memoryLimitMiB: 512 });
+      taskDefinition.addContainer('digest', { image: digestImage, memoryLimitMiB: 512 });
+
+      // THEN
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({ Name: 'tag' }),
+          Match.objectLike({ Name: 'digest' }),
+        ]),
+      });
+    });
+
     test('correctly sets containers from ECR repository using default props', () => {
       // GIVEN
       const stack = new cdk.Stack();


### PR DESCRIPTION
### Issue

Closes #30463

### Reason for this change

The static method `ContainerImage.fromEcrRepository(repository, tag)` uses parameter name `tag`, but the underlying `EcrImage` constructor already correctly uses `tagOrDigest` since the parameter accepts both image tags and `sha256:` digests. The ECS README also already documents it as `tagOrDigest`.

This inconsistency was partially addressed in #27143 (which updated docs) but the actual code parameter was not renamed.

### Description of changes

- Renamed the `tag` parameter to `tagOrDigest` in `ContainerImage.fromEcrRepository`
- Updated the `@param` JSDoc to describe both tag and digest usage
- Added entry to `allowed-breaking-changes.txt`

### Precedent

The `aws-codebuild` module already shipped this same rename for `LinuxBuildImage.fromEcrRepository`, `WindowsBuildImage.fromEcrRepository`, `MacBuildImage.fromEcrRepository`, and `LinuxArmBuildImage.fromEcrRepository`.

### Description of how you validated changes

- All 834 existing aws-ecs unit tests pass (12 pre-existing failures in `cluster.test.ts` unrelated to this change)
- ESLint: clean
- tsc: no new type errors
- All existing test call sites use positional arguments — no test changes needed

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
- [x] Is this fix associated with a [tracking issue](https://github.com/aws/aws-cdk/issues/30463)?

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

#### BREAKING CHANGE

The `tag` parameter of `ContainerImage.fromEcrRepository` has been renamed to `tagOrDigest`. This affects Python users who use the keyword argument `tag=` — they must change to `tag_or_digest=`. TypeScript, Java, C#, and Go callers using positional arguments are unaffected.