### PR TITLE
docs: fix "a ACM" to "an ACM" in source comments

### DIFF
--- a/packages/aws-cdk-lib/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/aws-cdk-lib/aws-appmesh/lib/tls-certificate.ts
@@ -52,7 +52,7 @@ export abstract class MutualTlsCertificate extends TlsCertificate {
 }
 
 /**
- * Represents a ACM provided TLS certificate
+ * Represents an ACM provided TLS certificate
  */
 class AcmTlsCertificate extends TlsCertificate {
   /**

--- a/packages/aws-cdk-lib/aws-route53-patterns/lib/website-redirect.ts
+++ b/packages/aws-cdk-lib/aws-route53-patterns/lib/website-redirect.ts
@@ -135,7 +135,7 @@ export class HttpsRedirect extends Construct {
    * _any_ region. So I could create a CloudFront distribution in `us-east-2` if I wanted
    * to (maybe the rest of my application lives there). The problem is that some supporting resources
    * that CloudFront uses (i.e. ACM Certificates) are required to exist in `us-east-1`. This means
-   * that if I want to create a CloudFront distribution in `us-east-2` I still need to create a ACM certificate in
+   * that if I want to create a CloudFront distribution in `us-east-2` I still need to create an ACM certificate in
    * `us-east-1`.
    *
    * In order to do this correctly we need to know which region the CloudFront distribution is being created in.


### PR DESCRIPTION
### Reason for this change
Fix incorrect indefinite article. "ACM" starts with a vowel sound.
### Description of changes
Fixed 2 occurrences of "a ACM" → "an ACM" in appmesh and route53-patterns.
### Description of how you validated changes
Documentation-only change. No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*