### PR TITLE
docs: fix "an" to "a" before consonant-sound words in README files

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/README.md
+++ b/packages/aws-cdk-lib/aws-cloudfront/README.md
@@ -1377,7 +1377,7 @@ You can customize the default certificate aliases. This is intended to be used i
 
 Example:
 
-[create a distribution with an default certificate example](test/example.default-cert-alias.lit.ts)
+[create a distribution with a default certificate example](test/example.default-cert-alias.lit.ts)
 
 #### ACM certificate
 

--- a/packages/aws-cdk-lib/aws-codebuild/README.md
+++ b/packages/aws-cdk-lib/aws-codebuild/README.md
@@ -1003,7 +1003,7 @@ const project = new codebuild.Project(this, 'MyProject', {
 
 ### Definition of VPC configuration in CodeBuild Project
 
-Typically, resources in an VPC are not accessible by AWS CodeBuild. To enable
+Typically, resources in a VPC are not accessible by AWS CodeBuild. To enable
 access, you must provide additional VPC-specific configuration information as
 part of your CodeBuild project configuration. This includes the VPC ID, the
 VPC subnet IDs, and the VPC security group IDs. VPC-enabled builds are then

--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1745,7 +1745,7 @@ new ec2.Instance(this, 'Instance', {
 
 ```
 
-It is also possible to encrypt the block devices. In this example we will create an customer managed key encrypted EBS-backed root device:
+It is also possible to encrypt the block devices. In this example we will create a customer managed key encrypted EBS-backed root device:
 
 ```ts
 import { Key } from 'aws-cdk-lib/aws-kms';


### PR DESCRIPTION
### Reason for this change

Fix incorrect indefinite article before consonant-sound words in README files.

### Description of changes

- `aws-codebuild`: "in an VPC" → "in a VPC"
- `aws-cloudfront`: "an default certificate" → "a default certificate"
- `aws-ec2`: "an customer managed" → "a customer managed"

### Description of how you validated changes

Documentation-only change (README files). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*