### PR TITLE
docs(cx-api): fix "featuer" typo to "feature" in README

### DIFF
--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -1475,7 +1475,7 @@ any prefix.
 
 Flag type: New default behavior
 
-When this featuer flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`.
+When this feature flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`.
 
 
 | Since | Unset behaves like | Recommended value |

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -345,7 +345,7 @@ _cdk.json_
 
 When enabled, the default volume type of the EBS volume will be GP3.
 
-When this featuer flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
+When this feature flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
 
 _cdk.json_
 
@@ -361,7 +361,7 @@ _cdk.json_
 
 When enabled, remove default deployment alarm settings.
 
-When this featuer flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
 
 _cdk.json_
 

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -1173,7 +1173,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.ApiDefault,
     summary: 'When enabled, the default volume type of the EBS volume will be GP3',
     detailsMd: `
-      When this featuer flag is enabled, the default volume type of the EBS volume will be \`EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3\`.
+      When this feature flag is enabled, the default volume type of the EBS volume will be \`EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3\`.
     `,
     introducedIn: { v2: '2.140.0' },
     recommendedValue: true,


### PR DESCRIPTION
### Reason for this change

Fix spelling error in README.

### Description of changes

Fixed 2 occurrences of "featuer" → "feature" in `packages/aws-cdk-lib/cx-api/README.md`.

### Description of how you validated changes

Documentation-only change. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*