### PR TITLE
docs(s3tables): fix "priveleges" to "privileges" in comments

### DIFF
--- a/packages/@aws-cdk/aws-s3tables-alpha/lib/permissions.ts
+++ b/packages/@aws-cdk/aws-s3tables-alpha/lib/permissions.ts
@@ -1,12 +1,12 @@
 // Table Bucket
-// Read priveleges
+// Read privileges
 export const TABLE_BUCKET_READ_ACCESS = [
   's3tables:Get*',
   's3tables:ListNamespaces',
   's3tables:ListTables',
 ];
 
-// Write priveleges
+// Write privileges
 export const TABLE_BUCKET_WRITE_ACCESS = [
   's3tables:PutTableData',
   's3tables:UpdateTableMetadataLocation',
@@ -23,11 +23,11 @@ export const TABLE_BUCKET_READ_WRITE_ACCESS = [...new Set([
 ])];
 
 // Table
-// Read priveleges
+// Read privileges
 export const TABLE_READ_ACCESS = [
   's3tables:Get*',
 ];
-// Write priveleges
+// Write privileges
 export const TABLE_WRITE_ACCESS = [
   's3tables:PutTableData',
   's3tables:UpdateTableMetadataLocation',


### PR DESCRIPTION
### Reason for this change

Fix spelling error in source comments.

### Description of changes

Fixed 4 occurrences of "priveleges" → "privileges" in `packages/@aws-cdk/aws-s3tables-alpha/lib/permissions.ts`.

### Description of how you validated changes

Documentation-only change (source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*