### PR TITLE
fix(logs): correct metricIncomingLogEvents metric name from IncomingLogs to IncomingLogEvents

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/aws-cdk-log-group-metrics.assets.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/aws-cdk-log-group-metrics.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "38.0.1",
   "files": {
-    "71b53c3965d74bf965044819161cded75e176bd07805af4fceff5dcda7eab49e": {
+    "847009047bb0e46b399a3a7ed11c8e74cf0e0cc75357320e8b2dc36610d80327": {
       "source": {
         "path": "aws-cdk-log-group-metrics.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "71b53c3965d74bf965044819161cded75e176bd07805af4fceff5dcda7eab49e.json",
+          "objectKey": "847009047bb0e46b399a3a7ed11c8e74cf0e0cc75357320e8b2dc36610d80327.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/aws-cdk-log-group-metrics.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/aws-cdk-log-group-metrics.template.json
@@ -26,7 +26,7 @@
    "Properties": {
     "ComparisonOperator": "GreaterThanOrEqualToThreshold",
     "EvaluationPeriods": 1,
-    "MetricName": "IncomingLogs",
+    "MetricName": "IncomingLogEvents",
     "Namespace": "AWS/Logs",
     "Period": 300,
     "Statistic": "Sum",

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/manifest.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/manifest.json
@@ -19,7 +19,7 @@
         "notificationArns": [],
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/71b53c3965d74bf965044819161cded75e176bd07805af4fceff5dcda7eab49e.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/847009047bb0e46b399a3a7ed11c8e74cf0e0cc75357320e8b2dc36610d80327.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/tree.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-logs/test/integ.log-group-metrics.js.snapshot/tree.json
@@ -75,7 +75,7 @@
                   "aws:cdk:cloudformation:props": {
                     "comparisonOperator": "GreaterThanOrEqualToThreshold",
                     "evaluationPeriods": 1,
-                    "metricName": "IncomingLogs",
+                    "metricName": "IncomingLogEvents",
                     "namespace": "AWS/Logs",
                     "period": 300,
                     "statistic": "Sum",

--- a/packages/aws-cdk-lib/aws-events-targets/test/logs/log-group.test.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/test/logs/log-group.test.ts
@@ -551,7 +551,7 @@ test('metricIncomingLogEvents', () => {
       unit: { label: 'minutes', inMillis: 60000, isoLabel: 'M' },
     },
     namespace: 'AWS/Logs',
-    metricName: 'IncomingLogs',
+    metricName: 'IncomingLogEvents',
     statistic: 'Sum',
   });
 });
@@ -572,7 +572,7 @@ test('metricIncomingLogEvents with MetricOptions props', () => {
       unit: { label: 'hours', inMillis: 3600000, isoLabel: 'H' },
     },
     namespace: 'AWS/Logs',
-    metricName: 'IncomingLogs',
+    metricName: 'IncomingLogEvents',
     statistic: 'Sum',
     label: 'MyMetric',
   });

--- a/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
@@ -343,7 +343,7 @@ abstract class LogGroupBase extends Resource implements ILogGroup {
    * ```
    */
   public metricIncomingLogEvents(props?: cloudwatch.MetricOptions): cloudwatch.Metric {
-    return this.metric('IncomingLogs', props);
+    return this.metric('IncomingLogEvents', props);
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
+++ b/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
@@ -339,6 +339,26 @@ describe('log group', () => {
     expect(metric.metricName).toEqual('Field');
   });
 
+  test('metricIncomingLogEvents uses correct metric name', () => {
+    const stack = new Stack();
+    const lg = new LogGroup(stack, 'LogGroup');
+
+    const metric = lg.metricIncomingLogEvents();
+
+    expect(metric.metricName).toEqual('IncomingLogEvents');
+    expect(metric.namespace).toEqual('AWS/Logs');
+  });
+
+  test('metricIncomingBytes uses correct metric name', () => {
+    const stack = new Stack();
+    const lg = new LogGroup(stack, 'LogGroup');
+
+    const metric = lg.metricIncomingBytes();
+
+    expect(metric.metricName).toEqual('IncomingBytes');
+    expect(metric.namespace).toEqual('AWS/Logs');
+  });
+
   test('extractMetric allows passing in namespaces with "/"', () => {
     // GIVEN
     const stack = new Stack();


### PR DESCRIPTION
### Issue

Closes #36815

### Reason for this change

The `metricIncomingLogEvents()` method was using `'IncomingLogs'` as the metric name, but the correct CloudWatch metric name per [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch-Logs-Monitoring-CloudWatch-Metrics.html) is `'IncomingLogEvents'`. This caused alarms created with this method to have no datapoints.

### Description of changes

Changed the metric name from `'IncomingLogs'` to `'IncomingLogEvents'` in `LogGroup.metricIncomingLogEvents()`.

### Description of how you validated changes

Verified against the [AWS CloudWatch Logs metrics documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch-Logs-Monitoring-CloudWatch-Metrics.html).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)