### PR TITLE
docs(apigateway): fix "a the" to "the" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/lambda-api.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/lambda-api.ts
@@ -15,7 +15,7 @@ export interface LambdaRestApiProps extends RestApiProps {
   /**
    * The default Lambda function that handles all requests from this API.
    *
-   * This handler will be used as a the default integration for all methods in
+   * This handler will be used as the default integration for all methods in
    * this API, unless specified otherwise in `addMethod`.
    */
   readonly handler: lambda.IFunction;

--- a/packages/aws-cdk-lib/aws-apigateway/lib/stepfunctions-api.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/stepfunctions-api.ts
@@ -17,7 +17,7 @@ export interface StepFunctionsRestApiProps extends RestApiProps {
   /**
    * The default State Machine that handles all requests from this API.
    *
-   * This stateMachine will be used as a the default integration for all methods in
+   * This stateMachine will be used as the default integration for all methods in
    * this API, unless specified otherwise in `addMethod`.
    */
   readonly stateMachine: sfn.IStateMachine;


### PR DESCRIPTION
### Reason for this change

Fix a grammatical error in JSDoc comments.

### Description of changes

Fix duplicate article "a the" to "the" in two files:
- `StepFunctionsRestApi`: "used as a the default integration" → "used as the default integration"
- `LambdaRestApi`: "used as a the default integration" → "used as the default integration"

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*