### PR TITLE
fix(ec2): fix typo in SecurityGroup egress error message

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
@@ -626,7 +626,7 @@ export class SecurityGroup extends SecurityGroupBase {
       // to "allOutbound=true" mode, because we might have already emitted
       // EgressRule objects (which count as rules added later) and there's no way
       // to recall those. Better to prevent this for now.
-      throw new ValidationError('CannotAddTrafficEgressRule', 'Cannot add an "all traffic" egress rule in this way; set allowAllOutbound=true (for ipv6) or allowAllIpv6Outbound=true (for ipv6) on the SecurityGroup instead.', this);
+      throw new ValidationError('CannotAddTrafficEgressRule', 'Cannot add an "all traffic" egress rule in this way; set allowAllOutbound=true (for ipv4) or allowAllIpv6Outbound=true (for ipv6) on the SecurityGroup instead.', this);
     }
 
     this.addDirectEgressRule(rule);

--- a/packages/aws-cdk-lib/aws-ec2/test/security-group.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/security-group.test.ts
@@ -155,7 +155,7 @@ describe('security group', () => {
     const sg = new SecurityGroup(stack, 'SG1', { vpc, allowAllOutbound: false });
     expect(() => {
       sg.addEgressRule(Peer.anyIpv4(), Port.allTraffic(), 'All traffic');
-    }).toThrow(/Cannot add/);
+    }).toThrow(/allowAllOutbound=true \(for ipv4\).*allowAllIpv6Outbound=true \(for ipv6\)/);
   });
 
   test('all ipv6 outbound rule cannot be added after creation', () => {
@@ -167,7 +167,7 @@ describe('security group', () => {
     const sg = new SecurityGroup(stack, 'SG1', { vpc, allowAllOutbound: false });
     expect(() => {
       sg.addEgressRule(Peer.anyIpv6(), Port.allTraffic(), 'All traffic');
-    }).toThrow(/Cannot add/);
+    }).toThrow(/allowAllOutbound=true \(for ipv4\).*allowAllIpv6Outbound=true \(for ipv6\)/);
   });
 
   test('immutable imports do not add rules', () => {


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The error message in `SecurityGroup.addEgressRule()` says `allowAllOutbound=true (for ipv6)`, but `allowAllOutbound` controls IPv4 egress (`SecurityGroupProps.allowAllOutbound`, default: `true`). The IPv6 counterpart is `allowAllIpv6Outbound` (`SecurityGroupProps.allowAllIpv6Outbound`, default: `false`). The first parenthetical should read `(for ipv4)`.

### Description of changes

Fix `(for ipv6)` → `(for ipv4)` in the `allowAllOutbound` portion of the error message (L629 in `security-group.ts`).

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Strengthened existing test assertions to verify correct IP version labels in the error message.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*