### PR TITLE
feat(bedrock): add Amazon Nova 2 Lite foundation model identifier

### DIFF
--- a/packages/aws-cdk-lib/aws-bedrock/README.md
+++ b/packages/aws-cdk-lib/aws-bedrock/README.md
@@ -18,6 +18,18 @@ bedrock.FoundationModel.fromFoundationModelId(
 );
 ```
 
+To look up an Amazon Nova model:
+
+```ts
+import * as bedrock from 'aws-cdk-lib/aws-bedrock';
+
+bedrock.FoundationModel.fromFoundationModelId(
+  this,
+  'NovaModel',
+  bedrock.FoundationModelIdentifier.AMAZON_NOVA_2_LITE_V1_0,
+);
+```
+
 To look up a Bedrock provisioned throughput model:
 
 ```ts

--- a/packages/aws-cdk-lib/aws-bedrock/lib/foundation-model.ts
+++ b/packages/aws-cdk-lib/aws-bedrock/lib/foundation-model.ts
@@ -98,6 +98,9 @@ export class FoundationModelIdentifier {
   /** amazon.nova-2-multimodal-embeddings-v1:0 */
   public static readonly AMAZON_NOVA_2_MULTIMODAL_EMBEDDINGS_V1_0 = new FoundationModelIdentifier('amazon.nova-2-multimodal-embeddings-v1:0');
 
+  /** Base model "amazon.nova-2-lite-v1:0". */
+  public static readonly AMAZON_NOVA_2_LITE_V1_0 = new FoundationModelIdentifier('amazon.nova-2-lite-v1:0');
+
   /**
    * Base model "ai21.j2-mid".
    * @deprecated use latest version of the model

--- a/packages/aws-cdk-lib/aws-bedrock/test/model.test.ts
+++ b/packages/aws-cdk-lib/aws-bedrock/test/model.test.ts
@@ -38,4 +38,15 @@ describe('FoundationModel', () => {
     // THEN
     expect(stack.resolve(model.modelArn)).toEqual({ 'Fn::Join': ['', ['arn:', { 'Ref': 'AWS::Partition' }, ':bedrock:', { 'Ref': 'AWS::Region' }, '::foundation-model/new-base-model']] });
   });
+
+  test('fromFoundationModelId with Amazon Nova 2 Lite', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    const model = bedrock.FoundationModel.fromFoundationModelId(stack, 'Model', bedrock.FoundationModelIdentifier.AMAZON_NOVA_2_LITE_V1_0);
+
+    // THEN
+    expect(stack.resolve(model.modelArn)).toEqual({ 'Fn::Join': ['', ['arn:', { 'Ref': 'AWS::Partition' }, ':bedrock:', { 'Ref': 'AWS::Region' }, '::foundation-model/amazon.nova-2-lite-v1:0']] });
+  });
 });


### PR DESCRIPTION
Closes #36909

Adds AMAZON_NOVA_2_LITE_V1_0 (amazon.nova-2-lite-v1:0) to FoundationModelIdentifier.

Exemption Request: Adding a static constant to an enum does not require integration tests.