### PR TITLE
fix(dynamodb): remove deprecated TableGrantsProps wiring in TableV2

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -669,8 +669,6 @@ export class TableV2 extends TableBaseV2 {
         this.grants = new TableGrants({
           table: this,
           hasIndex: this.hasIndex,
-          encryptedResource: this.encryptionKey ? this : undefined,
-          policyResource: this.resourcePolicy ? this : undefined,
         });
       }
 
@@ -865,8 +863,6 @@ export class TableV2 extends TableBaseV2 {
       table: this,
       regions: Array.from(this.replicaTables.keys()),
       hasIndex: this.hasIndex,
-      encryptedResource: this.encryptionKey ? this : undefined,
-      policyResource: this,
     });
 
     if (props.tableName) {
@@ -1473,8 +1469,6 @@ export class TableV2MultiAccountReplica extends TableBaseV2 {
     this.grants = new TableGrants({
       table: this,
       regions: [],
-      encryptedResource: this.encryptionKey ? this : undefined,
-      policyResource: this,
     });
 
     this.grants.multiAccountReplicationFrom(props.replicaSourceTable.tableArn);


### PR DESCRIPTION
## Description
This PR removes deprecated `TableGrantsProps` fields from `TableV2` grant initialization to stop runtime deprecation warnings during synth.

Specifically, it removes `encryptedResource` and `policyResource` from `new TableGrants(...)` in:
- imported table path
- main `TableV2` path
- `TableV2MultiAccountReplica` path

`TableGrants` already infers these capabilities from `table` itself, so behavior remains unchanged while warnings are eliminated.

## Why
Issue #37221 reports deprecation warnings from `grantReadWriteData` / `grantReadData` usage with Dynamo event source setups. This cleans up deprecated prop wiring at the source.

## Testing
- Searched DynamoDB v2 table grant initialization paths and verified deprecated prop wiring is removed.

Closes #37221
