### PR TITLE
fix(cloudwatch): add missing liveData property to SingleValueWidget output

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
@@ -938,6 +938,7 @@ export class SingleValueWidget extends ConcreteWidget {
         metrics: allMetricsGraphJson(this.props.metrics, []),
         setPeriodToTimeRange: this.props.setPeriodToTimeRange,
         singleValueFullPrecision: this.props.fullPrecision,
+        liveData: this.props.liveData,
         period: this.props.period?.toSeconds(),
         start: this.props.start,
         end: this.props.end,

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/graph.ts
@@ -882,6 +882,13 @@ export interface SingleValueWidgetProps extends MetricWidgetProps {
   readonly sparkline?: boolean;
 
   /**
+   * Whether the graph should show live data
+   *
+   * @default false
+   */
+  readonly liveData?: boolean;
+
+  /**
    * The start of the time range to use for each widget independently from those of the dashboard.
    * You can specify start without specifying end to specify a relative time range that ends with the current time.
    * In this case, the value of start must begin with -P, and you can use M, H, D, W and M as abbreviations for

--- a/packages/aws-cdk-lib/aws-cloudwatch/test/graphs.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/test/graphs.test.ts
@@ -756,6 +756,19 @@ describe('Graphs', () => {
     }]);
   });
 
+  test('add liveData to singleValueWidget', () => {
+    const widget = new SingleValueWidget({
+      metrics: [new Metric({ namespace: 'CDK', metricName: 'Test' })],
+      liveData: true,
+    });
+
+    expect(widget.toJson()).toEqual([expect.objectContaining({
+      properties: expect.objectContaining({
+        liveData: true,
+      }),
+    })]);
+  });
+
   test('throws if setPeriodToTimeRange and sparkline is set on singleValueWidget', () => {
     // GIVEN
     new Stack();


### PR DESCRIPTION
Closes #36915

The liveData property was defined in SingleValueWidgetProps but not included in toJson() output, making it impossible to enable live data on SingleValueWidget dashboards.

Exemption Request: Widget JSON output change, covered by unit test.