### PR TITLE
docs: fix "can not" to "cannot" and use HTTPS for external links

### DIFF
--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool-client.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool-client.ts
@@ -301,7 +301,7 @@ export interface UserPoolClientOptions {
 
   /**
    * Validity of the ID token.
-   * Values between 5 minutes and 1 day are valid. The duration can not be longer than the refresh token validity.
+   * Values between 5 minutes and 1 day are valid. The duration cannot be longer than the refresh token validity.
    * @see https://docs.aws.amazon.com/en_us/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-id-token
    * @default Duration.minutes(60)
    */
@@ -317,7 +317,7 @@ export interface UserPoolClientOptions {
 
   /**
    * Validity of the access token.
-   * Values between 5 minutes and 1 day are valid. The duration can not be longer than the refresh token validity.
+   * Values between 5 minutes and 1 day are valid. The duration cannot be longer than the refresh token validity.
    * @see https://docs.aws.amazon.com/en_us/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-access-token
    * @default Duration.minutes(60)
    */

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
@@ -478,7 +478,7 @@ export interface PasswordPolicy {
   /**
    * The number of previous passwords that you want Amazon Cognito to restrict each user from reusing.
    *
-   * `passwordHistorySize` can not be set when `featurePlan` is `FeaturePlan.LITE`.
+   * `passwordHistorySize` cannot be set when `featurePlan` is `FeaturePlan.LITE`.
    *
    * @default undefined - Cognito default setting is no restriction
    */

--- a/packages/aws-cdk-lib/aws-fsx/README.md
+++ b/packages/aws-cdk-lib/aws-fsx/README.md
@@ -17,7 +17,7 @@ The open-source Lustre file system is designed for applications that require fas
 to keep up with your compute. Lustre was built to solve the problem of quickly and cheaply processing the world's
 ever-growing datasets. It's a widely used file system designed for the fastest computers in the world. It provides
 submillisecond latencies, up to hundreds of GBps of throughput, and up to millions of IOPS. For more information on
-Lustre, see the [Lustre website](http://lustre.org/).
+Lustre, see the [Lustre website](https://www.lustre.org/).
 
 As a fully managed service, Amazon FSx makes it easier for you to use Lustre for workloads where storage speed matters.
 Amazon FSx for Lustre eliminates the traditional complexity of setting up and managing Lustre file systems, enabling

--- a/packages/aws-cdk-lib/aws-iam/README.md
+++ b/packages/aws-cdk-lib/aws-iam/README.md
@@ -698,7 +698,7 @@ user identities. For more information about this scenario, see [About Web
 Identity Federation] and the relevant documentation in the [Amazon Cognito
 Identity Pools Developer Guide].
 
-[OpenID Connect]: http://openid.net/connect
+[OpenID Connect]: https://openid.net/connect
 [About Web Identity Federation]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 [Amazon Cognito Identity Pools Developer Guide]: https://docs.aws.amazon.com/cognito/latest/developerguide/open-id.html
 

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -2593,7 +2593,7 @@ export class Bucket extends BucketBase {
       throw new ValidationError('EncryptionkeySpecified', `encryptionKey is specified, so 'encryption' must be set to KMS or DSSE (value: ${encryptionType})`, this);
     }
 
-    // if bucketKeyEnabled is set, encryption can not be BucketEncryption.UNENCRYPTED
+    // if bucketKeyEnabled is set, encryption cannot be BucketEncryption.UNENCRYPTED
     if (props.bucketKeyEnabled && encryptionType === BucketEncryption.UNENCRYPTED) {
       throw new ValidationError('BucketKeyEnabledSpecifiedEncryption', `bucketKeyEnabled is specified, so 'encryption' must be set to KMS, DSSE or S3 (value: ${encryptionType})`, this);
     }
@@ -3215,7 +3215,7 @@ export class Bucket extends BucketBase {
  */
 export enum BucketEncryption {
   /**
-   * Previous option. Buckets can not be unencrypted now.
+   * Previous option. Buckets cannot be unencrypted now.
    * @see https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
    * @deprecated S3 applies server-side encryption with SSE-S3 for every bucket
    * that default encryption is not configured.


### PR DESCRIPTION
### Issue

N/A (self-discovered)

### Reason for this change

- "can not" should be "cannot" (single word) per standard English usage in technical documentation
- External links should use HTTPS

### Description of changes

- `aws-cognito/lib/user-pool-client.ts`: "can not" → "cannot" in JSDoc (2 occurrences)
- `aws-cognito/lib/user-pool.ts`: "can not" → "cannot" in JSDoc
- `aws-s3/lib/bucket.ts`: "can not" → "cannot" in comments (2 occurrences)
- `aws-iam/README.md`: use HTTPS for OpenID Connect link
- `aws-fsx/README.md`: use HTTPS for Lustre website link

### Description of how you validated changes

Comment and documentation-only changes. No functional impact.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
