### PR TITLE
docs(msk-alpha): fix "eg." to "e.g." in JSDoc comments

### DIFF
--- a/packages/@aws-cdk/aws-msk-alpha/lib/cluster.ts
+++ b/packages/@aws-cdk/aws-msk-alpha/lib/cluster.ts
@@ -778,7 +778,7 @@ export class Cluster extends ClusterBase {
    *
    * Uses a Custom Resource to make an API call to `describeCluster` using the Javascript SDK
    *
-   * @param responseField Field to return from API call. eg. ZookeeperConnectString, ZookeeperConnectStringTls
+   * @param responseField Field to return from API call. e.g. ZookeeperConnectString, ZookeeperConnectStringTls
    * @returns - The connection string to use to connect to the Apache ZooKeeper cluster.
    */
   private _zookeeperConnectionString(responseField: string): string {
@@ -835,7 +835,7 @@ export class Cluster extends ClusterBase {
    *
    * Uses a Custom Resource to make an API call to `getBootstrapBrokers` using the Javascript SDK
    *
-   * @param responseField Field to return from API call. eg. BootstrapBrokerStringSaslScram, BootstrapBrokerString
+   * @param responseField Field to return from API call. e.g. BootstrapBrokerStringSaslScram, BootstrapBrokerString
    * @returns - A string containing one or more hostname:port pairs.
    */
   private _bootstrapBrokers(responseField: string): string {


### PR DESCRIPTION
### Reason for this change
Fix abbreviation format.
### Description of changes
Fixed 2 occurrences of "eg." → "e.g." in `packages/@aws-cdk/aws-msk-alpha/lib/cluster.ts`.
### Description of how you validated changes
Documentation-only change (JSDoc comments). No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*