### PR TITLE
fix(certificatemanager): apexDomain returns incorrect results for domains colliding with Object.prototype

### DIFF
--- a/packages/aws-cdk-lib/aws-certificatemanager/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-certificatemanager/lib/util.ts
@@ -14,7 +14,7 @@ export function apexDomain(domainName: string): string {
   const accumulated: string[] = [];
   for (const part of parts) {
     accumulated.push(part);
-    if (!(part in curr)) { break; }
+    if (!Object.prototype.hasOwnProperty.call(curr, part)) { break; }
     curr = curr[part];
   }
   return accumulated.reverse().join('.');

--- a/packages/aws-cdk-lib/aws-certificatemanager/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-certificatemanager/test/util.test.ts
@@ -13,6 +13,12 @@ describe('apex domain', () => {
   test('understands eTLDs', () => {
     expect(apexDomain('test.domain.co.uk')).toEqual('domain.co.uk');
   });
+
+  test('handles domains colliding with Object.prototype methods', () => {
+    expect(apexDomain('www.toString.com')).toEqual('toString.com');
+    expect(apexDomain('www.hasOwnProperty.com')).toEqual('hasOwnProperty.com');
+    expect(apexDomain('www.valueOf.com')).toEqual('valueOf.com');
+  });
 });
 
 describe('isDnsValidatedCertificate', () => {


### PR DESCRIPTION
Closes #37193

The apexDomain utility used the 'in' operator which traverses the prototype chain. Domains like 'www.toString.com' were incorrectly classified. Replaced with Object.prototype.hasOwnProperty.call().

Exemption Request: Utility function fix, covered by unit test.