### PR TITLE
docs(dynamodb): document that `TableV2` creates an `AWS::DynamoDB::GlobalTable` resource

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -596,6 +596,12 @@ export interface TableAttributesV2 {
 
 /**
  * A DynamoDB Table.
+ *
+ * This construct creates an `AWS::DynamoDB::GlobalTable` CloudFormation resource,
+ * even for single-region tables. This is the recommended resource type for all
+ * new DynamoDB tables. See the
+ * [AWS blog post](https://aws.amazon.com/blogs/devops/a-new-and-improved-aws-cdk-construct-for-amazon-dynamodb-tables/)
+ * for more details on the differences between `Table` and `TableV2`.
  */
 @propertyInjectable
 export class TableV2 extends TableBaseV2 {


### PR DESCRIPTION
Users are often confused that `TableV2` translates to an `AWS::DynamoDB::GlobalTable` CloudFormation resource even for single-region tables. Added JSDoc to clarify this and link to the AWS blog post explaining the differences.

Closes #32407