### PR TITLE
docs(mixins-preview): fix "@defualt" typo to "@default" in JSDoc

### DIFF
--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
@@ -46,7 +46,7 @@ export interface RecordFieldDeliveryProps {
   /**
    * RecordFields the user has defined to be used in log delivery
    *
-   * @defualt - no fields were provided
+   * @default - no fields were provided
    */
   readonly providedFields?: string[];
   /**
@@ -64,7 +64,7 @@ export interface DeliveryProps extends RecordFieldDeliveryProps {
   /**
    * Format of the logs that are sent to the delivery destination specified
    *
-   * @defualt - undefined, use whatever default the delivery destination specifies
+   * @default - undefined, use whatever default the delivery destination specifies
    */
   readonly outputFormat?: string;
 }


### PR DESCRIPTION
### Reason for this change
Fix spelling error in JSDoc tag.
### Description of changes
Fixed 2 occurrences of `@defualt` → `@default` in `packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts`.
### Description of how you validated changes
Documentation-only change (JSDoc tag). No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*