### PR TITLE
feat(ec2): add C8a (InstanceClass.C8A) to available instance classes

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1362,6 +1362,13 @@ new ec2.Instance(this, 'Instance5', {
     cpuType: ec2.AmazonLinuxCpuType.ARM_64,
   }),
 });
+
+// Compute optimized instances with 5th generation AMD EPYC processors
+new ec2.Instance(this, 'Instance6', {
+  vpc,
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.C8A, ec2.InstanceSize.LARGE),
+  machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+});
 ```
 
 ### Latest Amazon Linux Images

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance-types.ts
@@ -794,6 +794,16 @@ export enum InstanceClass {
   C7A = 'c7a',
 
   /**
+   * Compute optimized instances based on 5th generation AMD EPYC processors, 8th generation
+   */
+  COMPUTE8_AMD = 'compute8-amd',
+
+  /**
+   * Compute optimized instances based on 5th generation AMD EPYC processors, 8th generation
+   */
+  C8A = 'c8a',
+
+  /**
    * Storage-optimized instances, 2nd generation
    */
   STORAGE2 = 'storage2',
@@ -1972,6 +1982,8 @@ export class InstanceType {
       [InstanceClass.C7I_FLEX]: 'c7i-flex',
       [InstanceClass.COMPUTE7_AMD]: 'c7a',
       [InstanceClass.C7A]: 'c7a',
+      [InstanceClass.COMPUTE8_AMD]: 'c8a',
+      [InstanceClass.C8A]: 'c8a',
       [InstanceClass.COMPUTE8_GRAVITON4]: 'c8g',
       [InstanceClass.C8G]: 'c8g',
       [InstanceClass.COMPUTE8_GRAVITON4_NVME_DRIVE]: 'c8gd',

--- a/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/instance-type.test.ts
@@ -5,4 +5,14 @@ describe('InstanceType', () => {
     const instanceType = InstanceType.of(InstanceClass.MAC2_M1ULTRA, InstanceSize.METAL);
     expect(instanceType.toString()).toEqual('mac2-m1ultra.metal');
   });
+
+  test('c8a instance class', () => {
+    const instanceType = InstanceType.of(InstanceClass.C8A, InstanceSize.XLARGE);
+    expect(instanceType.toString()).toEqual('c8a.xlarge');
+  });
+
+  test('compute8_amd instance class', () => {
+    const instanceType = InstanceType.of(InstanceClass.COMPUTE8_AMD, InstanceSize.LARGE);
+    expect(instanceType.toString()).toEqual('c8a.large');
+  });
 });


### PR DESCRIPTION
### Issue

Closes #36722

### Reason for this change

The C8a instance class (compute-optimized, based on 5th generation AMD EPYC processors) is available on AWS but was missing from the CDK `InstanceClass` enum.

### Description of changes

- Added `COMPUTE8_AMD` and `C8A` enum values to `InstanceClass`
- Added corresponding entries in the instance class mapping table

### Description of how you validated changes

Follows the same pattern as other instance class additions (e.g., C7A, C8G, C8I).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)