### PR TITLE
chore(build): update dotnet version check to support .NET 10+

### DIFF
--- a/scripts/check-build-prerequisites.sh
+++ b/scripts/check-build-prerequisites.sh
@@ -127,7 +127,7 @@ app_min="6.0.100"
 check_which $app $app_min
 app_v=$(${app} --list-sdks)
 echo -e "Checking dotnet version... \c"
-if [ $(echo $app_v | grep -c -E "[6789]\.[0-9]+\.[0-9]+") -eq 1 ]
+if [ $(echo $app_v | grep -c -E "([6-9]|[1-9][0-9]+)\.[0-9]+\.[0-9]+") -eq 1 ]
 then
     echo "Ok"
 else


### PR DESCRIPTION
### Issue # (if applicable)

Closes  #37261

### Reason for this change

.NET 10 is now out: [Announcing .NET 10](https://devblogs.microsoft.com/dotnet/announcing-dotnet-10)
The prerequisite check does not currently recognize .NET 10 SDK versions.

A similar update was previously made for .NET 9, and this change extends the version check so contributors using .NET 10 do not fail setup unnecessarily.

### Description of changes

Updated the dotnet prerequisite version check regex to recognize .NET 10 SDK versions.

This keeps the existing behavior for previously allowed versions and fixes the case where two-digit major versions were not accepted by the check.

### Describe any new or updated permissions being added

No new permissions are required.

### Description of how you validated changes

- Reproduced the failure locally with .NET SDK 10.0.105
- Updated the version check to allow 10.x SDKs
- Verified the prerequisite check passes with the updated regex

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*