### PR TITLE
docs(stepfunctions-tasks): fix "a EKS" to "an EKS" in JSDoc comments

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/eks/call.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/eks/call.ts
@@ -36,28 +36,28 @@ interface EksCallOptions {
 }
 
 /**
- * Properties for calling a EKS endpoint with EksCall using JSONPath
+ * Properties for calling an EKS endpoint with EksCall using JSONPath
  */
 export interface EksCallJsonPathProps extends sfn.TaskStateJsonPathBaseProps, EksCallOptions { }
 
 /**
- * Properties for calling a EKS endpoint with EksCall using JSONata
+ * Properties for calling an EKS endpoint with EksCall using JSONata
  */
 export interface EksCallJsonataProps extends sfn.TaskStateJsonataBaseProps, EksCallOptions { }
 
 /**
- * Properties for calling a EKS endpoint with EksCall
+ * Properties for calling an EKS endpoint with EksCall
  */
 export interface EksCallProps extends sfn.TaskStateBaseProps, EksCallOptions { }
 
 /**
- * Call a EKS endpoint as a Task
+ * Call an EKS endpoint as a Task
  *
  * @see https://docs.aws.amazon.com/step-functions/latest/dg/connect-eks.html
  */
 export class EksCall extends sfn.TaskStateBase {
   /**
-   * Call a EKS endpoint as a Task that using JSONPath
+   * Call an EKS endpoint as a Task that using JSONPath
    *
    * @see https://docs.aws.amazon.com/step-functions/latest/dg/connect-eks.html
    */
@@ -66,7 +66,7 @@ export class EksCall extends sfn.TaskStateBase {
   }
 
   /**
-   * Call a EKS endpoint as a Task that using JSONata
+   * Call an EKS endpoint as a Task that using JSONata
    *
    * @see https://docs.aws.amazon.com/step-functions/latest/dg/connect-eks.html
    */
@@ -133,7 +133,7 @@ export class EksCall extends sfn.TaskStateBase {
 }
 
 /**
- * Method type of a EKS call
+ * Method type of an EKS call
  */
 export enum HttpMethods {
   /**

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/create-virtual-cluster.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emrcontainers/create-virtual-cluster.ts
@@ -11,7 +11,7 @@ import { integrationResourceArn, validatePatternSupported } from '../private/tas
 enum ContainerProviderTypes {
 
   /**
-   * Supported container provider type for a EKS Cluster
+   * Supported container provider type for an EKS Cluster
    */
   EKS = 'EKS',
 }


### PR DESCRIPTION
### Reason for this change
Fix incorrect indefinite article. "EKS" starts with a vowel sound.
### Description of changes
Fixed occurrences of "a EKS" → "an EKS" in stepfunctions-tasks (eks and emrcontainers).
### Description of how you validated changes
Documentation-only change. No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*