### PR TITLE
docs(route53): fix duplicate "that that" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
@@ -70,7 +70,7 @@ export interface HostedZoneProps extends CommonHostedZoneProps {
  */
 export interface ZoneSigningOptions {
   /**
-   * The customer-managed KMS key that that will be used to sign the records.
+   * The customer-managed KMS key that will be used to sign the records.
    *
    * The KMS Key must be unique for each KSK within a hosted zone. Additionally, the
    * KMS key must be an asymetric customer-managed key using the ECC_NIST_P256 algorithm.

--- a/packages/aws-cdk-lib/aws-route53/lib/key-signing-key.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/key-signing-key.ts
@@ -19,7 +19,7 @@ export interface KeySigningKeyProps {
   readonly hostedZone: IHostedZone;
 
   /**
-   * The customer-managed KMS key that that will be used to sign the records.
+   * The customer-managed KMS key that will be used to sign the records.
    *
    * The KMS Key must be unique for each KSK within a hosted zone. Additionally, the
    * KMS key must be an asymetric customer-managed key using the ECC_NIST_P256 algorithm.


### PR DESCRIPTION
### Reason for this change

Fix duplicate word in JSDoc comments.

### Description of changes

- `The customer-managed KMS key that that will be used` → `The customer-managed KMS key that will be used`

Fixed in `hosted-zone.ts` and `key-signing-key.ts`.

### Description of how you validated changes

Documentation-only change. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*