### PR TITLE
docs(cloudfront): add India to `PRICE_CLASS_200` region list

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -912,7 +912,7 @@ export enum HttpVersion {
 export enum PriceClass {
   /** USA, Canada, Europe, & Israel */
   PRICE_CLASS_100 = 'PriceClass_100',
-  /** PRICE_CLASS_100 + South Africa, Kenya, Middle East, Japan, Singapore, South Korea, Taiwan, Hong Kong, & Philippines */
+  /** PRICE_CLASS_100 + South Africa, Kenya, Middle East, Japan, Singapore, South Korea, Taiwan, Hong Kong, Philippines, & India */
   PRICE_CLASS_200 = 'PriceClass_200',
   /** All locations */
   PRICE_CLASS_ALL = 'PriceClass_All',


### PR DESCRIPTION
India is included in PRICE_CLASS_200 per the [AWS CloudFront pricing page](https://aws.amazon.com/cloudfront/pricing/) but was missing from the JSDoc comment.

Closes #35992