### PR TITLE
docs(integ-tests): fix "exeuction" typo to "execution" in comments

### DIFF
--- a/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
+++ b/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
@@ -41,7 +41,7 @@ export interface LambdaFunctionProviderProps {
  */
 class LambdaFunctionProvider extends Construct {
   /**
-   * A Reference to the provider lambda exeuction role ARN
+   * A Reference to the provider lambda execution role ARN
    */
   public readonly roleArn: Reference;
 


### PR DESCRIPTION
### Reason for this change
Fix spelling error.
### Description of changes
Fixed "exeuction" → "execution" in `packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts`.
### Description of how you validated changes
Documentation-only change (source comments). No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*