### PR TITLE
docs: fix "a SSM" to "an SSM" and "a EKS" to "an EKS" in README files

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1366,7 +1366,7 @@ new ec2.Instance(this, 'Instance5', {
 
 ### Latest Amazon Linux Images
 
-Rather than specifying a specific AMI ID to use, it is possible to specify a SSM
+Rather than specifying a specific AMI ID to use, it is possible to specify an SSM
 Parameter that contains the AMI ID. AWS publishes a set of [public parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html)
 that contain the latest Amazon Linux AMIs. To make it easier to query a
 particular image parameter, the CDK provides a couple of constructs `AmazonLinux2ImageSsmParameter`,

--- a/packages/aws-cdk-lib/aws-ecs/README.md
+++ b/packages/aws-cdk-lib/aws-ecs/README.md
@@ -735,7 +735,7 @@ taskDefinition.addContainer('windowsservercore', {
 
 Amazon ECS supports Active Directory authentication for Linux containers through a special kind of service account called a group Managed Service Account (gMSA). For more details, please see the [product documentation on how to implement on Windows containers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/windows-gmsa.html), or this [blog post on how to implement on  Linux containers](https://aws.amazon.com/blogs/containers/using-windows-authentication-with-gmsa-on-linux-containers-on-amazon-ecs/).
 
-There are two types of CredentialSpecs, domained-join or domainless. Both types support creation from a S3 bucket, a SSM parameter, or by directly specifying a location for the file in the constructor.
+There are two types of CredentialSpecs, domained-join or domainless. Both types support creation from a S3 bucket, an SSM parameter, or by directly specifying a location for the file in the constructor.
 
 A domian-joined gMSA container looks like:
 
@@ -744,7 +744,7 @@ A domian-joined gMSA container looks like:
 declare const parameter: ssm.IParameter;
 declare const taskDefinition: ecs.TaskDefinition;
 
-// Domain-joined gMSA container from a SSM parameter
+// Domain-joined gMSA container from an SSM parameter
 taskDefinition.addContainer('gmsa-domain-joined-container', {
   image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
   cpu: 128,

--- a/packages/aws-cdk-lib/aws-ssm/README.md
+++ b/packages/aws-cdk-lib/aws-ssm/README.md
@@ -42,7 +42,7 @@ You can also reference an existing SSM Parameter Store value that matches an
 ssm.StringParameter.valueForTypedStringParameterV2(this, '/My/Public/Parameter', ssm.ParameterValueType.AWS_EC2_IMAGE_ID);
 ```
 
-To do the same for a SSM Parameter Store value that is stored as a list:
+To do the same for an SSM Parameter Store value that is stored as a list:
 
 ```ts
 ssm.StringListParameter.valueForTypedListParameter(this, '/My/Public/Parameter', ssm.ParameterValueType.AWS_EC2_IMAGE_ID);
@@ -77,7 +77,7 @@ When using `valueFromLookup` an initial value of 'dummy-value-for-${parameterNam
 (`dummy-value-for-/My/Public/Parameter` in the above example)
 is returned prior to the lookup being performed. This can lead to errors if you are using this
 value in places that require a certain format. For example if you have stored the ARN for a SNS
-topic in a SSM Parameter which you want to lookup and provide to `Topic.fromTopicArn()`
+topic in an SSM Parameter which you want to lookup and provide to `Topic.fromTopicArn()`
 
 ```ts
 const arnLookup = ssm.StringParameter.valueFromLookup(this, '/my/topic/arn');

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -1440,7 +1440,7 @@ const myEksCluster = new eks.Cluster(this, 'my sample cluster', {
   kubectlLayer: new KubectlV35Layer(this, 'kubectl'),
 });
 
-new tasks.EksCall(this, 'Call a EKS Endpoint', {
+new tasks.EksCall(this, 'Call an EKS Endpoint', {
   cluster: myEksCluster,
   httpMethod: tasks.HttpMethods.GET,
   httpPath: '/api/v1/namespaces/default/pods',


### PR DESCRIPTION
### Reason for this change
Fix incorrect indefinite article in README files.
### Description of changes
- "a SSM" → "an SSM" in ec2, ecs, and ssm README files
- "a EKS" → "an EKS" in stepfunctions-tasks README
### Description of how you validated changes
Documentation-only change. No functional impact.
### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*