### PR TITLE
fix(redshift-alpha): replace deprecated Provider role with frameworkOnEventRole

### DIFF
--- a/packages/@aws-cdk/aws-redshift-alpha/lib/private/database-query.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/lib/private/database-query.ts
@@ -65,7 +65,7 @@ export class DatabaseQuery<HandlerProps> extends Construct implements iam.IGrant
 
     const provider = new customresources.Provider(this, 'Provider', {
       onEventHandler: handler,
-      role: this.getOrCreateInvokerRole(handler),
+      frameworkOnEventRole: this.getOrCreateInvokerRole(handler),
     });
 
     const queryHandlerProps: DatabaseQueryHandlerProps & HandlerProps = {

--- a/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
@@ -251,4 +251,18 @@ describe('database query', () => {
 
     expect(iamRoles.length === 1);
   });
+
+  it('does not use deprecated Provider role property', () => {
+    new DatabaseQuery(stack, 'Query', {
+      ...minimalProps,
+    });
+
+    // The framework onEvent Lambda should use the invoker role
+    Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+      Description: Match.stringLikeRegexp('framework-onEvent'),
+      Role: Match.objectLike({
+        'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('InvokerRole')]),
+      }),
+    });
+  });
 });

--- a/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/test/database-query.test.ts
@@ -259,7 +259,7 @@ describe('database query', () => {
 
     // The framework onEvent Lambda should use the invoker role
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
-      Description: Match.stringLikeRegexp('framework-onEvent'),
+      Description: Match.stringLikeRegexp('onEvent'),
       Role: Match.objectLike({
         'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('InvokerRole')]),
       }),


### PR DESCRIPTION
### Issue

Closes #37006

### Reason for this change

The `DatabaseQuery` construct in `aws-redshift-alpha` was using the deprecated `role` property on `custom_resources.Provider`, which triggers deprecation warnings during synthesis:

```
[WARNING] aws-cdk-lib.custom_resources.ProviderProps#role is deprecated
```

### Description of changes

Replaced `role` with `frameworkOnEventRole` in the `Provider` constructor call in `database-query.ts`. Since the Redshift `DatabaseQuery` construct does not use `isCompleteHandler`, only the `frameworkOnEventRole` is needed (no `frameworkCompleteAndTimeoutRole` required).

The behavior is functionally equivalent — the same IAM role is assigned to the framework's onEvent Lambda function.

### Description of how you validated changes

- `frameworkOnEventRole` is the documented replacement for the deprecated `role` property
- The `Provider` implementation shows that `role` and `frameworkOnEventRole` are applied to the same Lambda function via `this.role ?? role` in `createFunction()`
- No `isCompleteHandler` is used, so only the onEvent role is relevant

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)