### PR TITLE
docs: fix duplicate "the the" typos in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-appsync/lib/key.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/key.ts
@@ -27,7 +27,7 @@ export class KeyCondition {
   }
 
   /**
-   * Condition k > arg, true if the key attribute k is greater than the the Query argument
+   * Condition k > arg, true if the key attribute k is greater than the Query argument
    */
   public static gt(keyName: string, arg: string): KeyCondition {
     return new KeyCondition(new BinaryCondition(keyName, '>', arg));

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
@@ -116,7 +116,7 @@ export interface CsvOptions {
    * List of the headers used to specify a common header for all source CSV files being imported.
    *
    * **NOTE**: If this field is specified then the first line of each CSV file is treated as data instead of the header.
-   * If this field is not specified the the first line of each CSV file is treated as the header.
+   * If this field is not specified the first line of each CSV file is treated as the header.
    *
    * @default - the first line of the CSV file is treated as the header
    */

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -2491,7 +2491,7 @@ export class PublicSubnet extends Subnet implements IPublicSubnet {
   /**
    * Creates a new managed NAT gateway attached to this public subnet.
    * Also adds the EIP for the managed NAT.
-   * @returns A ref to the the NAT Gateway ID
+   * @returns A ref to the NAT Gateway ID
    */
   @MethodMetadata()
   public addNatGateway(eipAllocationId?: string) {

--- a/packages/aws-cdk-lib/aws-events-targets/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/lib/log-group.ts
@@ -54,7 +54,7 @@ export abstract class LogGroupTargetInput {
   }
 
   /**
-   * Pass a JSON object to the the log group event target
+   * Pass a JSON object to the log group event target
    *
    * May contain strings returned by `EventField.from()` to substitute in parts of the
    * matched event.


### PR DESCRIPTION
### Issue

N/A (self-discovered typos)

### Reason for this change

Several JSDoc comments contain the duplicate word "the the" which is a typo.

### Description of changes

Fixed repeated word "the the" → "the" in four source files:
- `aws-appsync/lib/key.ts`: `KeyCondition.gt()` description
- `aws-dynamodb/lib/table.ts`: CSV header field description
- `aws-ec2/lib/vpc.ts`: NAT Gateway ID return description
- `aws-events-targets/lib/log-group.ts`: `LogGroupProps.event` description

### Description of how you validated changes

Comment-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
