### PR TITLE
docs: fix duplicate words in source comments

### DIFF
--- a/packages/@aws-cdk/aws-imagebuilder-alpha/lib/workflow.ts
+++ b/packages/@aws-cdk/aws-imagebuilder-alpha/lib/workflow.ts
@@ -204,7 +204,7 @@ export enum WorkflowAction {
   EXECUTE_COMPONENTS = 'ExecuteComponents',
 
   /**
-   * The ExecuteStateMachine action executes a the state machine provided and waits for completion as part of the
+   * The ExecuteStateMachine action executes the state machine provided and waits for completion as part of the
    * workflow
    */
   EXECUTE_STATE_MACHINE = 'ExecuteStateMachine',

--- a/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/lib/types.ts
+++ b/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/lib/types.ts
@@ -107,7 +107,7 @@ export class Runtime {
   /** SQL Version 1.0 */
   public static readonly SQL_1_0 = Runtime.of('SQL-1_0');
 
-  /** Create a new Runtime with with an arbitrary Flink version string */
+  /** Create a new Runtime with an arbitrary Flink version string */
   public static of(value: string) {
     return new Runtime(value);
   }

--- a/packages/aws-cdk-lib/aws-lambda/lib/function-base.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function-base.ts
@@ -48,7 +48,7 @@ export interface IFunction extends IResource, ec2.IConnectable, iam.IGrantable, 
   /**
    * Whether or not this Lambda function was bound to a VPC
    *
-   * If this is is `false`, trying to access the `connections` object will fail.
+   * If this is `false`, trying to access the `connections` object will fail.
    */
   readonly isBoundToVpc: boolean;
 
@@ -489,7 +489,7 @@ export abstract class FunctionBase extends Resource implements IFunction, ec2.IC
   /**
    * Whether or not this Lambda function was bound to a VPC
    *
-   * If this is is `false`, trying to access the `connections` object will fail.
+   * If this is `false`, trying to access the `connections` object will fail.
    */
   public get isBoundToVpc(): boolean {
     return !!this._connections;

--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/source.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/source.ts
@@ -267,7 +267,7 @@ export class Source {
    * Process objects such that it escapes token output suitable for JSON output.
    *
    * @param scope Parent construct scope
-   * @returns Object with with tokens escaped for JSON output.
+   * @returns Object with tokens escaped for JSON output.
    */
   private static escapeTokens(scope: Construct, obj: any): any {
     if (Token.isUnresolved(obj)) {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-fleet-by-name.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-fleet-by-name.ts
@@ -50,17 +50,17 @@ export interface EmrModifyInstanceFleetByNameJsonataProps extends sfn.TaskStateJ
 export interface EmrModifyInstanceFleetByNameProps extends sfn.TaskStateBaseProps, EmrModifyInstanceFleetByNameOptions { }
 
 /**
- * A Step Functions Task to to modify an InstanceFleet on an EMR Cluster.
+ * A Step Functions Task to modify an InstanceFleet on an EMR Cluster.
  */
 export class EmrModifyInstanceFleetByName extends sfn.TaskStateBase {
   /**
-   * A Step Functions Task using JSONPath to to modify an InstanceFleet on an EMR Cluster.
+   * A Step Functions Task using JSONPath to modify an InstanceFleet on an EMR Cluster.
    */
   public static jsonPath(scope: Construct, id: string, props: EmrModifyInstanceFleetByNameJsonPathProps) {
     return new EmrModifyInstanceFleetByName(scope, id, props);
   }
   /**
-   * A Step Functions Task using JSONata to to modify an InstanceFleet on an EMR Cluster.
+   * A Step Functions Task using JSONata to modify an InstanceFleet on an EMR Cluster.
    */
   public static jsonata(scope: Construct, id: string, props: EmrModifyInstanceFleetByNameJsonataProps) {
     return new EmrModifyInstanceFleetByName(scope, id, {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-group-by-name.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-group-by-name.ts
@@ -47,7 +47,7 @@ export interface EmrModifyInstanceGroupByNameJsonataProps extends sfn.TaskStateJ
 export interface EmrModifyInstanceGroupByNameProps extends sfn.TaskStateBaseProps, EmrModifyInstanceGroupByNameOptions {}
 
 /**
- * A Step Functions Task to to modify an InstanceGroup on an EMR Cluster.
+ * A Step Functions Task to modify an InstanceGroup on an EMR Cluster.
  *
  */
 export class EmrModifyInstanceGroupByName extends sfn.TaskStateBase {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-set-cluster-termination-protection.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-set-cluster-termination-protection.ts
@@ -32,7 +32,7 @@ export interface EmrSetClusterTerminationProtectionJsonataProps extends sfn.Task
 export interface EmrSetClusterTerminationProtectionProps extends sfn.TaskStateBaseProps, EmrSetClusterTerminationProtectionOptions { }
 
 /**
- * A Step Functions Task to to set Termination Protection on an EMR Cluster.
+ * A Step Functions Task to set Termination Protection on an EMR Cluster.
  */
 export class EmrSetClusterTerminationProtection extends sfn.TaskStateBase {
   /**

--- a/packages/aws-cdk-lib/core/lib/assets.ts
+++ b/packages/aws-cdk-lib/core/lib/assets.ts
@@ -334,7 +334,7 @@ export interface DockerImageAssetSource {
 export enum FileAssetPackaging {
   /**
    * The asset source path points to a directory, which should be archived using
-   * zip and and then uploaded to Amazon S3.
+   * zip and then uploaded to Amazon S3.
    */
   ZIP_DIRECTORY = 'zip',
 


### PR DESCRIPTION
### Reason for this change

Fix duplicate word typos in source comments.

### Description of changes

Fixed various duplicate word typos across 8 files:
- "a the state machine" → "the state machine" (imagebuilder-alpha)
- "this is is" → "this is" (lambda, 2 occurrences)
- "Task to to set/modify" → "Task to set/modify" (stepfunctions-tasks, 5 occurrences)
- "and and then" → "and then" (core)
- "with with" → "with" (s3-deployment, kinesisanalytics-flink-alpha)

### Description of how you validated changes

Documentation-only change (source comments). No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*