### PR TITLE
chore(mixins-preview): fix namespace collision in spec2logs generator

### DIFF
--- a/packages/@aws-cdk/mixins-preview/scripts/spec2logs/generate.ts
+++ b/packages/@aws-cdk/mixins-preview/scripts/spec2logs/generate.ts
@@ -12,6 +12,7 @@ export async function generateAll(options: GenerateOptions): Promise<GeneratorRe
   const services = await db.all('service');
   const moduleMap: ModuleMap = loadModuleMap({
     packageBases: MIXINS_PREVIEW_BASE_NAMES,
+    respectOverrides: false,
   });
   const moduleRequests: GenerateModuleMap = {};
 


### PR DESCRIPTION
### Description of changes

Build failure caused in new log-source update PR: https://github.com/cdklabs/awscdk-service-spec/pull/2535.

The `respectOverrides` was not set to false, causing it to inherit `aws-cdk-lib` dotnet namespace overrides from [scope-map.json](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/scripts/scope-map.json); causing both `aws-cdk-lib` and `mixins-preview` emit to the same dotnet namespace "Amazon.CDK.AWS.APIGateway".

The PR build is failing with [error](https://github.com/cdklabs/awscdk-service-spec/actions/runs/23177806351/job/67343784969?pr=2535) 
```
Error: 3-17T04:15:12.459] [ERROR] jsii/compiler - Type model errors prevented the JSII assembly from being created
  warning JSII4010: Multiple modules emit to the same dotnet namespace "Amazon.CDK.AWS.APIGateway": aws-cdk-lib.aws_apigateway, @aws-cdk/mixins-preview.aws_apigateway [jsii-config/submodule-conflict]
```
<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
