### PR TITLE
docs(stepfunctions-tasks): fix "a EMR" to "an EMR" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/create-virtual-cluster.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/create-virtual-cluster.ts
@@ -72,19 +72,19 @@ interface EmrContainersCreateVirtualClusterOptions {
 }
 
 /**
- * Properties to define a EMR Containers CreateVirtualCluster Task using JSONPath on an EKS cluster
+ * Properties to define an EMR Containers CreateVirtualCluster Task using JSONPath on an EKS cluster
  *
  */
 export interface EmrContainersCreateVirtualClusterJsonPathProps extends sfn.TaskStateJsonPathBaseProps, EmrContainersCreateVirtualClusterOptions { }
 
 /**
- * Properties to define a EMR Containers CreateVirtualCluster Task using JSONata on an EKS cluster
+ * Properties to define an EMR Containers CreateVirtualCluster Task using JSONata on an EKS cluster
  *
  */
 export interface EmrContainersCreateVirtualClusterJsonataProps extends sfn.TaskStateJsonataBaseProps, EmrContainersCreateVirtualClusterOptions { }
 
 /**
- * Properties to define a EMR Containers CreateVirtualCluster Task on an EKS cluster
+ * Properties to define an EMR Containers CreateVirtualCluster Task on an EKS cluster
  */
 export interface EmrContainersCreateVirtualClusterProps extends sfn.TaskStateBaseProps, EmrContainersCreateVirtualClusterOptions { }
 

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/delete-virtual-cluster.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/delete-virtual-cluster.ts
@@ -12,17 +12,17 @@ interface EmrContainersDeleteVirtualClusterOptions {
 }
 
 /**
- * Properties to define a EMR Containers DeleteVirtualCluster Task using JSONPath
+ * Properties to define an EMR Containers DeleteVirtualCluster Task using JSONPath
  */
 export interface EmrContainersDeleteVirtualClusterJsonPathProps extends sfn.TaskStateJsonPathBaseProps, EmrContainersDeleteVirtualClusterOptions { }
 
 /**
- * Properties to define a EMR Containers DeleteVirtualCluster Task using JSONata
+ * Properties to define an EMR Containers DeleteVirtualCluster Task using JSONata
  */
 export interface EmrContainersDeleteVirtualClusterJsonataProps extends sfn.TaskStateJsonataBaseProps, EmrContainersDeleteVirtualClusterOptions { }
 
 /**
- * Properties to define a EMR Containers DeleteVirtualCluster Task
+ * Properties to define an EMR Containers DeleteVirtualCluster Task
  */
 export interface EmrContainersDeleteVirtualClusterProps extends sfn.TaskStateBaseProps, EmrContainersDeleteVirtualClusterOptions { }
 

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/start-job-run.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/start-job-run.ts
@@ -86,7 +86,7 @@ export interface EmrContainersStartJobRunJsonPathProps extends sfn.TaskStateJson
 export interface EmrContainersStartJobRunJsonataProps extends sfn.TaskStateJsonataBaseProps, EmrContainersStartJobRunOptions {}
 
 /**
- * The props for a EMR Containers StartJobRun Task.
+ * The props for an EMR Containers StartJobRun Task.
  */
 export interface EmrContainersStartJobRunProps extends sfn.TaskStateBaseProps, EmrContainersStartJobRunOptions {}
 
@@ -522,7 +522,7 @@ export interface JobDriver {
 }
 
 /**
- * The classification within a EMR Containers application configuration.
+ * The classification within an EMR Containers application configuration.
  * Class can be extended to add other classifications.
  * For example, new Classification('xxx-yyy');
  */


### PR DESCRIPTION
### Reason for this change
Fix incorrect indefinite article. "EMR" starts with a vowel sound.
### Description of changes
Fixed occurrences of "a EMR" → "an EMR" in stepfunctions-tasks emrcontainers.
### Description of how you validated changes
Documentation-only change. No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*