### PR TITLE
chore: fix typo and use HTTPS for doc links in alpha packages

### DIFF
--- a/packages/@aws-cdk/app-staging-synthesizer-alpha/lib/staging-stack.ts
+++ b/packages/@aws-cdk/app-staging-synthesizer-alpha/lib/staging-stack.ts
@@ -82,7 +82,7 @@ export interface IStagingResourcesFactory {
   /**
    * Return an object that will manage staging resources for the given stack
    *
-   * This is called whenever the the `AppStagingSynthesizer` binds to a specific
+   * This is called whenever the `AppStagingSynthesizer` binds to a specific
    * stack, and allows selecting where the staging resources go.
    *
    * This method can choose to either create a new construct (perhaps a stack)

--- a/packages/@aws-cdk/aws-ec2-alpha/lib/ipam.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/ipam.ts
@@ -60,7 +60,7 @@ export interface IpamProps {
    * The operating Regions for an IPAM.
    * Operating Regions are AWS Regions where the IPAM is allowed to manage IP address CIDRs
    * For more information about operating Regions, see [Create an IPAM](https://docs.aws.amazon.com//vpc/latest/ipam/create-ipam.html) in the *Amazon VPC IPAM User Guide* .
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipam.html#cfn-ec2-ipam-operatingregions
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipam.html#cfn-ec2-ipam-operatingregions
    *
    * @default - Stack.region if defined in the stack
    */
@@ -113,7 +113,7 @@ export interface PoolOptions {
    *  Only resources in the same Region as the locale of the pool can get IP address allocations from the pool.
    * You can only allocate a CIDR for a VPC, for example, from an IPAM pool that shares a locale with the VPC’s Region.
    * Note that once you choose a Locale for a pool, you cannot modify it. If you choose an AWS Region for locale that has not been configured as an operating Region for the IPAM, you'll get an error.
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipampool.html#cfn-ec2-ipampool-locale
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipampool.html#cfn-ec2-ipampool-locale
    *
    * @default - Current operating region of IPAM
    */
@@ -133,7 +133,7 @@ export interface PoolOptions {
    *
    * "ec2", for example, allows users to use space for Elastic IP addresses and VPCs.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipampool.html#cfn-ec2-ipampool-awsservice
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ipampool.html#cfn-ec2-ipampool-awsservice
    *
    * @default - required in case of an IPv6, throws an error if not provided.
    */

--- a/packages/@aws-cdk/aws-ec2-alpha/lib/vpc-v2-base.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/vpc-v2-base.ts
@@ -114,7 +114,7 @@ export interface InternetGatewayOptions{
 export interface VPNGatewayV2Options {
   /**
    * The type of VPN connection the virtual private gateway supports.
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpngateway.html#cfn-ec2-vpngateway-type
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpngateway.html#cfn-ec2-vpngateway-type
    */
   readonly type: VpnConnectionType;
 

--- a/packages/@aws-cdk/aws-gamelift-alpha/lib/fleet-base.ts
+++ b/packages/@aws-cdk/aws-gamelift-alpha/lib/fleet-base.ts
@@ -308,7 +308,7 @@ export interface FleetProps {
    * The GameLift-supported Amazon EC2 instance type to use for all fleet instances.
    * Instance type determines the computing resources that will be used to host your game servers, including CPU, memory, storage, and networking capacity.
    *
-   * @see http://aws.amazon.com/ec2/instance-types/ for detailed descriptions of Amazon EC2 instance types.
+   * @see https://aws.amazon.com/ec2/instance-types/ for detailed descriptions of Amazon EC2 instance types.
    */
   readonly instanceType: ec2.InstanceType;
 

--- a/packages/@aws-cdk/aws-pipes-alpha/lib/enrichment.ts
+++ b/packages/@aws-cdk/aws-pipes-alpha/lib/enrichment.ts
@@ -5,7 +5,7 @@ import type { IPipe } from '.';
 /**
  * The parameters required to set up enrichment on your pipe.
  *
- * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipeenrichmentparameters.html
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipeenrichmentparameters.html
  */
 export interface EnrichmentParametersConfig {
 

--- a/packages/@aws-cdk/aws-pipes-alpha/lib/logs.ts
+++ b/packages/@aws-cdk/aws-pipes-alpha/lib/logs.ts
@@ -104,7 +104,7 @@ export interface LogDestinationParameters {
   /**
    * The logging configuration settings for the pipe.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-cloudwatchlogslogdestination
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-cloudwatchlogslogdestination
    *
    * @default - none
    */
@@ -113,7 +113,7 @@ export interface LogDestinationParameters {
   /**
    * The Amazon Data Firehose logging configuration settings for the pipe.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-firehoselogdestination
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-firehoselogdestination
    *
    * @default - none
    */
@@ -122,7 +122,7 @@ export interface LogDestinationParameters {
   /**
    * The Amazon S3 logging configuration settings for the pipe.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-s3logdestination
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-s3logdestination
    *
    * @default - none
    */

--- a/packages/@aws-cdk/aws-pipes-alpha/lib/pipe.ts
+++ b/packages/@aws-cdk/aws-pipes-alpha/lib/pipe.ts
@@ -97,7 +97,7 @@ export interface PipeProps {
   /**
    * Name of the pipe in the AWS console
    *
-   * @link http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-name
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-name
    *
    * @default - automatically generated name
    */
@@ -138,7 +138,7 @@ export interface PipeProps {
    *
    * For more information, see [Including execution data in logs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-logs.html#eb-pipes-logs-execution-data) and the [message schema](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-logs-schema.html) in the *Amazon EventBridge User Guide* .
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-includeexecutiondata
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipelogconfiguration.html#cfn-pipes-pipe-pipelogconfiguration-includeexecutiondata
    * @default - none
    */
   readonly logIncludeExecutionData?: IncludeExecutionData[];
@@ -146,7 +146,7 @@ export interface PipeProps {
   /**
    * A description of the pipe displayed in the AWS console
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-description
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-description
    *
    * @default - no description
    */
@@ -164,7 +164,7 @@ export interface PipeProps {
   /**
    * The list of key-value pairs to associate with the pipe.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-tags
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pipe.html#cfn-pipes-pipe-tags
    *
    * @default - no tags
    */

--- a/packages/@aws-cdk/aws-pipes-sources-alpha/lib/sqs.ts
+++ b/packages/@aws-cdk/aws-pipes-sources-alpha/lib/sqs.ts
@@ -10,7 +10,7 @@ export interface SqsSourceParameters {
   /**
    * The maximum number of records to include in each batch.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipesourcesqsqueueparameters.html#cfn-pipes-pipe-pipesourcesqsqueueparameters-batchsize
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipesourcesqsqueueparameters.html#cfn-pipes-pipe-pipesourcesqsqueueparameters-batchsize
    * @default 10
    */
   readonly batchSize?: number;
@@ -18,7 +18,7 @@ export interface SqsSourceParameters {
   /**
    * The maximum length of a time to wait for events.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipesourcesqsqueueparameters.html#cfn-pipes-pipe-pipesourcesqsqueueparameters-maximumbatchingwindowinseconds
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipesourcesqsqueueparameters.html#cfn-pipes-pipe-pipesourcesqsqueueparameters-maximumbatchingwindowinseconds
    * @default 1
    */
   readonly maximumBatchingWindow?: Duration;

--- a/packages/@aws-cdk/aws-pipes-targets-alpha/lib/sqs.ts
+++ b/packages/@aws-cdk/aws-pipes-targets-alpha/lib/sqs.ts
@@ -19,7 +19,7 @@ export interface SqsTargetParameters {
    *
    * The token used for deduplication of sent messages.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagededuplicationid
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagededuplicationid
    * @default - none
    */
   readonly messageDeduplicationId?: string;
@@ -27,7 +27,7 @@ export interface SqsTargetParameters {
   /**
    * The FIFO message group ID to use as the target.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagegroupid
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagegroupid
    * @default - none
    */
   readonly messageGroupId?: string;

--- a/packages/@aws-cdk/aws-pipes-targets-alpha/lib/stepfunctions.ts
+++ b/packages/@aws-cdk/aws-pipes-targets-alpha/lib/stepfunctions.ts
@@ -18,7 +18,7 @@ export interface SfnStateMachineParameters {
   /**
    * Specify whether to invoke the State Machine synchronously (`REQUEST_RESPONSE`) or asynchronously (`FIRE_AND_FORGET`).
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagededuplicationid
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pipes-pipe-pipetargetsqsqueueparameters.html#cfn-pipes-pipe-pipetargetsqsqueueparameters-messagededuplicationid
    * @default StateMachineInvocationType.FIRE_AND_FORGET
    */
   readonly invocationType?: StateMachineInvocationType;

--- a/packages/@aws-cdk/aws-s3tables-alpha/lib/table.ts
+++ b/packages/@aws-cdk/aws-s3tables-alpha/lib/table.ts
@@ -508,13 +508,13 @@ export interface TablePropertyEntry {
 
 /**
  * Contains details about the metadata for an Iceberg table.
- * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3tables-table-icebergmetadata.html
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3tables-table-icebergmetadata.html
  */
 export interface IcebergMetadataProperty {
   /**
    * Contains details about the schema for an Iceberg table.
    *
-   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3tables-table-icebergmetadata.html#cfn-s3tables-table-icebergmetadata-icebergschema
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3tables-table-icebergmetadata.html#cfn-s3tables-table-icebergmetadata-icebergschema
    */
   readonly icebergSchema: IcebergSchemaProperty;
 


### PR DESCRIPTION
### Issue

N/A (self-discovered)

### Reason for this change

- A duplicate word typo ("the the") exists in `app-staging-synthesizer-alpha`
- Several `@see`/`@link` references in alpha packages use `http://` URLs for AWS documentation

### Description of changes

- `app-staging-synthesizer-alpha/lib/staging-stack.ts`: fix "the the" → "the"
- Updated 20 HTTP links to HTTPS across 10 alpha package source files

### Description of how you validated changes

Comment-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
