### PR TITLE
docs: fix "a environment" to "an environment" in JSDoc comments

### DIFF
--- a/packages/@aws-cdk/aws-apprunner-alpha/lib/service.ts
+++ b/packages/@aws-cdk/aws-apprunner-alpha/lib/service.ts
@@ -1130,7 +1130,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager
@@ -1148,7 +1148,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager

--- a/packages/aws-cdk-lib/aws-batch/lib/ecs-container-definition.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/ecs-container-definition.ts
@@ -50,7 +50,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager
@@ -68,7 +68,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager

--- a/packages/aws-cdk-lib/aws-ecs/lib/container-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/container-definition.ts
@@ -48,7 +48,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager
@@ -66,7 +66,7 @@ export abstract class Secret {
   }
 
   /**
-   * Creates a environment variable value from a secret stored in AWS Secrets
+   * Creates an environment variable value from a secret stored in AWS Secrets
    * Manager.
    *
    * @param secret the secret stored in AWS Secrets Manager


### PR DESCRIPTION
### Reason for this change

Fix incorrect indefinite article. "environment" starts with a vowel sound.

### Description of changes

Fixed "Creates a environment variable" → "Creates an environment variable" in:
- `aws-batch/ecs-container-definition.ts` (2 occurrences)
- `aws-ecs/container-definition.ts` (2 occurrences)
- `aws-apprunner-alpha/service.ts` (1 occurrence)

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*