### PR TITLE
docs: use HTTPS for AWS links in README files

### DIFF
--- a/packages/aws-cdk-lib/aws-cognito-identitypool/README.md
+++ b/packages/aws-cdk-lib/aws-cognito-identitypool/README.md
@@ -187,7 +187,7 @@ Pools, OpenIdConnect, or SAML. Only one provider per external service can be att
 
 [OpenID Connect](https://docs.aws.amazon.com/cognito/latest/developerguide/open-id.html) is an open standard for  
 authentication that is supported by a number of login providers. Amazon Cognito supports linking of identities with  
-OpenID Connect providers that are configured through [AWS Identity and Access Management](http://aws.amazon.com/iam/). 
+OpenID Connect providers that are configured through [AWS Identity and Access Management](https://aws.amazon.com/iam/). 
 
 An identity provider that supports [Security Assertion Markup Language 2.0 (SAML 2.0)](https://docs.aws.amazon.com/cognito/latest/developerguide/saml-identity-provider.html) can be used to provide a simple  
 onboarding flow for users. The SAML-supporting identity provider specifies the IAM roles that can be assumed by users  

--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -2638,7 +2638,7 @@ Please note this feature does not support Launch Configurations.
 
 ## Detailed Monitoring
 
-The following demonstrates how to enable [Detailed Monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) for an EC2 instance. Keep in mind that Detailed Monitoring results in [additional charges](http://aws.amazon.com/cloudwatch/pricing/).
+The following demonstrates how to enable [Detailed Monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) for an EC2 instance. Keep in mind that Detailed Monitoring results in [additional charges](https://aws.amazon.com/cloudwatch/pricing/).
 
 ```ts
 declare const vpc: ec2.Vpc;

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -1759,7 +1759,7 @@ Step Functions supports [AWS MediaConvert](https://docs.aws.amazon.com/step-func
 ### CreateJob
 
 The [CreateJob](https://docs.aws.amazon.com/mediaconvert/latest/apireference/jobs.html#jobspost) API creates a new transcoding job.
-For information about jobs and job settings, see the User Guide at http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html
+For information about jobs and job settings, see the User Guide at https://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html
 
 You can call the `CreateJob` API from a `Task` state. Optionally you can specify the `integrationPattern`.
 


### PR DESCRIPTION
### Issue

N/A (self-discovered)

### Reason for this change

Several README files contain `http://` links to AWS documentation and services that should use `https://`.

### Description of changes

Updated HTTP links to HTTPS in three README files:
- `aws-cognito-identitypool/README.md`: AWS IAM link
- `aws-ec2/README.md`: CloudWatch pricing link
- `aws-stepfunctions-tasks/README.md`: MediaConvert user guide link

### Description of how you validated changes

Documentation-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
