### PR TITLE
docs(sns): add IAM action details to `grantPublish` and `grantSubscribe`

### DIFF
--- a/packages/aws-cdk-lib/aws-sns/lib/topic-base.ts
+++ b/packages/aws-cdk-lib/aws-sns/lib/topic-base.ts
@@ -70,12 +70,18 @@ export interface ITopic extends IResource, notifications.INotificationRuleTarget
   addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult;
 
   /**
-   * Grant topic publishing permissions to the given identity
+   * Grant topic publishing permissions to the given identity.
+   *
+   * This grants the `sns:Publish` action on this topic. If the topic is encrypted
+   * with a customer-managed KMS key, it also grants `kms:Decrypt` and
+   * `kms:GenerateDataKey*` on the key.
    */
   grantPublish(identity: iam.IGrantable): iam.Grant;
 
   /**
-   * Grant topic subscribing permissions to the given identity
+   * Grant topic subscribing permissions to the given identity.
+   *
+   * This grants the `sns:Subscribe` action on this topic.
    */
   grantSubscribe(identity: iam.IGrantable): iam.Grant;
 }
@@ -224,7 +230,11 @@ export abstract class TopicBase extends Resource implements ITopic, IEncryptedRe
   }
 
   /**
-   * Grant topic publishing permissions to the given identity
+   * Grant topic publishing permissions to the given identity.
+   *
+   * This grants the `sns:Publish` action on this topic. If the topic is encrypted
+   * with a customer-managed KMS key, it also grants `kms:Decrypt` and
+   * `kms:GenerateDataKey*` on the key.
    *
    * The use of this method is discouraged. Please use `grants.publish()` instead.
    *
@@ -235,7 +245,9 @@ export abstract class TopicBase extends Resource implements ITopic, IEncryptedRe
   }
 
   /**
-   * Grant topic subscribing permissions to the given identity
+   * Grant topic subscribing permissions to the given identity.
+   *
+   * This grants the `sns:Subscribe` action on this topic.
    *
    * The use of this method is discouraged. Please use `grants.subscribe()` instead.
    *


### PR DESCRIPTION
Added details about which IAM actions are granted by `grantPublish` (`sns:Publish` + KMS permissions for encrypted topics) and `grantSubscribe` (`sns:Subscribe`) to help users understand the exact permissions being granted.

Closes #35736