### PR TITLE
docs: fix "allows to" grammar in README files

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/README.md
+++ b/packages/aws-cdk-lib/aws-kms/README.md
@@ -100,7 +100,7 @@ must be set to `true`. By default, this flag is `false` and grant calls on an im
 
 If you can't use a KMS key imported by alias (e.g. because you need access to the key id), you can lookup the key with `Key.fromLookup()`.
 
-In general, the preferred method would be to use `Alias.fromAliasName()` which returns an `IAlias` object which extends `IKey`. However, some services need to have access to the underlying key id. In this case, `Key.fromLookup()` allows to lookup the key id.
+In general, the preferred method would be to use `Alias.fromAliasName()` which returns an `IAlias` object which extends `IKey`. However, some services need to have access to the underlying key id. In this case, `Key.fromLookup()` allows you to look up the key id.
 
 The result of the `Key.fromLookup()` operation will be written to a file
 called `cdk.context.json`. You must commit this file to source control so

--- a/packages/aws-cdk-lib/aws-lambda-destinations/README.md
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/README.md
@@ -122,7 +122,7 @@ payload file in the configured bucket is `aws/lambda/async/<function-name>/YYYY/
 
 ### Auto-extract response payload with lambda destination
 
-The `responseOnly` option of `LambdaDestination` allows to auto-extract the response payload from the
+The `responseOnly` option of `LambdaDestination` allows you to auto-extract the response payload from the
 invocation record:
 
 ```ts
@@ -146,5 +146,5 @@ In the above example, `destinationFn` will be invoked with the payload returned 
 When used with `onFailure`, the destination function is invoked with the error object returned
 by the source function.
 
-Using the `responseOnly` option allows to easily chain asynchronous Lambda functions without
+Using the `responseOnly` option allows you to easily chain asynchronous Lambda functions without
 having to deal with data extraction in the runtime code.

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/README.md
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/README.md
@@ -238,7 +238,7 @@ new nodejs.NodejsFunction(this, 'my-handler', {
     charset: nodejs.Charset.UTF8, // do not escape non-ASCII characters, defaults to Charset.ASCII
     format: nodejs.OutputFormat.ESM, // ECMAScript module output format, defaults to OutputFormat.CJS (OutputFormat.ESM requires Node.js >= 14)
     mainFields: ['module', 'main'], // prefer ECMAScript versions of dependencies
-    inject: ['./my-shim.js', './other-shim.js'], // allows to automatically replace a global variable with an import from another file
+    inject: ['./my-shim.js', './other-shim.js'], // allows you to automatically replace a global variable with an import from another file
     esbuildArgs: { // Pass additional arguments to esbuild
       "--log-limit": "0",
       "--splitting": true,


### PR DESCRIPTION
### Reason for this change

Fix grammatical errors in README files.

### Description of changes

"allows to \<verb\>" is grammatically incorrect. Fixed to "allows you to \<verb\>" in:
- `aws-kms/README.md`
- `aws-lambda-destinations/README.md` (2 occurrences)
- `aws-lambda-nodejs/README.md`

### Description of how you validated changes

Documentation-only change. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*