### PR TITLE
docs(ec2): fix typo in security group egress rule error message

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
@@ -626,7 +626,7 @@ export class SecurityGroup extends SecurityGroupBase {
       // to "allOutbound=true" mode, because we might have already emitted
       // EgressRule objects (which count as rules added later) and there's no way
       // to recall those. Better to prevent this for now.
-      throw new ValidationError('CannotAddTrafficEgressRule', 'Cannot add an "all traffic" egress rule in this way; set allowAllOutbound=true (for ipv6) or allowAllIpv6Outbound=true (for ipv6) on the SecurityGroup instead.', this);
+      throw new ValidationError('CannotAddTrafficEgressRule', 'Cannot add an "all traffic" egress rule in this way; set allowAllOutbound=true (for ipv4) or allowAllIpv6Outbound=true (for ipv6) on the SecurityGroup instead.', this);
     }
 
     this.addDirectEgressRule(rule);


### PR DESCRIPTION
The error message incorrectly said `allowAllOutbound=true (for ipv6)` when it should say `(for ipv4)`.

Closes #36551