### PR TITLE
docs(ecs): clarify that `fromEcrRepository` tag parameter also accepts digest

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/container-image.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/container-image.ts
@@ -20,7 +20,8 @@ export abstract class ContainerImage {
   /**
    * Reference an image in an ECR repository
    *
-   * @param tag If you don't specify this parameter, `latest` is used as default.
+   * @param tag Image tag or digest. Supports both tag (e.g., 'latest') and digest
+   * (e.g., 'sha256:abc123') formats. If you don't specify this parameter, `latest` is used as default.
    */
   public static fromEcrRepository(repository: ecr.IRepository, tag: string = 'latest') {
     return new EcrImage(repository, tag);


### PR DESCRIPTION
The `tag` parameter of `ContainerImage.fromEcrRepository` accepts both tag (e.g., `'latest'`) and digest (e.g., `'sha256:abc123'`) formats, but the documentation only mentioned tags. The underlying `EcrImage` constructor already names this parameter `tagOrDigest`.

Closes #30463