### PR TITLE
docs(cloudfront): clarify that `HttpVersion.HTTP3` does not include HTTP/2

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -201,7 +201,10 @@ export interface DistributionProps {
   readonly geoRestriction?: GeoRestriction;
 
   /**
-   * Specify the maximum HTTP version that you want viewers to use to communicate with CloudFront.
+   * Specify the HTTP version(s) that you want viewers to use to communicate with CloudFront.
+   *
+   * Note that setting `HTTP3` enables HTTP/3 only and does *not* include HTTP/2.
+   * To support both HTTP/2 and HTTP/3, use `HTTP2_AND_3`.
    *
    * For viewers and CloudFront to use HTTP/2, viewers must support TLS 1.2 or later, and must support server name identification (SNI).
    *
@@ -901,7 +904,7 @@ export enum HttpVersion {
   HTTP2 = 'http2',
   /** HTTP 2 and HTTP 3 */
   HTTP2_AND_3 = 'http2and3',
-  /** HTTP 3 */
+  /** HTTP 3 only (does not include HTTP/2) */
   HTTP3 = 'http3',
 }
 


### PR DESCRIPTION
The documentation for the `httpVersion` property described it as the 'maximum HTTP version', which is misleading because setting `HTTP3` disables HTTP/2. Clarified that `HTTP3` is HTTP/3 only and users should use `HTTP2_AND_3` to support both.

Closes #37092