### PR TITLE
docs: fix "it's" to "its" (possessive) in README files

### DIFF
--- a/packages/@aws-cdk/integ-tests-alpha/README.md
+++ b/packages/@aws-cdk/integ-tests-alpha/README.md
@@ -219,7 +219,7 @@ new AwsApiCall(myAppStack, 'GetObject', {
 
 ### DeployAssert
 
-Assertions are created by using the `DeployAssert` construct. This construct creates it's own `Stack` separate from
+Assertions are created by using the `DeployAssert` construct. This construct creates its own `Stack` separate from
 any stacks that you create as part of your integration tests. This `Stack` is treated differently from other stacks
 by the `integ-runner` tool. For example, this stack will not be diffed by the `integ-runner`.
 

--- a/packages/aws-cdk-lib/aws-config/README.md
+++ b/packages/aws-cdk-lib/aws-config/README.md
@@ -66,7 +66,7 @@ new config.AccessKeysRotated(this, 'AccessKeyRotated');
 #### CloudFormation Stack drift detection
 
 Checks whether your CloudFormation stack's actual configuration differs, or has drifted,
-from it's expected configuration.
+from its expected configuration.
 
 ```ts
 // compliant if stack's status is 'IN_SYNC'

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -2014,7 +2014,7 @@ Step Functions supports [AWS Step Functions](https://docs.aws.amazon.com/step-fu
 
 You can manage [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) executions.
 
-AWS Step Functions supports it's own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
+AWS Step Functions supports its own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
 
 ```ts
 // Define a state machine with one Pass state


### PR DESCRIPTION
### Reason for this change

Fix incorrect use of "it's" (contraction) where "its" (possessive) is intended.

### Description of changes

- `aws-config`: "from it's expected configuration" → "from its expected configuration"
- `aws-stepfunctions-tasks`: "supports it's own" → "supports its own"
- `integ-tests-alpha`: "creates it's own" → "creates its own"

### Description of how you validated changes

Documentation-only change (README files). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*