### PR TITLE
docs(assertions): fix "an warning" to "a warning" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/assertions/lib/annotations.ts
+++ b/packages/aws-cdk-lib/assertions/lib/annotations.ts
@@ -61,7 +61,7 @@ export class Annotations {
   }
 
   /**
-   * Assert that an warning with the given message exists in the synthesized CDK `Stack`.
+   * Assert that a warning with the given message exists in the synthesized CDK `Stack`.
    *
    * @param constructPath the construct path to the warning, provide `'*'` to match all warnings in the template.
    * @param message the warning message as should be expected. This should be a string or Matcher object.
@@ -74,7 +74,7 @@ export class Annotations {
   }
 
   /**
-   * Assert that an warning with the given message does not exist in the synthesized CDK `Stack`.
+   * Assert that a warning with the given message does not exist in the synthesized CDK `Stack`.
    *
    * @param constructPath the construct path to the warning, provide `'*'` to match all warnings in the template.
    * @param message the warning message as should be expected. This should be a string or Matcher object.


### PR DESCRIPTION
### Reason for this change

Fix grammatical error in JSDoc comments.

### Description of changes

"warning" starts with a consonant sound /w/, so the correct indefinite article is "a" (not "an").

Fixed 2 occurrences in `packages/aws-cdk-lib/assertions/lib/annotations.ts`:
- `Assert that an warning with the given message exists` → `Assert that a warning...`
- `Assert that an warning with the given message does not exist` → `Assert that a warning...`

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*