### PR TITLE
docs: fix "allows to" grammar in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
@@ -102,7 +102,7 @@ export class ImportedRole extends Resource implements IRole, IComparablePrincipa
 
   @MethodMetadata()
   public addManagedPolicy(policy: IManagedPolicy): void {
-    // Using "Type Predicate" to confirm x is ManagedPolicy, which allows to avoid
+    // Using "Type Predicate" to confirm x is ManagedPolicy, which allows us to avoid
     // using try ... catch and throw error.
     const isManagedPolicy = (x: IManagedPolicy): x is ManagedPolicy => {
       return (x as ManagedPolicy).attachToRole !== undefined;

--- a/packages/aws-cdk-lib/aws-rds/lib/props.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/props.ts
@@ -245,7 +245,7 @@ export abstract class Credentials {
    * @param secret The secret where the credentials are stored
    * @param username The username defined in the secret. If specified the username
    *   will be referenced as a string and not a dynamic reference to the username
-   *   field in the secret. This allows to replace the secret without replacing the
+   *   field in the secret. This allows you to replace the secret without replacing the
    *   instance or cluster.
    */
   public static fromSecret(secret: secretsmanager.ISecret, username?: string): Credentials {

--- a/packages/aws-cdk-lib/aws-route53/lib/record-set.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/record-set.ts
@@ -230,7 +230,7 @@ export interface RecordSetOptions {
   /**
    * Whether to delete the same record set in the hosted zone if it already exists (dangerous!)
    *
-   * This allows to deploy a new record set while minimizing the downtime because the
+   * This allows you to deploy a new record set while minimizing the downtime because the
    * new record set will be created immediately after the existing one is deleted. It
    * also avoids "manual" actions to delete existing record sets.
    *

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
@@ -933,7 +933,7 @@ export class SecretTargetAttachment extends SecretBase implements ISecretTargetA
     this.encryptionKey = this.attachedSecret.encryptionKey;
     this.secretName = this.attachedSecret.secretName;
 
-    // This allows to reference the secret after attachment (dependency).
+    // This allows you to reference the secret after attachment (dependency).
     this.secretArn = attachment.ref;
     this.secretTargetAttachmentSecretArn = attachment.ref;
   }


### PR DESCRIPTION
### Reason for this change

Fix grammatical errors in source comments.

### Description of changes

"allows to \<verb\>" is grammatically incorrect in English. The verb "allow" requires an object before the infinitive (e.g., "allows **you** to \<verb\>").

Fixed 4 occurrences:
- `aws-iam`: "which allows to avoid" → "which allows us to avoid"
- `aws-rds`: "This allows to replace" → "This allows you to replace"
- `aws-route53`: "This allows to deploy" → "This allows you to deploy"
- `aws-secretsmanager`: "This allows to reference" → "This allows you to reference"

### Description of how you validated changes

Documentation-only change (source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*