### PR TITLE
docs: fix "a origin" to "an origin" and "a instance" to "an instance"

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/function-url-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/function-url-origin.ts
@@ -42,7 +42,7 @@ export interface FunctionUrlOriginProps extends cloudfront.OriginProps {
 }
 
 /**
- * Properties for configuring a origin using a standard Lambda Functions URLs.
+ * Properties for configuring an origin using a standard Lambda Functions URLs.
  */
 export interface FunctionUrlOriginBaseProps extends cloudfront.OriginProps { }
 

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-bucket-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-bucket-origin.ts
@@ -26,7 +26,7 @@ const KEY_ACTIONS: Record<string, string[]> = {
 };
 
 /**
- * Properties for configuring a origin using a standard S3 bucket
+ * Properties for configuring an origin using a standard S3 bucket
  */
 export interface S3BucketOriginBaseProps extends cloudfront.OriginProps { }
 

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-static-website-origin.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/lib/s3-static-website-origin.ts
@@ -4,7 +4,7 @@ import * as cloudfront from '../../aws-cloudfront';
 import type { IBucket } from '../../aws-s3';
 
 /**
- * Properties for configuring a origin using a S3 bucket configured as a website endpoint
+ * Properties for configuring an origin using a S3 bucket configured as a website endpoint
  */
 export interface S3StaticWebsiteOriginProps extends HttpOriginProps { }
 

--- a/packages/aws-cdk-lib/aws-ec2/lib/nat.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/nat.ts
@@ -84,7 +84,7 @@ export abstract class NatProvider {
    * @see https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html
    *
    * @deprecated use instanceV2. 'instance' is deprecated since NatInstanceProvider
-   * uses a instance image that has reached EOL on Dec 31 2023
+   * uses an instance image that has reached EOL on Dec 31 2023
    */
   public static instance(props: NatInstanceProps): NatInstanceProvider {
     return new NatInstanceProvider(props);


### PR DESCRIPTION
### Reason for this change

Fix incorrect indefinite article before words starting with vowel sounds.

### Description of changes

- `aws-cloudfront-origins`: "a origin" → "an origin" (3 files)
- `aws-ec2`: "a instance image" → "an instance image" (nat.ts)

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*