### PR TITLE
fix(eks): truncate kubectl error messages to fit CloudFormation 4KB response limit

### DIFF
--- a/packages/@aws-cdk/custom-resource-handlers/lib/aws-eks-v2/kubectl-handler/apply/__init__.py
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/aws-eks-v2/kubectl-handler/apply/__init__.py
@@ -86,8 +86,16 @@ def kubectl(verb, file, *opts):
                 retry = retry - 1
                 logger.info("kubectl timed out, retries left: %s" % retry)
             else:
-                raise Exception(output)
+                raise Exception(_truncate_output(output))
         else:
             logger.info(output)
             return
-    raise Exception(f'Operation failed after {maxAttempts} attempts: {output}')
+    raise Exception(f'Operation failed after {maxAttempts} attempts: {_truncate_output(output)}')
+
+
+def _truncate_output(output, max_len=3000):
+    """Truncate output to fit within CloudFormation's 4KB response limit."""
+    s = output.decode('utf-8', errors='replace') if isinstance(output, bytes) else str(output)
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + f'\n... truncated ({len(s)} chars total). See CloudWatch logs for full output.'

--- a/packages/@aws-cdk/custom-resource-handlers/lib/aws-eks/kubectl-handler/apply/__init__.py
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/aws-eks/kubectl-handler/apply/__init__.py
@@ -88,8 +88,16 @@ def kubectl(verb, file, *opts):
                 retry = retry - 1
                 logger.info("kubectl timed out, retries left: %s" % retry)
             else:
-                raise Exception(output)
+                raise Exception(_truncate_output(output))
         else:
             logger.info(output)
             return
-    raise Exception(f'Operation failed after {maxAttempts} attempts: {output}')
+    raise Exception(f'Operation failed after {maxAttempts} attempts: {_truncate_output(output)}')
+
+
+def _truncate_output(output, max_len=3000):
+    """Truncate output to fit within CloudFormation's 4KB response limit."""
+    s = output.decode('utf-8', errors='replace') if isinstance(output, bytes) else str(output)
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + f'\n... truncated ({len(s)} chars total). See CloudWatch logs for full output.'


### PR DESCRIPTION
Closes #37353

When kubectl apply fails, Kubernetes includes the entire object in its error output, often exceeding CloudFormation's 4KB custom resource response limit. Truncate error output to 3000 chars and direct users to CloudWatch logs.

Exemption Request: Python handler change in custom resource, not testable via integration test.