### PR TITLE
fix(ec2): update EBS io2 and gp3 max volume size to 64 TiB

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/volume.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/volume.ts
@@ -824,9 +824,9 @@ export class Volume extends VolumeBase {
       // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-volume.html
       const sizeRanges: { [key: string]: { Min: number; Max: number } } = {};
       sizeRanges[EbsDeviceVolumeType.GENERAL_PURPOSE_SSD] = { Min: 1, Max: 16384 };
-      sizeRanges[EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3] = { Min: 1, Max: 16384 };
+      sizeRanges[EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3] = { Min: 1, Max: 65536 };
       sizeRanges[EbsDeviceVolumeType.PROVISIONED_IOPS_SSD] = { Min: 4, Max: 16384 };
-      sizeRanges[EbsDeviceVolumeType.PROVISIONED_IOPS_SSD_IO2] = { Min: 4, Max: 16384 };
+      sizeRanges[EbsDeviceVolumeType.PROVISIONED_IOPS_SSD_IO2] = { Min: 4, Max: 65536 };
       sizeRanges[EbsDeviceVolumeType.THROUGHPUT_OPTIMIZED_HDD] = { Min: 125, Max: 16384 };
       sizeRanges[EbsDeviceVolumeType.COLD_HDD] = { Min: 125, Max: 16384 };
       sizeRanges[EbsDeviceVolumeType.MAGNETIC] = { Min: 1, Max: 1024 };

--- a/packages/aws-cdk-lib/aws-ec2/test/volume.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/volume.test.ts
@@ -1416,9 +1416,9 @@ describe('volume', () => {
     // THEN
     for (const testData of [
       [EbsDeviceVolumeType.GENERAL_PURPOSE_SSD, 1, 16384],
-      [EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3, 1, 16384],
+      [EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3, 1, 65536],
       [EbsDeviceVolumeType.PROVISIONED_IOPS_SSD, 4, 16384],
-      [EbsDeviceVolumeType.PROVISIONED_IOPS_SSD_IO2, 4, 16384],
+      [EbsDeviceVolumeType.PROVISIONED_IOPS_SSD_IO2, 4, 65536],
       [EbsDeviceVolumeType.THROUGHPUT_OPTIMIZED_HDD, 125, 16384],
       [EbsDeviceVolumeType.COLD_HDD, 125, 16384],
       [EbsDeviceVolumeType.MAGNETIC, 1, 1024],


### PR DESCRIPTION
Closes #37045
AWS increased the maximum volume size for gp3 and io2 to 64 TiB (65536 GiB). CDK validation was incorrectly limiting these to 16 TiB.
Exemption Request: Validation constant change, no integration test needed.