### PR TITLE
docs(ec2-alpha): fix "assoicated" typo to "associated" in comments

### DIFF
--- a/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
@@ -529,7 +529,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
   const subnetCidrBlock = new CidrBlock(cidrRange);
   const allCidrs: CidrBlock[] = [];
 
-  // Secondary IP addresses assoicated using user defined IPv4 range
+  // Secondary IP addresses associated using user defined IPv4 range
   if (vpc.secondaryCidrBlock) {
     for (const ipAddress of vpc.secondaryCidrBlock) {
       if (ipAddress.cidrBlock) {
@@ -540,7 +540,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
     allCidrs.push(...cidrs);
   }
 
-  // Secondary IP addresses assoicated using IPAM IPv4 range
+  // Secondary IP addresses associated using IPAM IPv4 range
   if (vpc.ipv4IpamProvisionedCidrs) {
     const cidrs = vpc.ipv4IpamProvisionedCidrs.map(cidr => new CidrBlock(cidr));
     allCidrs.push(...cidrs);


### PR DESCRIPTION
### Reason for this change
Fix spelling error.
### Description of changes
Fixed 2 occurrences of "assoicated" → "associated" in `packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts`.
### Description of how you validated changes
Documentation-only change (source comments). No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*