### PR TITLE
feat(ec2): add C8a (`InstanceClass.C8A`) instance class

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1362,6 +1362,13 @@ new ec2.Instance(this, 'Instance5', {
     cpuType: ec2.AmazonLinuxCpuType.ARM_64,
   }),
 });
+
+// AMD EPYC (4th gen) Processor
+new ec2.Instance(this, 'Instance6', {
+  vpc,
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.C8A, ec2.InstanceSize.LARGE),
+  machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+});
 ```
 
 ### Latest Amazon Linux Images

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
@@ -793,6 +793,16 @@ export enum InstanceClass {
   C7A = 'c7a',
 
   /**
+   * Compute optimized instances based on 5th generation AMD EPYC (codename Turin), 8th generation
+   */
+  COMPUTE8_AMD = 'compute8-amd',
+
+  /**
+   * Compute optimized instances based on 5th generation AMD EPYC (codename Turin), 8th generation
+   */
+  C8A = 'c8a',
+
+  /**
    * Storage-optimized instances, 2nd generation
    */
   STORAGE2 = 'storage2',
@@ -1971,6 +1981,8 @@ export class InstanceType {
       [InstanceClass.C7I_FLEX]: 'c7i-flex',
       [InstanceClass.COMPUTE7_AMD]: 'c7a',
       [InstanceClass.C7A]: 'c7a',
+      [InstanceClass.COMPUTE8_AMD]: 'c8a',
+      [InstanceClass.C8A]: 'c8a',
       [InstanceClass.COMPUTE8_GRAVITON4]: 'c8g',
       [InstanceClass.C8G]: 'c8g',
       [InstanceClass.COMPUTE8_GRAVITON4_NVME_DRIVE]: 'c8gd',

--- a/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
@@ -5,4 +5,14 @@ describe('InstanceType', () => {
     const instanceType = InstanceType.of(InstanceClass.MAC2_M1ULTRA, InstanceSize.METAL);
     expect(instanceType.toString()).toEqual('mac2-m1ultra.metal');
   });
+
+  test('c8a instance class', () => {
+    const instanceType = InstanceType.of(InstanceClass.C8A, InstanceSize.LARGE);
+    expect(instanceType.toString()).toEqual('c8a.large');
+  });
+
+  test('COMPUTE8_AMD instance class', () => {
+    const instanceType = InstanceType.of(InstanceClass.COMPUTE8_AMD, InstanceSize.XLARGE);
+    expect(instanceType.toString()).toEqual('c8a.xlarge');
+  });
 });


### PR DESCRIPTION
### Reason for this change

C8a instances (compute optimized, 5th gen AMD EPYC Turin) are [generally available](https://aws.amazon.com/about-aws/whats-new/2025/12/compute-optimized-amazon-ec2-c8a-instances/) but not yet in CDK.

Closes #36722

### Description of changes

Add `InstanceClass.COMPUTE8_AMD` and `InstanceClass.C8A` enum values and their mapping to `c8a`.

### Description of how you validated changes

Follows the same pattern as existing instance classes (C7A, C8G, etc.).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)