### PR TITLE
chore: remove obsolete tslint disable comments

### DIFF
--- a/packages/@aws-cdk/aws-ec2-alpha/lib/util.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/util.ts
@@ -439,7 +439,6 @@ export class CidrBlockIpv6 {
     const blocks = this.parseBigIntParts(ipv6Address);
     let ipv6Number = BigInt(0);
     for (const block of blocks) {
-      /* tslint:disable:no-bitwise */
       ipv6Number = (ipv6Number << BigInt(16)) + block;
     }
     return ipv6Number;

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -2770,7 +2770,6 @@ class ImportedSubnet extends Resource implements ISubnet, IPublicSubnet, IPrivat
 
   public get ipv4CidrBlock(): string {
     if (!this._ipv4CidrBlock) {
-      // tslint:disable-next-line: max-line-length
       throw new ValidationError('CannotReferenceImportedSubnetS', 'You cannot reference an imported Subnet\'s IPv4 CIDR if it was not supplied. Add the ipv4CidrBlock when importing using Subnet.fromSubnetAttributes()', this);
     }
     return this._ipv4CidrBlock;

--- a/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/cluster.ts
@@ -799,7 +799,6 @@ export class Cluster extends Resource implements ICluster {
     // set the cluster name environment variable
     autoScalingGroup.addUserData(`[Environment]::SetEnvironmentVariable("ECS_CLUSTER", "${this.clusterName}", "Machine")`);
     autoScalingGroup.addUserData('[Environment]::SetEnvironmentVariable("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE", "true", "Machine")');
-    // tslint:disable-next-line: max-line-length
     autoScalingGroup.addUserData('[Environment]::SetEnvironmentVariable("ECS_AVAILABLE_LOGGING_DRIVERS", \'["json-file","awslogs"]\', "Machine")');
 
     // enable instance draining


### PR DESCRIPTION
### Issue

N/A (self-discovered)

### Reason for this change

The project migrated from tslint to eslint. These leftover `tslint:disable` comments no longer serve any purpose.

### Description of changes

Removed 3 obsolete tslint disable comments:
- `aws-ec2/lib/vpc.ts`: `tslint:disable-next-line: max-line-length`
- `aws-ecs/lib/cluster.ts`: `tslint:disable-next-line: max-line-length`
- `aws-ec2-alpha/lib/util.ts`: `tslint:disable:no-bitwise`

### Description of how you validated changes

Comment-only removal. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
