### PR TITLE
docs: fix "a SSM" to "an SSM" in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/experimental/edge-function.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/experimental/edge-function.ts
@@ -225,7 +225,7 @@ export class EdgeFunction extends Resource implements lambda.IVersion {
     return { edgeFunction, edgeArn: edgeFunction.currentVersion.edgeArn };
   }
 
-  /** Create a support stack and function in us-east-1, and a SSM reader in-region */
+  /** Create a support stack and function in us-east-1, and an SSM reader in-region */
   private createCrossRegionFunction(id: string, props: EdgeFunctionProps): FunctionConfig {
     const parameterNamePrefix = 'cdk/EdgeFunctionArn';
     if (Token.isUnresolved(this.env.region)) {

--- a/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux-2022.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux-2022.ts
@@ -54,7 +54,7 @@ export interface AmazonLinux2022ImageSsmParameterProps extends AmazonLinuxImageS
  */
 export class AmazonLinux2022ImageSsmParameter extends AmazonLinuxImageSsmParameterBase {
   /**
-   * Generates a SSM Parameter name for a specific amazon linux 2022 AMI
+   * Generates an SSM Parameter name for a specific amazon linux 2022 AMI
    *
    * Example values:
    *

--- a/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux-2023.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux-2023.ts
@@ -53,7 +53,7 @@ export interface AmazonLinux2023ImageSsmParameterProps extends AmazonLinuxImageS
  */
 export class AmazonLinux2023ImageSsmParameter extends AmazonLinuxImageSsmParameterBase {
   /**
-   * Generates a SSM Parameter name for a specific amazon linux 2023 AMI
+   * Generates an SSM Parameter name for a specific amazon linux 2023 AMI
    *
    * Example values:
    *

--- a/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux2.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/machine-image/amazon-linux2.ts
@@ -71,7 +71,7 @@ export interface AmazonLinux2ImageSsmParameterProps extends AmazonLinuxImageSsmP
  */
 export class AmazonLinux2ImageSsmParameter extends AmazonLinuxImageSsmParameterBase {
   /**
-   * Generates a SSM Parameter name for a specific amazon linux 2 AMI
+   * Generates an SSM Parameter name for a specific amazon linux 2 AMI
    *
    * Example values:
    *

--- a/packages/aws-cdk-lib/aws-ecs/lib/credential-spec.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/credential-spec.ts
@@ -18,7 +18,7 @@ export class CredentialSpec {
   }
 
   /**
-   * Helper method to generate the ARN for a SSM parameter. Used to avoid duplication of logic in derived classes.
+   * Helper method to generate the ARN for an SSM parameter. Used to avoid duplication of logic in derived classes.
    */
   protected static arnForSsmParameter(parameter: IParameter) {
     return parameter.parameterArn;
@@ -70,7 +70,7 @@ export class DomainJoinedCredentialSpec extends CredentialSpec {
   }
 
   /**
-   * Loads the CredSpec from a SSM parameter.
+   * Loads the CredSpec from an SSM parameter.
    *
    * @param parameter The SSM parameter
    * @returns CredSpec with it's locations set to the SSM parameter's ARN.
@@ -100,7 +100,7 @@ export class DomainlessCredentialSpec extends CredentialSpec {
   }
 
   /**
-   * Loads the CredSpec from a SSM parameter.
+   * Loads the CredSpec from an SSM parameter.
    *
    * @param parameter The SSM parameter
    * @returns CredSpec with it's locations set to the SSM parameter's ARN.


### PR DESCRIPTION
### Reason for this change
Fix incorrect indefinite article. "SSM" starts with a vowel sound (/ɛs/).
### Description of changes
Fixed 5 occurrences of "a SSM" → "an SSM" across cloudfront, ec2, and ecs packages.
### Description of how you validated changes
Documentation-only change. No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*