### PR TITLE
fix(elbv2): dropInvalidHeaderFields now reflected in CloudFormation when set to false

### DIFF
--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
@@ -229,7 +229,7 @@ export class ApplicationLoadBalancer extends BaseLoadBalancer implements IApplic
 
     if (props.http2Enabled !== undefined) { this.setAttribute('routing.http2.enabled', props.http2Enabled ? 'true' : 'false'); }
     if (props.idleTimeout !== undefined) { this.setAttribute('idle_timeout.timeout_seconds', props.idleTimeout.toSeconds().toString()); }
-    if (props.dropInvalidHeaderFields) { this.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true'); }
+    if (props.dropInvalidHeaderFields !== undefined) { this.setAttribute('routing.http.drop_invalid_header_fields.enabled', props.dropInvalidHeaderFields ? 'true' : 'false'); }
     if (props.desyncMitigationMode !== undefined) { this.setAttribute('routing.http.desync_mitigation_mode', props.desyncMitigationMode); }
     if (props.preserveHostHeader) { this.setAttribute('routing.http.preserve_host_header.enabled', 'true'); }
     if (props.xAmznTlsVersionAndCipherSuiteHeaders) { this.setAttribute('routing.http.x_amzn_tls_version_and_cipher_suite.enabled', 'true'); }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
@@ -173,6 +173,25 @@ describe('tests', () => {
     });
   });
 
+  test('dropInvalidHeaderFields set to false emits attribute', () => {
+    const stack = new cdk.Stack();
+    const vpc = new ec2.Vpc(stack, 'Stack');
+
+    new elbv2.ApplicationLoadBalancer(stack, 'LB', {
+      vpc,
+      dropInvalidHeaderFields: false,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      LoadBalancerAttributes: Match.arrayWith([
+        {
+          Key: 'routing.http.drop_invalid_header_fields.enabled',
+          Value: 'false',
+        },
+      ]),
+    });
+  });
+
   test.each([59, 604801])('throw error for invalid clientKeepAlive in seconds', (duration) => {
     // GIVEN
     const stack = new cdk.Stack();


### PR DESCRIPTION
### Issue

Closes #36409

### Reason for this change

When changing `dropInvalidHeaderFields` from `true` to `false`, the attribute was omitted from the CloudFormation template because the condition only checked for truthiness (`if (props.dropInvalidHeaderFields)`). This meant the ALB configuration was not updated during a stack update.

### Description of changes

Changed the condition from `if (props.dropInvalidHeaderFields)` to `if (props.dropInvalidHeaderFields !== undefined)` and emit the correct string value (`'true'` or `'false'`).

### Description of how you validated changes

This follows the same pattern used by other boolean properties like `http2Enabled` in the same file.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)