### PR TITLE
docs: fix incorrect indefinite article "a" to "an" before vowel-sound acronyms

### DIFF
--- a/packages/@aws-cdk/aws-amplify-alpha/lib/branch.ts
+++ b/packages/@aws-cdk/aws-amplify-alpha/lib/branch.ts
@@ -112,7 +112,7 @@ export interface BranchOptions {
    * Asset for deployment.
    *
    * The Amplify app must not have a sourceCodeProvider configured as this resource uses Amplify's
-   * startDeployment API to initiate and deploy a S3 asset onto the App.
+   * startDeployment API to initiate and deploy an S3 asset onto the App.
    *
    * @default - no asset
    */

--- a/packages/@aws-cdk/aws-glue-alpha/lib/s3-table.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/s3-table.ts
@@ -82,7 +82,7 @@ export interface S3TableProps extends TableBaseProps {
 }
 
 /**
- * A Glue table that targets a S3 dataset.
+ * A Glue table that targets an S3 dataset.
  * @resource AWS::Glue::Table
  */
 @propertyInjectable

--- a/packages/@aws-cdk/aws-iotevents-alpha/lib/action.ts
+++ b/packages/@aws-cdk/aws-iotevents-alpha/lib/action.ts
@@ -24,7 +24,7 @@ export interface IAction {
 }
 
 /**
- * Properties for a AWS IoT Events action
+ * Properties for an AWS IoT Events action
  */
 export interface ActionConfig {
   /**

--- a/packages/aws-cdk-lib/aws-apigatewayv2/lib/common/api.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/lib/common/api.ts
@@ -3,7 +3,7 @@ import type { IResource } from '../../../core';
 import type { IApiRef } from '../apigatewayv2.generated';
 
 /**
- * Represents a API Gateway HTTP/WebSocket API
+ * Represents an API Gateway HTTP/WebSocket API
  */
 export interface IApi extends IResource, IApiRef {
   /**

--- a/packages/aws-cdk-lib/aws-chatbot/lib/slack-channel-configuration.ts
+++ b/packages/aws-cdk-lib/aws-chatbot/lib/slack-channel-configuration.ts
@@ -341,7 +341,7 @@ export class SlackChannelConfiguration extends SlackChannelConfigurationBase {
   }
 
   /**
-   * Adds a SNS topic that deliver notifications to AWS Chatbot.
+   * Adds an SNS topic that deliver notifications to AWS Chatbot.
    */
   @MethodMetadata()
   public addNotificationTopic(notificationTopic: sns.ITopic): void {

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-bucket-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-bucket-origin.ts
@@ -32,7 +32,7 @@ const KEY_ACTIONS: Record<string, string[]> = {
 export interface S3BucketOriginBaseProps extends cloudfront.OriginProps { }
 
 /**
- * Properties for configuring a S3 origin with OAC
+ * Properties for configuring an S3 origin with OAC
  */
 export interface S3BucketOriginWithOACProps extends S3BucketOriginBaseProps {
   /**
@@ -52,7 +52,7 @@ export interface S3BucketOriginWithOACProps extends S3BucketOriginBaseProps {
 }
 
 /**
- * Properties for configuring a S3 origin with OAI
+ * Properties for configuring an S3 origin with OAI
  */
 export interface S3BucketOriginWithOAIProps extends S3BucketOriginBaseProps {
   /**
@@ -68,14 +68,14 @@ export interface S3BucketOriginWithOAIProps extends S3BucketOriginBaseProps {
  */
 export abstract class S3BucketOrigin extends cloudfront.OriginBase {
   /**
-   * Create a S3 Origin with Origin Access Control (OAC) configured
+   * Create an S3 Origin with Origin Access Control (OAC) configured
    */
   public static withOriginAccessControl(bucket: IBucket, props?: S3BucketOriginWithOACProps): cloudfront.IOrigin {
     return new S3BucketOriginWithOAC(bucket, props);
   }
 
   /**
-   * Create a S3 Origin with Origin Access Identity (OAI) configured
+   * Create an S3 Origin with Origin Access Identity (OAI) configured
    * OAI is a legacy feature and we **strongly** recommend you to use OAC via `withOriginAccessControl()`
    * unless it is not supported in your required region (e.g. China regions).
    */
@@ -84,7 +84,7 @@ export abstract class S3BucketOrigin extends cloudfront.OriginBase {
   }
 
   /**
-   * Create a S3 Origin with default S3 bucket settings (no origin access control)
+   * Create an S3 Origin with default S3 bucket settings (no origin access control)
    */
   public static withBucketDefaults(bucket: IBucket, props?: cloudfront.OriginProps): cloudfront.IOrigin {
     return new class extends S3BucketOrigin {

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-origin.ts
@@ -44,7 +44,7 @@ export class S3Origin implements cloudfront.IOrigin {
 }
 
 /**
- * An Origin specific to a S3 bucket (not configured for website hosting).
+ * An Origin specific to an S3 bucket (not configured for website hosting).
  *
  * Contains additional logic around bucket permissions and origin access identities.
  */

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-static-website-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-static-website-origin.ts
@@ -4,12 +4,12 @@ import * as cloudfront from '../../aws-cloudfront';
 import type { IBucket } from '../../aws-s3';
 
 /**
- * Properties for configuring a origin using a S3 bucket configured as a website endpoint
+ * Properties for configuring a origin using an S3 bucket configured as a website endpoint
  */
 export interface S3StaticWebsiteOriginProps extends HttpOriginProps { }
 
 /**
- * An Origin for a S3 bucket configured as a website endpoint
+ * An Origin for an S3 bucket configured as a website endpoint
  */
 export class S3StaticWebsiteOrigin extends HttpOrigin {
   constructor(bucket: IBucket, props?: S3StaticWebsiteOriginProps) {

--- a/packages/aws-cdk-lib/aws-cloudfront/lib/origin-access-control.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/origin-access-control.ts
@@ -70,7 +70,7 @@ export enum AccessLevel {
 }
 
 /**
- * Properties for creating a S3 Origin Access Control resource.
+ * Properties for creating an S3 Origin Access Control resource.
  */
 export interface S3OriginAccessControlProps extends OriginAccessControlBaseProps { }
 

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
@@ -1006,7 +1006,7 @@ export interface CustomWidgetProps {
 }
 
 /**
- * A CustomWidget shows the result of a AWS lambda function
+ * A CustomWidget shows the result of an AWS lambda function
  */
 export class CustomWidget extends ConcreteWidget {
   private readonly props: CustomWidgetProps;

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool-email.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool-email.ts
@@ -48,7 +48,7 @@ export interface UserPoolSESOptions {
   /**
    * Required if the UserPool region is different than the SES region.
    *
-   * If sending emails with a Amazon SES verified email address,
+   * If sending emails with an Amazon SES verified email address,
    * and the region that SES is configured is different than the
    * region in which the UserPool is deployed, you must specify that
    * region here.

--- a/packages/aws-cdk-lib/aws-config/lib/managed-rules.ts
+++ b/packages/aws-cdk-lib/aws-config/lib/managed-rules.ts
@@ -123,7 +123,7 @@ export interface CloudFormationStackNotificationCheckProps extends RuleProps {
 
 /**
  * Checks whether your CloudFormation stacks are sending event notifications to
- * a SNS topic. Optionally checks whether specified SNS topics are used.
+ * an SNS topic. Optionally checks whether specified SNS topics are used.
  *
  * @see https://docs.aws.amazon.com/config/latest/developerguide/cloudformation-stack-notification-check.html
  *

--- a/packages/aws-cdk-lib/aws-config/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-config/lib/rule.ts
@@ -942,7 +942,7 @@ export class ManagedRuleIdentifiers {
   public static readonly CLOUDWATCH_ALARM_SETTINGS_CHECK = 'CLOUDWATCH_ALARM_SETTINGS_CHECK';
   /**
    * Checks whether a log group in Amazon CloudWatch Logs is encrypted with
-   * a AWS Key Management Service (KMS) managed Customer Master Keys (CMK).
+   * an AWS Key Management Service (KMS) managed Customer Master Keys (CMK).
    * @see https://docs.aws.amazon.com/config/latest/developerguide/cloudwatch-log-group-encrypted.html
    */
   public static readonly CLOUDWATCH_LOG_GROUP_ENCRYPTED = 'CLOUDWATCH_LOG_GROUP_ENCRYPTED';
@@ -973,7 +973,7 @@ export class ManagedRuleIdentifiers {
    */
   public static readonly CODEBUILD_PROJECT_LOGGING_ENABLED = 'CODEBUILD_PROJECT_LOGGING_ENABLED';
   /**
-   * Checks if a AWS CodeBuild project configured with Amazon S3 Logs has encryption enabled for its logs.
+   * Checks if an AWS CodeBuild project configured with Amazon S3 Logs has encryption enabled for its logs.
    * @see https://docs.aws.amazon.com/config/latest/developerguide/codebuild-project-s3-logs-encrypted.html
    */
   public static readonly CODEBUILD_PROJECT_S3_LOGS_ENCRYPTED = 'CODEBUILD_PROJECT_S3_LOGS_ENCRYPTED';

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc-flow-logs.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc-flow-logs.ts
@@ -165,7 +165,7 @@ export enum FlowLogFileFormat {
 }
 
 /**
- * Options for writing logs to a S3 destination
+ * Options for writing logs to an S3 destination
  */
 export interface S3DestinationOptions {
   /**

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/_imported-task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/_imported-task-definition.ts
@@ -127,7 +127,7 @@ export class ImportedTaskDefinition extends Resource implements IEc2TaskDefiniti
   }
 
   /**
-   * Return true if the task definition can be run on a ECS Anywhere cluster
+   * Return true if the task definition can be run on an ECS Anywhere cluster
    */
   public get isExternalCompatible(): boolean {
     return isExternalCompatible(this.compatibility);

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
@@ -51,7 +51,7 @@ export interface ITaskDefinition extends IResource, ITaskDefinitionRef {
   readonly isFargateCompatible: boolean;
 
   /**
-   * Return true if the task definition can be run on a ECS Anywhere cluster
+   * Return true if the task definition can be run on an ECS Anywhere cluster
    */
   readonly isExternalCompatible: boolean;
 
@@ -332,7 +332,7 @@ abstract class TaskDefinitionBase extends Resource implements ITaskDefinition {
   }
 
   /**
-   * Return true if the task definition can be run on a ECS anywhere cluster
+   * Return true if the task definition can be run on an ECS anywhere cluster
    */
   public get isExternalCompatible(): boolean {
     return isExternalCompatible(this.compatibility);
@@ -1421,7 +1421,7 @@ export function isFargateCompatible(compatibility: Compatibility): boolean {
 }
 
 /**
- * Return true if the given task definition can be run on a ECS Anywhere cluster
+ * Return true if the given task definition can be run on an ECS Anywhere cluster
  */
 export function isExternalCompatible(compatibility: Compatibility): boolean {
   return [Compatibility.EXTERNAL].includes(compatibility);

--- a/packages/aws-cdk-lib/aws-ecs/lib/credential-spec.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/credential-spec.ts
@@ -8,7 +8,7 @@ import { lit } from '../../core/lib/private/literal-string';
  */
 export class CredentialSpec {
   /**
-   * Helper method to generate the ARN for a S3 object. Used to avoid duplication of logic in derived classes.
+   * Helper method to generate the ARN for an S3 object. Used to avoid duplication of logic in derived classes.
    */
   protected static arnForS3Object(bucket: IBucket, key: string) {
     if (!key) {
@@ -60,7 +60,7 @@ export class CredentialSpec {
  */
 export class DomainJoinedCredentialSpec extends CredentialSpec {
   /**
-   * Loads the CredSpec from a S3 bucket object.
+   * Loads the CredSpec from an S3 bucket object.
    *
    * @param bucket The S3 bucket
    * @param key The object key
@@ -90,7 +90,7 @@ export class DomainJoinedCredentialSpec extends CredentialSpec {
  */
 export class DomainlessCredentialSpec extends CredentialSpec {
   /**
-   * Loads the CredSpec from a S3 bucket object.
+   * Loads the CredSpec from an S3 bucket object.
    *
    * @param bucket The S3 bucket
    * @param key The object key
@@ -116,7 +116,7 @@ export class DomainlessCredentialSpec extends CredentialSpec {
 }
 
 /**
- * Configuration for a credential specification (CredSpec) used for a ECS container.
+ * Configuration for a credential specification (CredSpec) used for an ECS container.
  */
 export interface CredentialSpecConfig {
   /**

--- a/packages/aws-cdk-lib/aws-events/lib/target.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/target.ts
@@ -73,7 +73,7 @@ export interface RuleTargetConfig {
   readonly ecsParameters?: CfnRule.EcsParametersProperty;
 
   /**
-   * Contains the HTTP parameters to use when the target is a API Gateway REST endpoint
+   * Contains the HTTP parameters to use when the target is an API Gateway REST endpoint
    * or EventBridge API destination.
    * @default - None
    */

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/lib/common.ts
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/lib/common.ts
@@ -75,7 +75,7 @@ interface DestinationLoggingProps {
 }
 
 /**
- * Common properties for defining a backup, intermediary, or final S3 destination for a Amazon Data Firehose delivery stream.
+ * Common properties for defining a backup, intermediary, or final S3 destination for an Amazon Data Firehose delivery stream.
  */
 export interface CommonDestinationS3Props {
   /**

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/lib/delivery-stream.ts
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/lib/delivery-stream.ts
@@ -275,7 +275,7 @@ export interface DeliveryStreamAttributes {
 }
 
 /**
- * Create a Amazon Data Firehose delivery stream
+ * Create an Amazon Data Firehose delivery stream
  *
  * @resource AWS::KinesisFirehose::DeliveryStream
  */

--- a/packages/aws-cdk-lib/aws-lambda-destinations/lib/s3.ts
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/lib/s3.ts
@@ -3,7 +3,7 @@ import type * as lambda from '../../aws-lambda';
 import type * as s3 from '../../aws-s3';
 
 /**
- * Use a S3 bucket as a Lambda destination
+ * Use an S3 bucket as a Lambda destination
  */
 export class S3Destination implements lambda.IDestination {
   constructor(private readonly bucket: s3.IBucket) {

--- a/packages/aws-cdk-lib/aws-lambda-destinations/lib/sns.ts
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/lib/sns.ts
@@ -3,7 +3,7 @@ import type * as lambda from '../../aws-lambda';
 import type * as sns from '../../aws-sns';
 
 /**
- * Use a SNS topic as a Lambda destination
+ * Use an SNS topic as a Lambda destination
  */
 export class SnsDestination implements lambda.IDestination {
   constructor(private readonly topic: sns.ITopic) {

--- a/packages/aws-cdk-lib/aws-lambda-destinations/lib/sqs.ts
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/lib/sqs.ts
@@ -3,7 +3,7 @@ import type * as lambda from '../../aws-lambda';
 import type * as sqs from '../../aws-sqs';
 
 /**
- * Use a SQS queue as a Lambda destination
+ * Use an SQS queue as a Lambda destination
  */
 export class SqsDestination implements lambda.IDestination {
   constructor(private readonly queue: sqs.IQueue) {

--- a/packages/aws-cdk-lib/aws-route53-targets/lib/bucket-website-target.ts
+++ b/packages/aws-cdk-lib/aws-route53-targets/lib/bucket-website-target.ts
@@ -7,7 +7,7 @@ import { lit } from '../../core/lib/private/literal-string';
 import { RegionInfo } from '../../region-info';
 
 /**
- * Use a S3 as an alias record target
+ * Use an S3 as an alias record target
  */
 export class BucketWebsiteTarget implements route53.IAliasRecordTarget {
   constructor(private readonly bucket: s3.IBucket, private readonly props?: IAliasRecordTargetProps) {}

--- a/packages/aws-cdk-lib/aws-scheduler-targets/lib/sqs-send-message.ts
+++ b/packages/aws-cdk-lib/aws-scheduler-targets/lib/sqs-send-message.ts
@@ -7,7 +7,7 @@ import { Token, ValidationError } from '../../core';
 import { lit } from '../../core/lib/private/literal-string';
 
 /**
- * Properties for a SQS Queue Target
+ * Properties for an SQS Queue Target
  */
 export interface SqsSendMessageProps extends ScheduleTargetBaseProps {
   /**

--- a/packages/aws-cdk-lib/aws-ses-actions/lib/s3.ts
+++ b/packages/aws-cdk-lib/aws-ses-actions/lib/s3.ts
@@ -6,7 +6,7 @@ import type * as sns from '../../aws-sns';
 import * as cdk from '../../core';
 
 /**
- * Construction properties for a S3 action.
+ * Construction properties for an S3 action.
  */
 export interface S3Props {
   /**
@@ -65,7 +65,7 @@ export class S3 implements ses.IReceiptRuleAction {
     if (policy) { // The bucket could be imported
       rule.node.addDependency(policy);
     } else {
-      cdk.Annotations.of(rule).addWarningV2('@aws-cdk/s3:AddBucketPermissions', 'This rule is using a S3 action with an imported bucket. Ensure permission is given to SES to write to that bucket.');
+      cdk.Annotations.of(rule).addWarningV2('@aws-cdk/s3:AddBucketPermissions', 'This rule is using an S3 action with an imported bucket. Ensure permission is given to SES to write to that bucket.');
     }
 
     // Allow SES to use KMS master key

--- a/packages/aws-cdk-lib/aws-ses-actions/lib/sns.ts
+++ b/packages/aws-cdk-lib/aws-ses-actions/lib/sns.ts
@@ -2,7 +2,7 @@ import type * as ses from '../../aws-ses';
 import type * as sns from '../../aws-sns';
 
 /**
- * The type of email encoding to use for a SNS action.
+ * The type of email encoding to use for an SNS action.
  */
 export enum EmailEncoding {
   /**
@@ -17,7 +17,7 @@ export enum EmailEncoding {
 }
 
 /**
- * Construction properties for a SNS action.
+ * Construction properties for an SNS action.
  */
 export interface SnsProps {
   /**

--- a/packages/aws-cdk-lib/aws-ses/lib/configuration-set-event-destination.ts
+++ b/packages/aws-cdk-lib/aws-ses/lib/configuration-set-event-destination.ts
@@ -59,7 +59,7 @@ export interface ConfigurationSetEventDestinationOptions {
  */
 export abstract class EventDestination {
   /**
-   * Use a SNS topic as event destination
+   * Use an SNS topic as event destination
    */
   public static snsTopic(topic: sns.ITopic): EventDestination {
     return { topic };
@@ -89,7 +89,7 @@ export abstract class EventDestination {
   /**
    * A SNS topic to use as event destination
    *
-   * @default - do not send events to a SNS topic
+   * @default - do not send events to an SNS topic
    */
   public abstract readonly topic?: sns.ITopic;
 

--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/states/distributed-map/item-reader.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/states/distributed-map/item-reader.ts
@@ -192,7 +192,7 @@ export class S3ObjectsItemReader implements IItemReader {
 }
 
 /**
- * Base interface for Item Reader configuration properties the iterate over entries in a S3 file
+ * Base interface for Item Reader configuration properties the iterate over entries in an S3 file
  */
 export interface S3FileItemReaderProps extends ItemReaderProps {
   /**
@@ -202,7 +202,7 @@ export interface S3FileItemReaderProps extends ItemReaderProps {
 }
 
 /**
- * Base Item Reader configuration for iterating over entries in a S3 file
+ * Base Item Reader configuration for iterating over entries in an S3 file
  */
 abstract class S3FileItemReader implements IItemReader {
   private readonly _bucket?: IBucket;
@@ -322,7 +322,7 @@ abstract class S3FileItemReader implements IItemReader {
 }
 
 /**
- * Item Reader configuration for iterating over items in a JSON array stored in a S3 file
+ * Item Reader configuration for iterating over items in a JSON array stored in an S3 file
  */
 export class S3JsonItemReader extends S3FileItemReader {
   protected readonly inputType: string = 'JSON';
@@ -474,7 +474,7 @@ export class S3CsvItemReader extends S3FileItemReader {
 }
 
 /**
- * Item Reader configuration for iterating over items in a S3 inventory manifest file stored in S3
+ * Item Reader configuration for iterating over items in an S3 inventory manifest file stored in S3
  */
 export class S3ManifestItemReader extends S3FileItemReader {
   protected readonly inputType: string = 'MANIFEST';

--- a/packages/aws-cdk-lib/custom-resources/lib/aws-custom-resource/aws-custom-resource.ts
+++ b/packages/aws-cdk-lib/custom-resources/lib/aws-custom-resource/aws-custom-resource.ts
@@ -214,7 +214,7 @@ export interface AwsSdkCall {
    * Note: The default Logging configuration is all. This configuration will enable logging on all logged data
    * in the lambda handler. This includes:
    *  - The event object that is received by the lambda handler
-   *  - The response received after making a API call
+   *  - The response received after making an API call
    *  - The response object that the lambda handler will return
    *  - SDK versioning information
    *  - Caught and uncaught errors

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -754,7 +754,7 @@ remain in control of it.
 
 Flag type: Backwards incompatible bugfix
 
-Enable this feature flag to restrict the decryption of a SQS queue, which is subscribed to a SNS topic, to
+Enable this feature flag to restrict the decryption of an SQS queue, which is subscribed to an SNS topic, to
 only the topic which it is subscribed to and not the whole SNS service of an account.
 
 Previously the decryption was only restricted to the SNS service principal. To make the SQS subscription more
@@ -1510,7 +1510,7 @@ When this feature flag is disabled, it will keep the root account principal in t
 
 Flag type: New default behavior
 
-When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+When this feature flag is enabled, remove the default deployment alarm settings when creating an AWS ECS service.
 
 
 | Since | Unset behaves like | Recommended value |
@@ -2060,7 +2060,7 @@ be added with a priority of MUTATING, independent of this feature flag.
 
 Flag type: Backwards incompatible bugfix
 
-When this feature flag is enabled, a S3 trust policy will be added to the KMS key resource policy for encrypted SNS subscriptions.
+When this feature flag is enabled, an S3 trust policy will be added to the KMS key resource policy for encrypted SNS subscriptions.
 
 
 | Since | Unset behaves like | Recommended value |

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -572,7 +572,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.BugFix,
     summary: 'Restrict KMS key policy for encrypted Queues a bit more',
     detailsMd: `
-      Enable this feature flag to restrict the decryption of a SQS queue, which is subscribed to a SNS topic, to
+      Enable this feature flag to restrict the decryption of an SQS queue, which is subscribed to an SNS topic, to
       only the topic which it is subscribed to and not the whole SNS service of an account.
 
       Previously the decryption was only restricted to the SNS service principal. To make the SQS subscription more
@@ -1185,7 +1185,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.ApiDefault,
     summary: 'When enabled, remove default deployment alarm settings',
     detailsMd: `
-      When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+      When this feature flag is enabled, remove the default deployment alarm settings when creating an AWS ECS service.
     `,
     introducedIn: { v2: '2.143.0' },
     recommendedValue: true,
@@ -1638,7 +1638,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.BugFix,
     summary: 'Add an S3 trust policy to a KMS key resource policy for SNS subscriptions.',
     detailsMd: `
-      When this feature flag is enabled, a S3 trust policy will be added to the KMS key resource policy for encrypted SNS subscriptions.
+      When this feature flag is enabled, an S3 trust policy will be added to the KMS key resource policy for encrypted SNS subscriptions.
           `,
     introducedIn: { v2: '2.195.0' },
     recommendedValue: true,

--- a/packages/aws-cdk-lib/region-info/lib/fact.ts
+++ b/packages/aws-cdk-lib/region-info/lib/fact.ts
@@ -173,7 +173,7 @@ export class FactName {
   public static readonly S3_STATIC_WEBSITE_ZONE_53_HOSTED_ZONE_ID = 's3-static-website:route-53-hosted-zone-id';
 
   /**
-   * The hosted zone ID used by Route 53 to alias a EBS environment endpoint in this region (e.g: Z2O1EMRO9K5GLX)
+   * The hosted zone ID used by Route 53 to alias an EBS environment endpoint in this region (e.g: Z2O1EMRO9K5GLX)
    */
   public static readonly EBS_ENV_ENDPOINT_HOSTED_ZONE_ID = 'ebs-environment:route-53-hosted-zone-id';
 

--- a/packages/aws-cdk-lib/region-info/lib/region-info.ts
+++ b/packages/aws-cdk-lib/region-info/lib/region-info.ts
@@ -99,14 +99,14 @@ export class RegionInfo {
   }
 
   /**
-   * The hosted zone ID used by Route 53 to alias a S3 static website in this region (e.g: Z2O1EMRO9K5GLX)
+   * The hosted zone ID used by Route 53 to alias an S3 static website in this region (e.g: Z2O1EMRO9K5GLX)
    */
   public get s3StaticWebsiteHostedZoneId(): string | undefined {
     return Fact.find(this.name, FactName.S3_STATIC_WEBSITE_ZONE_53_HOSTED_ZONE_ID);
   }
 
   /**
-   * The hosted zone ID used by Route 53 to alias a EBS environment endpoint in this region (e.g: Z2O1EMRO9K5GLX)
+   * The hosted zone ID used by Route 53 to alias an EBS environment endpoint in this region (e.g: Z2O1EMRO9K5GLX)
    */
   public get ebsEnvEndpointHostedZoneId(): string | undefined {
     return Fact.find(this.name, FactName.EBS_ENV_ENDPOINT_HOSTED_ZONE_ID);


### PR DESCRIPTION
### Reason for this change

Fix incorrect usage of the indefinite article "a" before words and acronyms that begin with a vowel sound. English grammar requires "an" before vowel sounds.

### Description of changes

Updated 53 occurrences across 33 files where "a" was incorrectly used before acronyms and words starting with a vowel sound:

- `a S3` → `an S3` (S is pronounced "ess")
- `a SNS` → `an SNS`
- `a SQS` → `an SQS`
- `a API` → `an API` (A is pronounced "ay")
- `a AWS` → `an AWS`
- `a Amazon` → `an Amazon`
- `a EC2` → `an EC2` (E is pronounced "ee")
- `a ECS` → `an ECS`
- `a EBS` → `an EBS`
- `a IAM` → `an IAM` (I is pronounced "eye")

All changes are in JSDoc comments and inline comments only — no functional code changes.

### Description of how you validated changes

Documentation-only change (comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*