### PR TITLE
fix(events): validate against empty arrays in EventPattern at synth time

### DIFF
--- a/packages/aws-cdk-lib/aws-events/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/util.ts
@@ -68,6 +68,9 @@ export function renderEventPattern(eventPattern: EventPattern): any {
   const out: any = {};
   for (let key of Object.keys(eventPattern)) {
     const value = (eventPattern as any)[key];
+    if (Array.isArray(value) && value.length === 0) {
+      throw new UnscopedValidationError(lit`EventPatternEmptyArray`, `Invalid event pattern field '${key}': empty arrays are not allowed. EventBridge does not accept empty arrays in event patterns.`);
+    }
     if (key === 'detailType') {
       key = 'detail-type';
     }

--- a/packages/aws-cdk-lib/aws-events/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/util.test.ts
@@ -1,5 +1,5 @@
 import { assertNoPrototypePollution } from '../../core/test/prototype-pollution';
-import { mergeEventPattern } from '../lib/util';
+import { mergeEventPattern, renderEventPattern } from '../lib/util';
 
 describe('util', () => {
   describe('mergeEventPattern', () => {
@@ -93,6 +93,25 @@ describe('util', () => {
       assertNoPrototypePollution(() => {
         mergeEventPattern({}, { __proto__: { name: 'evil' } });
       });
+    });
+  });
+
+  describe('renderEventPattern', () => {
+    test('throws on empty array fields', () => {
+      expect(() => renderEventPattern({ source: ['my.source'], detailType: [] }))
+        .toThrow(/Invalid event pattern field 'detailType': empty arrays are not allowed/);
+    });
+
+    test('allows non-empty array fields', () => {
+      expect(renderEventPattern({ source: ['my.source'] })).toEqual({ source: ['my.source'] });
+    });
+
+    test('renames detailType to detail-type', () => {
+      expect(renderEventPattern({ detailType: ['foo'] })).toEqual({ 'detail-type': ['foo'] });
+    });
+
+    test('returns undefined for empty pattern', () => {
+      expect(renderEventPattern({})).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
### Issue

Closes #36904

### Reason for this change

EventBridge rejects empty arrays in event patterns, causing CloudFormation deployment failures at deploy time. CDK should catch this at synth time with a clear error message.

### Description of changes

Added validation in `renderEventPattern()` in `packages/aws-cdk-lib/aws-events/lib/util.ts` to throw an error when any array-typed field in the EventPattern is empty.

### Description of how you validated changes

The `Match` class already validates for non-empty collections (e.g., `Match.anythingBut()`), so there's precedent for this kind of validation in the same module.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)