### PR TITLE
chore: use HTTPS for AWS documentation links in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/api-key.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/api-key.ts
@@ -37,7 +37,7 @@ export interface IApiKey extends IResourceBase, IApiKeyRef {
 export interface ApiKeyOptions extends ResourceOptions {
   /**
    * A name for the API key. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the API key name.
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-name
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-name
    * @default automically generated name
    */
   readonly apiKeyName?: string;
@@ -51,7 +51,7 @@ export interface ApiKeyOptions extends ResourceOptions {
 
   /**
    * A description of the purpose of the API key.
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-description
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-description
    * @default none
    */
   readonly description?: string;
@@ -77,21 +77,21 @@ export interface ApiKeyProps extends ApiKeyOptions {
 
   /**
    * An AWS Marketplace customer identifier to use when integrating with the AWS SaaS Marketplace.
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-customerid
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-customerid
    * @default none
    */
   readonly customerId?: string;
 
   /**
    * Indicates whether the API key can be used by clients.
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-enabled
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-enabled
    * @default true
    */
   readonly enabled?: boolean;
 
   /**
    * Specifies whether the key identifier is distinct from the created API key value.
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-generatedistinctid
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html#cfn-apigateway-apikey-generatedistinctid
    * @default false
    */
   readonly generateDistinctId?: boolean;

--- a/packages/aws-cdk-lib/aws-apigateway/lib/integration.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/integration.ts
@@ -96,7 +96,7 @@ export interface IntegrationOptions {
    *   { "application/json": "{ \"statusCode\": 200 }" }
    * ```
    *
-   * @see http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+   * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
    */
   readonly requestTemplates?: { [contentType: string]: string };
 
@@ -415,7 +415,7 @@ export interface IntegrationResponse {
    *   pre-encode these values based on the destination specified in the
    *   request.
    *
-   * @see http://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+   * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
    */
   readonly responseParameters?: { [destination: string]: string };
 
@@ -424,7 +424,7 @@ export interface IntegrationResponse {
    * Specify templates as key-value pairs, with a content type as the key and
    * a template as the value.
    *
-   * @see http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+   * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
    */
   readonly responseTemplates?: { [contentType: string]: string };
 }

--- a/packages/aws-cdk-lib/aws-codebuild/lib/file-location.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/file-location.ts
@@ -8,7 +8,7 @@ import type { IProject } from './project';
 export interface FileSystemConfig {
   /**
    * File system location wrapper property.
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html
    */
   readonly location: CfnProject.ProjectFileSystemLocationProperty;
 }

--- a/packages/aws-cdk-lib/aws-codebuild/lib/source.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/source.ts
@@ -23,7 +23,7 @@ export interface SourceConfig {
 
   /**
    * `AWS::CodeBuild::Project.SourceVersion`
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-sourceversion
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-sourceversion
    * @default the latest version
    */
   readonly sourceVersion?: string;

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
@@ -324,7 +324,7 @@ export interface TableOptions extends SchemaOptions {
   /**
    * Specify values to pre-warm you DynamoDB Table
    * Warm Throughput feature is not available for Global Table replicas using the `Table` construct. To enable Warm Throughput, use the `TableV2` construct instead.
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-warmthroughput
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-warmthroughput
    * @default - warm throughput is not configured
    */
   readonly warmThroughput?: WarmThroughput;

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
@@ -374,7 +374,7 @@ export interface InstanceProps {
    * Whether "Detailed Monitoring" is enabled for this instance
    * Keep in mind that Detailed Monitoring results in extra charges
    *
-   * @see http://aws.amazon.com/cloudwatch/pricing/
+   * @see https://aws.amazon.com/cloudwatch/pricing/
    * @default - false
    */
   readonly detailedMonitoring?: boolean;
@@ -431,7 +431,7 @@ export interface InstanceProps {
    * Alternatively, if you set InstanceInitiatedShutdownBehavior to terminate, you can terminate the instance
    * by running the shutdown command from the instance.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html#cfn-ec2-instance-disableapitermination
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html#cfn-ec2-instance-disableapitermination
    *
    * @default false
    */

--- a/packages/aws-cdk-lib/aws-ec2/lib/launch-template.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/launch-template.ts
@@ -234,7 +234,7 @@ export interface LaunchTemplateProps {
    *
    * The version description must be maximum 255 characters long.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-versiondescription
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-versiondescription
    *
    * @default - No description
    */

--- a/packages/aws-cdk-lib/aws-efs/lib/efs-file-system.ts
+++ b/packages/aws-cdk-lib/aws-efs/lib/efs-file-system.ts
@@ -17,7 +17,7 @@ import type { FileSystemReference, IFileSystemRef } from '../../interfaces/gener
  * EFS Lifecycle Policy, if a file is not accessed for given days, it will move to EFS Infrequent Access
  * or Archive storage.
  *
- * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-elasticfilesystem-filesystem-lifecyclepolicies
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-elasticfilesystem-filesystem-lifecyclepolicies
  */
 export enum LifecyclePolicy {
 

--- a/packages/aws-cdk-lib/aws-eks/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-eks/lib/cluster.ts
@@ -2672,7 +2672,7 @@ export interface RemoteNodeNetwork {
   /**
    * Specifies the list of remote node CIDRs.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-remotenodenetwork.html#cfn-eks-cluster-remotenodenetwork-cidrs
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-remotenodenetwork.html#cfn-eks-cluster-remotenodenetwork-cidrs
    */
   readonly cidrs: string[];
 }
@@ -2684,7 +2684,7 @@ export interface RemotePodNetwork {
   /**
    * Specifies the list of remote pod CIDRs.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-remotepodnetwork.html#cfn-eks-cluster-remotepodnetwork-cidrs
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-remotepodnetwork.html#cfn-eks-cluster-remotepodnetwork-cidrs
    */
   readonly cidrs: string[];
 }

--- a/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
@@ -160,7 +160,7 @@ export interface EventBusProps {
    *
    * The description can be up to 512 characters long.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
    *
    * @default - no description
    */

--- a/packages/aws-cdk-lib/aws-events/lib/event-pattern.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-pattern.ts
@@ -356,7 +356,7 @@ export interface EventPattern {
    * AWS Service Namespaces. For example, the source value for Amazon
    * CloudFront is aws.cloudfront.
    *
-   * @see http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
+   * @see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
    * @default - No filtering on source
    */
   readonly source?: string[];

--- a/packages/aws-cdk-lib/aws-fsx/lib/lustre-file-system.ts
+++ b/packages/aws-cdk-lib/aws-fsx/lib/lustre-file-system.ts
@@ -151,7 +151,7 @@ export interface LustreConfiguration {
    *
    * > This parameter is not supported for Lustre file systems using the `Persistent_2` deployment type.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-autoimportpolicy
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-autoimportpolicy
    * @default - no import policy
    */
   readonly autoImportPolicy?: LustreAutoImportPolicy;
@@ -160,7 +160,7 @@ export interface LustreConfiguration {
    * Sets the data compression configuration for the file system.
    * For more information, see [Lustre data compression](https://docs.aws.amazon.com/fsx/latest/LustreGuide/data-compression.html) in the *Amazon FSx for Lustre User Guide* .
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-datacompressiontype
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-datacompressiontype
    * @default - no compression
    */
 

--- a/packages/aws-cdk-lib/aws-iam/lib/group.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/group.ts
@@ -65,7 +65,7 @@ export interface GroupProps {
 
   /**
    * The path to the group. For more information about paths, see [IAM
-   * Identifiers](http://docs.aws.amazon.com/IAM/latest/UserGuide/index.html?Using_Identifiers.html)
+   * Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/index.html?Using_Identifiers.html)
    * in the IAM User Guide.
    *
    * @default /

--- a/packages/aws-cdk-lib/aws-iam/lib/policy.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/policy.ts
@@ -104,7 +104,7 @@ export interface PolicyProps {
 /**
  * The AWS::IAM::Policy resource associates an [inline](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#inline)
  * IAM policy with IAM users, roles, or groups. For more information about IAM policies, see
- * [Overview of IAM Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/policies_overview.html)
+ * [Overview of IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/policies_overview.html)
  * in the IAM User Guide guide.
  */
 @propertyInjectable

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/lib/processor.ts
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/lib/processor.ts
@@ -32,7 +32,7 @@ export interface DataProcessorProps {
 /**
  * The key-value pair that identifies the underlying processor resource.
  *
- * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-processorparameter.html
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-processorparameter.html
  */
 export interface DataProcessorIdentifier {
   /**

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/lib/s3-bucket.ts
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/lib/s3-bucket.ts
@@ -34,7 +34,7 @@ export interface S3BucketProps extends CommonDestinationS3Props, CommonDestinati
 
   /**
    * The input format, output format, and schema config for converting data from the JSON format to the Parquet or ORC format before writing to Amazon S3.
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-extendeds3destinationconfiguration.html#cfn-kinesisfirehose-deliverystream-extendeds3destinationconfiguration-dataformatconversionconfiguration
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-extendeds3destinationconfiguration.html#cfn-kinesisfirehose-deliverystream-extendeds3destinationconfiguration-dataformatconversionconfiguration
    *
    * @default - no data format conversion is done
    */

--- a/packages/aws-cdk-lib/aws-ses/lib/receipt-rule-action.ts
+++ b/packages/aws-cdk-lib/aws-ses/lib/receipt-rule-action.ts
@@ -18,13 +18,13 @@ export interface AddHeaderActionConfig {
   /**
    * The name of the header that you want to add to the incoming message
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-addheaderaction.html#cfn-ses-receiptrule-addheaderaction-headername
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-addheaderaction.html#cfn-ses-receiptrule-addheaderaction-headername
    */
   readonly headerName: string;
   /**
    * The content that you want to include in the header.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-addheaderaction.html#cfn-ses-receiptrule-addheaderaction-headervalue
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-addheaderaction.html#cfn-ses-receiptrule-addheaderaction-headervalue
    */
   readonly headerValue: string;
 }
@@ -36,26 +36,26 @@ export interface BounceActionConfig {
   /**
    * Human-readable text to include in the bounce message.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-message
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-message
    */
   readonly message: string;
   /**
    * The email address of the sender of the bounced email.
    * This is the address that the bounce message is sent from.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-sender
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-sender
    */
   readonly sender: string;
   /**
    * The SMTP reply code, as defined by RFC 5321
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-smtpreplycode
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-smtpreplycode
    */
   readonly smtpReplyCode: string;
   /**
    * The SMTP enhanced status code, as defined by RFC 3463
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-statuscode
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-statuscode
    *
    * @default - No status code.
    */
@@ -64,7 +64,7 @@ export interface BounceActionConfig {
    * The Amazon Resource Name (ARN) of the Amazon SNS topic to
    * notify when the bounce action is taken.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-bounceaction.html#cfn-ses-receiptrule-bounceaction-topicarn
    *
    * @default - No notification is sent to SNS.
    */
@@ -78,13 +78,13 @@ export interface LambdaActionConfig {
   /**
    * The Amazon Resource Name (ARN) of the AWS Lambda function.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-functionarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-functionarn
    */
   readonly functionArn: string;
   /**
    * The invocation type of the AWS Lambda function
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-invocationtype
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-invocationtype
    *
    * @default 'Event'
    */
@@ -93,7 +93,7 @@ export interface LambdaActionConfig {
    * The Amazon Resource Name (ARN) of the Amazon SNS topic to
    * notify when the Lambda action is executed.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-lambdaaction.html#cfn-ses-receiptrule-lambdaaction-topicarn
    *
    * @default - No notification is sent to SNS.
    */
@@ -107,14 +107,14 @@ export interface S3ActionConfig {
   /**
    * The name of the Amazon S3 bucket that you want to send incoming mail to.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-bucketname
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-bucketname
    */
   readonly bucketName: string;
   /**
    * The customer master key that Amazon SES should use to encrypt your emails before saving
    * them to the Amazon S3 bucket.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-kmskeyarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-kmskeyarn
    *
    * @default - Emails are not encrypted.
    */
@@ -122,7 +122,7 @@ export interface S3ActionConfig {
   /**
    * The key prefix of the Amazon S3 bucket.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-objectkeyprefix
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-objectkeyprefix
    *
    * @default - No prefix.
    */
@@ -130,7 +130,7 @@ export interface S3ActionConfig {
   /**
    * The ARN of the Amazon SNS topic to notify when the message is saved to the Amazon S3 bucket.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-s3action.html#cfn-ses-receiptrule-s3action-topicarn
    *
    * @default - No notification is sent to SNS.
    */
@@ -144,7 +144,7 @@ export interface SNSActionConfig {
   /**
    * The encoding to use for the email within the Amazon SNS notification.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-snsaction.html#cfn-ses-receiptrule-snsaction-encoding
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-snsaction.html#cfn-ses-receiptrule-snsaction-encoding
    *
    * @default 'UTF-8'
    */
@@ -152,7 +152,7 @@ export interface SNSActionConfig {
   /**
    * The Amazon Resource Name (ARN) of the Amazon SNS topic to notify.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-snsaction.html#cfn-ses-receiptrule-snsaction-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-snsaction.html#cfn-ses-receiptrule-snsaction-topicarn
    *
    * @default - No notification is sent to SNS.
    */
@@ -166,13 +166,13 @@ export interface StopActionConfig {
   /**
    * The scope of the StopAction. The only acceptable value is RuleSet.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-stopaction.html#cfn-ses-receiptrule-stopaction-scope
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-stopaction.html#cfn-ses-receiptrule-stopaction-scope
    */
   readonly scope: string;
   /**
    * The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the stop action is taken.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-stopaction.html#cfn-ses-receiptrule-stopaction-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-stopaction.html#cfn-ses-receiptrule-stopaction-topicarn
    *
    * @default - No notification is sent to SNS.
    */
@@ -186,13 +186,13 @@ export interface WorkmailActionConfig {
   /**
    * The Amazon Resource Name (ARN) of the Amazon WorkMail organization.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-workmailaction.html#cfn-ses-receiptrule-workmailaction-organizationarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-workmailaction.html#cfn-ses-receiptrule-workmailaction-organizationarn
    */
   readonly organizationArn: string;
   /**
    * The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the WorkMail action is called.
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-workmailaction.html#cfn-ses-receiptrule-workmailaction-topicarn
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-receiptrule-workmailaction.html#cfn-ses-receiptrule-workmailaction-topicarn
    *
    * @default - No notification is sent to SNS.
    */

--- a/packages/aws-cdk-lib/core/lib/cfn-fn.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-fn.ts
@@ -10,7 +10,7 @@ import { Token } from './token';
 
 /**
  * CloudFormation intrinsic functions.
- * http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
  */
 export class Fn {
   /**

--- a/packages/aws-cdk-lib/core/lib/cfn-tag.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-tag.ts
@@ -1,14 +1,14 @@
 /**
- * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
+ * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
  */
 export interface CfnTag {
   /**
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-key
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-key
    */
   readonly key: string;
 
   /**
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-value
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-value
    */
   readonly value: string;
 }


### PR DESCRIPTION
### Issue

N/A (self-discovered)

### Reason for this change

Many `@see` and `@link` references in source comments use `http://` URLs for AWS documentation. These should use `https://` for security best practices.

### Description of changes

Updated 48 HTTP links to HTTPS across 19 source files in `aws-cdk-lib`, covering modules including:
`aws-apigateway`, `aws-codebuild`, `aws-dynamodb`, `aws-ec2`, `aws-efs`, `aws-eks`, `aws-events`, `aws-fsx`, `aws-iam`, `aws-kinesisfirehose`, `aws-ses`, and `core`.

All changes are in `@see`, `@link`, or inline comment references pointing to `docs.aws.amazon.com` or `aws.amazon.com`.

### Description of how you validated changes

Comment-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
