### PR TITLE
docs(ecs): fix incorrect default value for `enableManagedDraining`

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -1405,7 +1405,7 @@ export interface AsgCapacityProviderProps extends AddAutoScalingGroupCapacityOpt
    * Infrastructure maintenance and updates are preformed without disruptions to workloads.
    * To use managed instance draining, set enableManagedDraining to true.
    *
-   * @default true
+   * @default - undefined, which means Amazon ECS will use its default behavior.
    */
   readonly enableManagedDraining?: boolean;
 


### PR DESCRIPTION
The JSDoc stated `@default true` but the actual code defaults to `undefined`, which delegates to the AWS service default behavior.

Closes #35539