### PR TITLE
docs: fix "a action" to "an action" and "a IPv6" to "an IPv6"

### DIFF
--- a/packages/@aws-cdk/aws-ec2-alpha/lib/ipam.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/ipam.ts
@@ -203,7 +203,7 @@ export interface IIpamPool {
   readonly ipamIpv4Cidrs?: string[];
 
   /**
-   * Function to associate a IPv6 address with IPAM pool
+   * Function to associate an IPv6 address with IPAM pool
    */
   provisionCidr(id: string, options: IpamPoolCidrProvisioningOptions): CfnIPAMPoolCidr;
 

--- a/packages/@aws-cdk/aws-iot-alpha/lib/topic-rule.ts
+++ b/packages/@aws-cdk/aws-iot-alpha/lib/topic-rule.ts
@@ -157,7 +157,7 @@ export class TopicRule extends Resource implements ITopicRule {
   }
 
   /**
-   * Add a action to the topic rule.
+   * Add an action to the topic rule.
    *
    * @param action the action to associate with the topic rule.
    */


### PR DESCRIPTION
### Reason for this change

Fix incorrect indefinite article before vowel-sound words.

### Description of changes

- `aws-iot-alpha`: "Add a action" → "Add an action"
- `aws-ec2-alpha`: "a IPv6 address" → "an IPv6 address"

### Description of how you validated changes

Documentation-only change (JSDoc comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*