### PR TITLE
docs(cloudfront): add India to PriceClass.PRICE_CLASS_200 documentation

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -913,7 +913,7 @@ export enum HttpVersion {
 export enum PriceClass {
   /** USA, Canada, Europe, & Israel */
   PRICE_CLASS_100 = 'PriceClass_100',
-  /** PRICE_CLASS_100 + South Africa, Kenya, Middle East, Japan, Singapore, South Korea, Taiwan, Hong Kong, & Philippines */
+  /** PRICE_CLASS_100 + South Africa, Kenya, Middle East, India, Japan, Singapore, South Korea, Taiwan, Hong Kong, & Philippines */
   PRICE_CLASS_200 = 'PriceClass_200',
   /** All locations */
   PRICE_CLASS_ALL = 'PriceClass_All',


### PR DESCRIPTION
Closes #35992

India is included in PRICE_CLASS_200 per AWS CloudFront pricing page but was missing from the JSDoc comment.

Exemption Request: Documentation-only change.