### PR TITLE
fix(stepfunctions-tasks): scope SubmitBatchJob IAM permissions to specific job definition

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.js.snapshot/aws-stepfunctions-integ.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.js.snapshot/aws-stepfunctions-integ.template.json
@@ -663,12 +663,6 @@
        "Effect": "Allow",
        "Resource": [
         {
-         "Fn::GetAtt": [
-          "JobQueueEE3AD499",
-          "JobQueueArn"
-         ]
-        },
-        {
          "Fn::Join": [
           "",
           [
@@ -684,8 +678,38 @@
            {
             "Ref": "AWS::AccountId"
            },
-           ":job-definition/*"
+           ":job-definition/",
+           {
+            "Fn::Select": [
+             0,
+             {
+              "Fn::Split": [
+               ":",
+               {
+                "Fn::Select": [
+                 1,
+                 {
+                  "Fn::Split": [
+                   "/",
+                   {
+                    "Ref": "JobDefinition24FFE3ED"
+                   }
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           },
+           ":*"
           ]
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "JobQueueEE3AD499",
+          "JobQueueArn"
          ]
         }
        ]

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.js.snapshot/tree.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.js.snapshot/tree.json
@@ -1164,12 +1164,6 @@
                                   "Effect": "Allow",
                                   "Resource": [
                                     {
-                                      "Fn::GetAtt": [
-                                        "JobQueueEE3AD499",
-                                        "JobQueueArn"
-                                      ]
-                                    },
-                                    {
                                       "Fn::Join": [
                                         "",
                                         [
@@ -1185,8 +1179,38 @@
                                           {
                                             "Ref": "AWS::AccountId"
                                           },
-                                          ":job-definition/*"
+                                          ":job-definition/",
+                                          {
+                                            "Fn::Select": [
+                                              0,
+                                              {
+                                                "Fn::Split": [
+                                                  ":",
+                                                  {
+                                                    "Fn::Select": [
+                                                      1,
+                                                      {
+                                                        "Fn::Split": [
+                                                          "/",
+                                                          {
+                                                            "Ref": "JobDefinition24FFE3ED"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          ":*"
                                         ]
+                                      ]
+                                    },
+                                    {
+                                      "Fn::GetAtt": [
+                                        "JobQueueEE3AD499",
+                                        "JobQueueArn"
                                       ]
                                     }
                                   ]

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.ts
@@ -13,6 +13,11 @@ import { BatchSubmitJob } from 'aws-cdk-lib/aws-stepfunctions-tasks';
  * *
  * * aws batch describe-jobs --jobs <job-id returned by list-jobs> --query 'jobs[0].status': wait until the status is 'SUCCEEDED'
  * * aws stepfunctions describe-execution --execution-arn <execution-arn generated before> --query 'status': should return status as SUCCEEDED
+ * *
+ * * IAM policy verification:
+ * * aws iam get-role-policy --role-name <state machine execution role name> --policy-name <inline policy name>
+ * * The batch:SubmitJob action should be scoped to the specific job definition ARN (with :* revision wildcard)
+ * * and job queue ARN, not a wildcard (*).
  */
 
 class RunBatchStack extends cdk.Stack {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/batch/submit-job.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/batch/submit-job.ts
@@ -3,7 +3,7 @@ import type * as ec2 from '../../../aws-ec2';
 import * as iam from '../../../aws-iam';
 import * as sfn from '../../../aws-stepfunctions';
 import type { Size } from '../../../core';
-import { Stack, ValidationError, withResolved } from '../../../core';
+import { Fn, Stack, ValidationError, withResolved } from '../../../core';
 import { integrationResourceArn, isJsonPathOrJsonataExpression, validatePatternSupported } from '../private/task-utils';
 
 /**
@@ -307,19 +307,28 @@ export class BatchSubmitJob extends sfn.TaskStateBase {
   }
 
   private configurePolicyStatements(): iam.PolicyStatement[] {
+    const useDynamicResource = isJsonPathOrJsonataExpression(this.props.jobQueueArn)
+      || isJsonPathOrJsonataExpression(this.props.jobDefinitionArn);
+
+    let batchResources: string[];
+    if (useDynamicResource) {
+      batchResources = ['*'];
+    } else {
+      // Extract job definition name (without revision) and use :* to scope to any revision
+      // e.g., arn:aws:batch:...:job-definition/MyDef:2 → arn:...:job-definition/MyDef:*
+      const nameAndRevision = Fn.select(1, Fn.split('/', this.props.jobDefinitionArn));
+      const jobDefName = Fn.select(0, Fn.split(':', nameAndRevision));
+      const jobDefinitionResource = Stack.of(this).formatArn({
+        service: 'batch',
+        resource: 'job-definition',
+        resourceName: `${jobDefName}:*`,
+      });
+      batchResources = [jobDefinitionResource, this.props.jobQueueArn];
+    }
+
     return [
-      // Resource level access control for job-definition requires revision which batch does not support yet
-      // Using the alternative permissions as mentioned here:
-      // https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html
       new iam.PolicyStatement({
-        resources: isJsonPathOrJsonataExpression(this.props.jobQueueArn) ? ['*'] : [
-          Stack.of(this).formatArn({
-            service: 'batch',
-            resource: 'job-definition',
-            resourceName: '*',
-          }),
-          this.props.jobQueueArn,
-        ],
+        resources: batchResources,
         actions: ['batch:SubmitJob'],
       }),
       new iam.PolicyStatement({

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/test/batch/submit-job.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/test/batch/submit-job.test.ts
@@ -514,6 +514,119 @@ test('throws if tags has invalid value', () => {
   );
 });
 
+test('grants tighter permissions when jobDefinitionArn and jobQueueArn are static', () => {
+  // WHEN
+  const task = new BatchSubmitJob(stack, 'Task', {
+    jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+    jobQueueArn: batchJobQueue.jobQueueArn,
+    jobName: 'JobName',
+  });
+
+  new sfn.StateMachine(stack, 'StateMachine', {
+    definitionBody: sfn.DefinitionBody.fromChainable(task),
+  });
+
+  // THEN - should grant permissions to specific job definition name:* (not wildcard job-definition/*)
+  Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: 'batch:SubmitJob',
+          Effect: 'Allow',
+          Resource: [
+            {
+              'Fn::Join': ['', [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':batch:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':job-definition/',
+                { 'Fn::Select': [0, { 'Fn::Split': [':', { 'Fn::Select': [1, { 'Fn::Split': ['/', { Ref: 'JobDefinition24FFE3ED' }] }] }] }] },
+                ':*',
+              ]],
+            },
+            { 'Fn::GetAtt': ['JobQueueEE3AD499', 'JobQueueArn'] },
+          ],
+        },
+        {
+          Action: [
+            'events:PutTargets',
+            'events:PutRule',
+            'events:DescribeRule',
+          ],
+          Effect: 'Allow',
+          Resource: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':events:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':rule/StepFunctionsGetEventsForBatchJobsRule',
+              ],
+            ],
+          },
+        },
+      ],
+      Version: '2012-10-17',
+    },
+  });
+});
+
+test('falls back to wildcard permissions when jobDefinitionArn is JSONPath', () => {
+  // WHEN
+  const task = new BatchSubmitJob(stack, 'Task', {
+    jobDefinitionArn: sfn.JsonPath.stringAt('$.jobDefinitionArn'),
+    jobQueueArn: batchJobQueue.jobQueueArn,
+    jobName: 'JobName',
+  });
+
+  new sfn.StateMachine(stack, 'StateMachine', {
+    definitionBody: sfn.DefinitionBody.fromChainable(task),
+  });
+
+  // THEN - should fall back to wildcard when jobDefinitionArn is dynamic
+  Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: 'batch:SubmitJob',
+          Effect: 'Allow',
+          Resource: '*',
+        },
+        {
+          Action: [
+            'events:PutTargets',
+            'events:PutRule',
+            'events:DescribeRule',
+          ],
+          Effect: 'Allow',
+          Resource: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':events:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':rule/StepFunctionsGetEventsForBatchJobsRule',
+              ],
+            ],
+          },
+        },
+      ],
+      Version: '2012-10-17',
+    },
+  });
+});
+
 test('supports passing jobQueueArn as JsonPath or JSONata', () => {
   // WHEN
   const task = new BatchSubmitJob(stack, 'Task', {


### PR DESCRIPTION
## What does this PR do?

`BatchSubmitJob` currently grants `batch:SubmitJob` on `*` (all resources) when static ARNs are provided. This PR scopes the permission to the specific job queue ARN and a wildcard over all revisions of the job definition (e.g., `arn:aws:batch:...:job-definition/MyDef:*`), following least-privilege best practices.

When either ARN is a dynamic value (JSONPath / JSONata expression), the existing wildcard behavior is preserved as the ARN cannot be resolved at synthesis time.

## Closes

Closes #37214

## Testing

- [x] Unit tests added (2 new test cases)
  - Static ARNs → scoped permissions to job definition name with `:*` revision wildcard + job queue ARN
  - JSONPath ARN → falls back to `*`
- [x] Integration test snapshot updated

## Breaking Changes

None. Previously the policy used `*`; this change only restricts the scope, which is a security improvement and not a behavioral breaking change for CDK users.