### PR TITLE
docs(apigateway): fix "the a stage" to "a stage" in README

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/README.md
+++ b/packages/aws-cdk-lib/aws-apigateway/README.md
@@ -1416,7 +1416,7 @@ new apigateway.RestApi(this, 'books', {
 
 You can use the `methodOptions` property to configure
 [default method throttling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html#apigateway-api-level-throttling-in-usage-plan)
-for a stage. The following snippet configures the a stage that accepts
+for a stage. The following snippet configures a stage that accepts
 100 requests per minute, allowing burst up to 200 requests per minute.
 
 ```ts


### PR DESCRIPTION
### Reason for this change

Fix duplicate article in README.

### Description of changes

"configures the a stage" → "configures a stage" in `aws-apigateway/README.md`.

### Description of how you validated changes

Documentation-only change. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*