### PR TITLE
docs: fix "an" to "a" before consonant-sound words

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
@@ -56,7 +56,7 @@ export interface IWorkflow extends cdk.IResource {
   addWeeklyScheduledTrigger(id: string, options: WeeklyScheduleTriggerOptions): CfnTrigger;
 
   /**
-   * Add an custom-scheduled trigger to the workflow
+   * Add a custom-scheduled trigger to the workflow
    */
   addCustomScheduledTrigger(id: string, options: CustomScheduledTriggerOptions): CfnTrigger;
 }

--- a/packages/@aws-cdk/aws-pipes-sources-alpha/lib/dynamodb.ts
+++ b/packages/@aws-cdk/aws-pipes-sources-alpha/lib/dynamodb.ts
@@ -18,7 +18,7 @@ export interface DynamoDBSourceParameters extends StreamSourceParameters {
 }
 
 /**
- * A source that reads from an DynamoDB stream.
+ * A source that reads from a DynamoDB stream.
  */
 export class DynamoDBSource extends StreamSource {
   private readonly table: ITableV2;

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
@@ -141,7 +141,7 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
   public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-codedeploy.LambdaDeploymentGroup';
 
   /**
-   * Import an Lambda Deployment Group defined either outside the CDK app, or in a different AWS region.
+   * Import a Lambda Deployment Group defined either outside the CDK app, or in a different AWS region.
    *
    * Account and region for the DeploymentGroup are taken from the application.
    *


### PR DESCRIPTION
### Reason for this change

Fix incorrect indefinite article before words starting with consonant sounds.

### Description of changes

- `aws-codedeploy`: "Import an Lambda" → "Import a Lambda"
- `aws-pipes-sources-alpha`: "from an DynamoDB" → "from a DynamoDB"
- `aws-glue-alpha`: "an custom-scheduled" → "a custom-scheduled"

### Description of how you validated changes

Documentation-only change (JSDoc/source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*