### PR TITLE
docs(appsync): fix "an unique" to "a unique" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/aws-appsync/lib/eventapi.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/eventapi.ts
@@ -513,7 +513,7 @@ export interface EventApiAttributes {
   readonly apiName?: string;
 
   /**
-   * an unique AWS AppSync Event API identifier
+   * a unique AWS AppSync Event API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   readonly apiId: string;
@@ -579,7 +579,7 @@ export class EventApi extends EventApiBase {
   }
 
   /**
-   * an unique AWS AppSync Event API identifier
+   * a unique AWS AppSync Event API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public readonly apiId: string;

--- a/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi-base.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi-base.ts
@@ -171,7 +171,7 @@ export enum AuthorizationType {
 export interface IGraphqlApi extends IResource, IGraphQLApiRef {
 
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    *
    * @attribute
@@ -352,7 +352,7 @@ export interface IGraphqlApi extends IResource, IGraphQLApiRef {
  */
 export abstract class GraphqlApiBase extends Resource implements IGraphqlApi {
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public abstract readonly apiId: string;

--- a/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi.ts
@@ -531,7 +531,7 @@ export interface GraphqlApiProps {
  */
 export interface GraphqlApiAttributes {
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   readonly graphqlApiId: string;
@@ -621,7 +621,7 @@ export class GraphqlApi extends GraphqlApiBase {
   }
 
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public readonly apiId: string;


### PR DESCRIPTION
### Reason for this change

Fix grammatical error. "unique" starts with a consonant sound /juː/, so the correct article is "a" (not "an").

### Description of changes

Fixed 6 occurrences of "an unique" → "a unique" in `aws-appsync` JSDoc comments.

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*