### PR TITLE
docs: correct typos in CLOUDFORMATION, DESIGN_GUIDELINES, and …

### DIFF
--- a/docs/CLOUDFORMATION.md
+++ b/docs/CLOUDFORMATION.md
@@ -22,7 +22,7 @@ state resource `Creates`, `Updates` or `Deletes` are performed.
 ```text
       ╔══════════════════╗
       ║                  ║
-      ║  <nonexistant>   ║──────────────────┐
+      ║  <nonexistent>   ║──────────────────┐
       ║                  ║                  ▼
       ╚══════════════════╝       ┌────────────────────┐
                 │                │                    │
@@ -118,7 +118,7 @@ be immediately followed by delete and an update back to the original state, resp
 ```text
                                   ╔════════════════════════╗
                                   ║                        ║
-                                  ║     <nonexistant>      ║
+                                  ║     <nonexistent>      ║
                                   ║                        ║
                                   ╚════════════════════════╝
                                                │

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -2052,7 +2052,7 @@ constructor(scope: Scope, id: string, props: MyConstructProps) {
 in a `Lazy`.
 
 * The why:
- - `Lazy`s are called after the construct tree has already been sythesized. Mutating it
+ - `Lazy`s are called after the construct tree has already been synthesized. Mutating it
  at this point could have not-obvious consequences.
 
 ## Documentation

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,7 +34,7 @@ This script will also update the relevant changelog file.
 
 ## `scripts/resolve-version.js`
 
-The script evaluates evaluates the configuration in `release.json` and exports an
+The script evaluates the configuration in `release.json` and exports an
 object like this:
 
 ```js


### PR DESCRIPTION
### Issue # (if applicable)

N/A (no issue)

### Reason for this change

Fixes a few typos/grammar issues in documentation.

### Description of changes

- `CLOUDFORMATION.md`: `nonexistant` → `nonexistent` (2 occurrences)
- `DESIGN_GUIDELINES.md`: `sythesized` → `synthesized`
- `release.md`: removed duplicated word `evaluates`

Documentation-only changes; no functional impact.

### Describe any new or updated permissions being added

N/A – documentation only.

### Description of how you validated changes

Reviewed the edited files and confirmed the corrected spelling/grammar.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*