### PR TITLE
fix(amplify): custom domain with blank prefix causes stack drift

### DIFF
--- a/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/lib/domain.ts
@@ -199,10 +199,13 @@ export class Domain extends Resource {
   }
 
   private renderSubDomainSettings() {
-    return this.subDomains.map(s => ({
-      branchName: s.branch.branchName,
-      prefix: s.prefix ?? s.branch.branchName,
-    }));
+    return this.subDomains.map(s => {
+      const prefix = s.prefix ?? s.branch.branchName;
+      return {
+        branchName: s.branch.branchName,
+        ...(prefix ? { prefix } : {}),
+      };
+    });
   }
 }
 

--- a/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/test/domain.test.ts
@@ -353,3 +353,32 @@ test('auto subdomain with IAM role', () => {
     },
   });
 });
+
+test('blank prefix is omitted from subdomain settings to avoid stack drift', () => {
+  // GIVEN
+  const stack = new Stack();
+  const app = new amplify.App(stack, 'App', {
+    sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
+      owner: 'aws',
+      repository: 'aws-cdk',
+      oauthToken: SecretValue.unsafePlainText('secret'),
+    }),
+  });
+  const prodBranch = app.addBranch('main');
+  const domain = new amplify.Domain(stack, 'Domain', {
+    app,
+    domainName: 'example.com',
+  });
+
+  // WHEN
+  domain.mapSubDomain(prodBranch, '');
+
+  // THEN - prefix should not appear in the template
+  Template.fromStack(stack).hasResourceProperties('AWS::Amplify::Domain', {
+    SubDomainSettings: [
+      {
+        BranchName: 'main',
+      },
+    ],
+  });
+});


### PR DESCRIPTION
When a subdomain is mapped with an empty string prefix, the CloudFormation template includes `Prefix: ""` but AWS omits empty prefix values, causing immediate stack drift after deployment.

Now omit the `prefix` property entirely when it is an empty string.

Closes #35958