### PR TITLE
fix(kms): `Alias.fromAliasName` now adds 'alias/' prefix when missing

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/lib/alias.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/alias.ts
@@ -246,10 +246,14 @@ export class Alias extends AliasBase {
    * @param aliasName The full name of the KMS Alias (e.g., 'alias/aws/s3', 'alias/myKeyAlias').
    */
   public static fromAliasName(scope: Construct, id: string, aliasName: string): IAlias {
+    const normalizedAliasName = !Token.isUnresolved(aliasName) && !aliasName.startsWith(REQUIRED_ALIAS_PREFIX)
+      ? REQUIRED_ALIAS_PREFIX + aliasName
+      : aliasName;
+
     class Import extends Resource implements IAlias {
-      public readonly keyArn = Stack.of(this).formatArn({ service: 'kms', resource: aliasName });
-      public readonly keyId = aliasName;
-      public readonly aliasName = aliasName;
+      public readonly keyArn = Stack.of(this).formatArn({ service: 'kms', resource: normalizedAliasName });
+      public readonly keyId = normalizedAliasName;
+      public readonly aliasName = normalizedAliasName;
       public get aliasTargetKey(): IKey { throw new ValidationError(lit`CannotAccessAliasTargetKey`, 'Cannot access aliasTargetKey on an Alias imported by Alias.fromAliasName().', this); }
       public addAlias(_alias: string): Alias { throw new ValidationError(lit`CannotAddAliasToImported`, 'Cannot call addAlias on an Alias imported by Alias.fromAliasName().', this); }
       public addToResourcePolicy(_statement: iam.PolicyStatement, _allowNoOp?: boolean): iam.AddToResourcePolicyResult {

--- a/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
@@ -214,6 +214,22 @@ test('imported alias by name - will throw an error when accessing the key', () =
   expect(() => myAlias.aliasTargetKey).toThrow('Cannot access aliasTargetKey on an Alias imported by Alias.fromAliasName().');
 });
 
+test('imported alias by name - adds alias/ prefix when missing', () => {
+  const stack = new Stack();
+
+  const myAlias = Alias.fromAliasName(stack, 'MyAlias', 'myAlias');
+
+  expect(myAlias.aliasName).toEqual('alias/myAlias');
+});
+
+test('imported alias by name - does not double-prefix alias/', () => {
+  const stack = new Stack();
+
+  const myAlias = Alias.fromAliasName(stack, 'MyAlias', 'alias/myAlias');
+
+  expect(myAlias.aliasName).toEqual('alias/myAlias');
+});
+
 test('imported alias by name - grantDecrypt applies kms:ResourceAliases condition', () => {
   const stack = new Stack();
   stack.node.setContext(KMS_APPLY_IMPORTED_ALIAS_PERMISSIONS_TO_PRINCIPAL, true);


### PR DESCRIPTION
### Issue

Closes #36693

### Reason for this change

`Alias.fromAliasName` did not add the required `alias/` prefix to the alias name, unlike the `Alias` constructor. This caused inconsistent behavior:

```ts
Alias.fromAliasName(this, 'Foo', 'my-alias-name').aliasName; // 'my-alias-name'
new Alias(this, 'FooNew', { aliasName: 'my-alias-name' }).aliasName; // 'alias/my-alias-name'
```

### Description of changes

Added normalization logic in `fromAliasName` to prepend `alias/` when the provided name doesn't already start with it (and is not a token).

### Description of how you validated changes

Consistent with the existing normalization in the `Alias` constructor.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)