### PR TITLE
docs: fix spelling errors in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-batch/lib/scheduling-policy.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/scheduling-policy.ts
@@ -205,7 +205,7 @@ export class FairshareSchedulingPolicy extends SchedulingPolicyBase implements I
   public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-batch.FairshareSchedulingPolicy';
 
   /**
-   * Reference an exisiting Scheduling Policy by its ARN
+   * Reference an existing Scheduling Policy by its ARN
    */
   public static fromFairshareSchedulingPolicyArn(scope: Construct, id: string, fairshareSchedulingPolicyArn: string): IFairshareSchedulingPolicy {
     const stack = Stack.of(scope);

--- a/packages/aws-cdk-lib/aws-certificatemanager/lib/dns-validated-certificate.ts
+++ b/packages/aws-cdk-lib/aws-certificatemanager/lib/dns-validated-certificate.ts
@@ -157,7 +157,7 @@ export class DnsValidatedCertificate extends CertificateBase implements ICertifi
         Region: props.region,
         Route53Endpoint: props.route53Endpoint,
         RemovalPolicy: cdk.Lazy.any({ produce: () => this._removalPolicy }),
-        // Custom resources properties are always converted to strings; might as well be explict here.
+        // Custom resources properties are always converted to strings; might as well be explicit here.
         CleanupRecords: props.cleanupRoute53Records ? 'true' : undefined,
         Tags: cdk.Lazy.list({ produce: () => this.tags.renderTags() }),
       },

--- a/packages/aws-cdk-lib/aws-cloudtrail/lib/cloudtrail.ts
+++ b/packages/aws-cdk-lib/aws-cloudtrail/lib/cloudtrail.ts
@@ -120,7 +120,7 @@ export interface TrailProps {
 
   /** The Amazon S3 bucket
    *
-   * @default - if not supplied a bucket will be created with all the correct permisions
+   * @default - if not supplied a bucket will be created with all the correct permissions
    */
   readonly bucket?: s3.IBucket;
 

--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
@@ -118,7 +118,7 @@ export interface BucketDeploymentProps {
   readonly distributionPaths?: string[];
 
   /**
-   * In case of using a cloudfront distribtuion, if this property is set to false then the custom resource
+   * In case of using a cloudfront distribution, if this property is set to false then the custom resource
    * will not wait and verify for Cloudfront invalidation to complete. This may speed up deployment and avoid
    * intermittent Cloudfront issues. However, this is risky and not recommended as cache invalidation
    * can silently fail.


### PR DESCRIPTION
### Issue

N/A (self-discovered spelling errors)

### Reason for this change

Several JSDoc and inline comments contain spelling errors.

### Description of changes

Fixed spelling errors in comments across four modules:
- `aws-batch/lib/scheduling-policy.ts`: "exisiting" → "existing"
- `aws-certificatemanager/lib/dns-validated-certificate.ts`: "explict" → "explicit"
- `aws-cloudtrail/lib/cloudtrail.ts`: "permisions" → "permissions"
- `aws-s3-deployment/lib/bucket-deployment.ts`: "distribtuion" → "distribution"

### Description of how you validated changes

Comment-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
