### PR TITLE
fix(stepfunctions): warn when timeout is used with non-chainable definition body

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
@@ -13,7 +13,7 @@ import * as iam from '../../aws-iam';
 import type * as logs from '../../aws-logs';
 import * as s3_assets from '../../aws-s3-assets';
 import type { Duration, IResource } from '../../core';
-import { ArnFormat, RemovalPolicy, Resource, Stack, Token, ValidationError } from '../../core';
+import { Annotations, ArnFormat, RemovalPolicy, Resource, Stack, Token, ValidationError } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { lit } from '../../core/lib/private/literal-string';
@@ -126,6 +126,10 @@ export interface StateMachineProps {
 
   /**
    * Maximum run time for this state machine
+   *
+   * This property is only applied when the definition is provided via `DefinitionBody.fromChainable()`.
+   * If you provide a definition via `DefinitionBody.fromString()` or `DefinitionBody.fromFile()`,
+   * set the timeout directly in your ASL definition using `TimeoutSeconds`.
    *
    * @default No timeout
    */
@@ -488,6 +492,8 @@ export class StateMachine extends StateMachineBase {
       for (const statement of graph.policyStatements) {
         this.addToRolePolicy(statement);
       }
+    } else if (props.timeout) {
+      Annotations.of(this).addWarningV2('@aws-cdk/aws-stepfunctions:timeoutIgnored', 'The \'timeout\' property is only applied when using DefinitionBody.fromChainable(). Set \'TimeoutSeconds\' directly in your ASL definition instead.');
     }
 
     if (props.encryptionConfiguration instanceof CustomerManagedEncryptionConfiguration) {

--- a/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine.test.ts
@@ -1,5 +1,5 @@
 import { FakeTask } from './private/fake-task';
-import { Match, Template } from '../../assertions';
+import { Annotations, Match, Template } from '../../assertions';
 import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
 import * as logs from '../../aws-logs';
@@ -1530,5 +1530,27 @@ describe('State Machine', () => {
         Type: 'AWS_OWNED_KEY',
       }),
     });
+  });
+
+  test('warns when timeout is used with non-ChainDefinitionBody', () => {
+    const stack = new cdk.Stack();
+
+    new sfn.StateMachine(stack, 'MyStateMachine', {
+      definitionBody: sfn.DefinitionBody.fromString('{"StartAt":"Pass","States":{"Pass":{"Type":"Pass","End":true}}}'),
+      timeout: cdk.Duration.hours(1),
+    });
+
+    Annotations.fromStack(stack).hasWarning('/Default/MyStateMachine', Match.stringLikeRegexp('timeout.*only applied.*fromChainable'));
+  });
+
+  test('does not warn when timeout is used with ChainDefinitionBody', () => {
+    const stack = new cdk.Stack();
+
+    new sfn.StateMachine(stack, 'MyStateMachine', {
+      definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, 'Pass')),
+      timeout: cdk.Duration.hours(1),
+    });
+
+    Annotations.fromStack(stack).hasNoWarning('/Default/MyStateMachine', Match.anyValue());
   });
 });


### PR DESCRIPTION
### Issue

Closes #37150

### Reason for this change

The `timeout` property on `StateMachine` is only applied when the definition is provided via `DefinitionBody.fromChainable()`. When using `fromString()` or `fromFile()` (e.g., `.asl.json`), the timeout is silently ignored, which can cause unexpected behavior.

### Description of changes

1. Added a warning annotation when `timeout` is specified with a non-`ChainDefinitionBody` definition, guiding users to set `TimeoutSeconds` directly in their ASL definition.
2. Updated the JSDoc for the `timeout` property to clarify this behavior.

### Description of how you validated changes

Added unit tests verifying:
- A warning is emitted when `timeout` is used with `DefinitionBody.fromString()`
- No warning is emitted when `timeout` is used with `DefinitionBody.fromChainable()`

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

Exemption Request: This change adds a warning annotation and JSDoc update, not a CloudFormation resource change, so an integration test is not applicable.