### PR TITLE
docs(ec2): use HTTPS for AWS CloudWatch pricing link

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
@@ -374,7 +374,7 @@ export interface InstanceProps {
    * Whether "Detailed Monitoring" is enabled for this instance
    * Keep in mind that Detailed Monitoring results in extra charges
    *
-   * @see http://aws.amazon.com/cloudwatch/pricing/
+   * @see https://aws.amazon.com/cloudwatch/pricing/
    * @default - false
    */
   readonly detailedMonitoring?: boolean;


### PR DESCRIPTION
### Reason for this change

Use HTTPS instead of HTTP for external AWS links, consistent with the recent cleanup in #37359.

### Description of changes

Update the CloudWatch pricing URL from `http://` to `https://` in `packages/aws-cdk-lib/aws-ec2/lib/instance.ts`.

### Description of how you validated changes

Documentation-only change (JSDoc comment URL). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*