### PR TITLE
fix(applicationautoscaling): validate schedule expression format in scaleOnSchedule

### DIFF
--- a/packages/aws-cdk-lib/aws-applicationautoscaling/lib/scalable-target.ts
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/lib/scalable-target.ts
@@ -7,7 +7,7 @@ import type { BasicTargetTrackingScalingPolicyProps } from './target-tracking-sc
 import { TargetTrackingScalingPolicy } from './target-tracking-scaling-policy';
 import * as iam from '../../aws-iam';
 import type { IResource, TimeZone } from '../../core';
-import { Lazy, Resource, withResolved } from '../../core';
+import { Lazy, Resource, Token, withResolved } from '../../core';
 import { ValidationError } from '../../core/lib/errors';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
@@ -222,6 +222,15 @@ export class ScalableTarget extends Resource implements IScalableTarget {
   public scaleOnSchedule(id: string, action: ScalingSchedule) {
     if (action.minCapacity === undefined && action.maxCapacity === undefined) {
       throw new ValidationError(`You must supply at least one of minCapacity or maxCapacity, got ${JSON.stringify(action)}`, this);
+    }
+
+    const expr = action.schedule.expressionString;
+    if (!Token.isUnresolved(expr) && !expr.startsWith('cron(') && !expr.startsWith('rate(') && !expr.startsWith('at(')) {
+      throw new ValidationError(
+        `Invalid schedule expression: "${expr}". Application Auto Scaling requires expressions in the format \'cron(...)\', \'rate(...)\', or \'at(...)\'. `
+        + 'If you imported Schedule from \'aws-cdk-lib/aws-autoscaling\', use Schedule from \'aws-cdk-lib/aws-applicationautoscaling\' instead.',
+        this,
+      );
     }
 
     // add a warning on synth when minute is not defined in a cron schedule

--- a/packages/aws-cdk-lib/aws-applicationautoscaling/test/scalable-target.test.ts
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/test/scalable-target.test.ts
@@ -299,4 +299,15 @@ describe('scalable target', () => {
       });
     }).toThrow(/You must supply at least one of minCapacity or maxCapacity, got/);
   });
+
+  test('throws when schedule expression is not a valid Application Auto Scaling format', () => {
+    const stack = new cdk.Stack();
+    const target = createScalableTarget(stack);
+    expect(() => {
+      target.scaleOnSchedule('ScaleUp', {
+        schedule: appscaling.Schedule.expression('30 3 * * *'),
+        minCapacity: 1,
+      });
+    }).toThrow(/Invalid schedule expression: "30 3 \* \* \*"/);
+  });
 });


### PR DESCRIPTION
## Description

Add runtime validation in `ScalableTarget.scaleOnSchedule()` to check that the schedule expression matches valid Application Auto Scaling formats: `cron(...)`, `rate(...)`, or `at(...)`.

This catches the common mistake of importing `Schedule` from `aws-cdk-lib/aws-autoscaling` instead of `aws-cdk-lib/aws-applicationautoscaling`, which produces bare cron expressions (e.g. `30 3 * * *`) that fail at deploy time with a cryptic CloudFormation error.

Closes #30502

### What should reviewers focus on

- The validation logic in `scaleOnSchedule()` — it skips unresolved Tokens and only checks resolved string expressions
- The error message guides users to the correct import

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*