### PR TITLE
docs: fix "it's" to "its" (possessive) in source comments

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
@@ -388,7 +388,7 @@ export class Workflow extends WorkflowBase {
   }
 
   /**
-   * Import an workflow from it's name
+   * Import a workflow from its name
    */
   public static fromWorkflowArn(scope: constructs.Construct, id: string, workflowArn: string): IWorkflow {
     return this.fromWorkflowAttributes(scope, id, {

--- a/packages/aws-cdk-lib/aws-config/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-config/lib/rule.ts
@@ -818,7 +818,7 @@ export class ManagedRuleIdentifiers {
   public static readonly CLB_MULTIPLE_AZ = 'CLB_MULTIPLE_AZ';
   /**
    * Checks whether an AWS CloudFormation stack's actual configuration differs, or has drifted,
-   * from it's expected configuration.
+   * from its expected configuration.
    * @see https://docs.aws.amazon.com/config/latest/developerguide/cloudformation-stack-drift-detection-check.html
    */
   public static readonly CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK = 'CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK';

--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/queue-processing-service-base.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/queue-processing-service-base.ts
@@ -347,7 +347,7 @@ export abstract class QueueProcessingServiceBase extends Construct {
       const errorProps = ['retentionPeriod', 'visibilityTimeout', 'maxReceiveCount'].filter(prop => props.hasOwnProperty(prop));
       throw new ValidationError('OnlyQueue', `${errorProps.join(', ')} can be set only when queue is not set. Specify them in the QueueProps of the queue`, this);
     }
-    // Create the SQS queue and it's corresponding DLQ if one is not provided
+    // Create the SQS queue and its corresponding DLQ if one is not provided
     if (props.queue) {
       this.sqsQueue = props.queue;
     } else {

--- a/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
@@ -114,7 +114,7 @@ export class CfnParameter extends CfnElement {
 
   /**
    * Creates a parameter construct.
-   * Note that the name (logical ID) of the parameter will derive from it's `coname` and location
+   * Note that the name (logical ID) of the parameter will derive from its `coname` and location
    * within the stack. Therefore, it is recommended that parameters are defined at the stack level.
    *
    * @param scope The parent construct.


### PR DESCRIPTION
### Reason for this change

Fix incorrect use of "it's" (contraction of "it is") where "its" (possessive) is intended.

### Description of changes

- `aws-config`: "from it's expected configuration" → "from its expected configuration"
- `aws-ecs-patterns`: "it's corresponding DLQ" → "its corresponding DLQ"
- `core`: "from it's \`coname\`" → "from its \`coname\`"
- `aws-glue-alpha`: "from it's name" → "from its name"

### Description of how you validated changes

Documentation-only change (source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*