### PR TITLE
docs: fix "acces" typo to "access" in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
@@ -1544,7 +1544,7 @@ export class Cluster extends ClusterBase {
    *
    * This method creates an `AccessEntry` construct that grants the specified IAM principal the cluster admin
    * access permissions. This allows the IAM principal to perform the actions permitted
-   * by the cluster admin acces.
+   * by the cluster admin access.
    * [disable-awslint:no-grants]
    *
    * @param id - The ID of the `AccessEntry` construct to be created.

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
@@ -62,7 +62,7 @@ export interface CodeBuildStepProps extends ShellStepProps {
   /**
    * Policy statements to add to role used during the synth
    *
-   * Can be used to add acces to a CodeArtifact repository etc.
+   * Can be used to add access to a CodeArtifact repository etc.
    *
    * @default - No policy statements added to CodeBuild Project Role
    */


### PR DESCRIPTION
### Reason for this change

Fix spelling error in source comments.

### Description of changes

Fixed "acces" → "access" in:
- `aws-eks-v2/cluster.ts`: "admin acces" → "admin access"
- `pipelines/codebuild-step.ts`: "add acces to" → "add access to"

### Description of how you validated changes

Documentation-only change (source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*