### PR TITLE
fix(core): assign result of string concat for cdk migrate telemetry

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/metadata-resource.ts
+++ b/packages/aws-cdk-lib/core/lib/private/metadata-resource.ts
@@ -122,12 +122,12 @@ export function formatAnalytics(infos: ConstructAnalytics[]) {
   setGzipOperatingSystemToUnknown(compressedConstructsBuffer);
 
   const compressedConstructs = compressedConstructsBuffer.toString('base64');
-  const analyticsString = `v2:deflate64:${compressedConstructs}`;
+  let analyticsString = `v2:deflate64:${compressedConstructs}`;
 
   if (process.env.CDK_CONTEXT_JSON && JSON.parse(process.env.CDK_CONTEXT_JSON)['cdk-migrate']) {
     const compressedAppInfoBuffer = zlib.gzipSync(Buffer.from('cdk-migrate'));
     const compressedAppInfo = compressedAppInfoBuffer.toString('base64');
-    analyticsString.concat(':', compressedAppInfo);
+    analyticsString = analyticsString.concat(':', compressedAppInfo);
   }
 
   return analyticsString;

--- a/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
+++ b/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
@@ -10,6 +10,7 @@ import { JSII_RUNTIME_SYMBOL } from '../lib/constants';
 import { MetadataType } from '../lib/metadata-type';
 import { formatAnalytics, parseAnalytics } from '../lib/private/metadata-resource';
 import type { ConstructInfo } from '../lib/private/runtime-info';
+import type { ConstructAnalytics } from '../lib/private/stack-metadata';
 import { constructAnalyticsFromScope } from '../lib/private/stack-metadata';
 
 describe('MetadataResource', () => {
@@ -349,7 +350,7 @@ test('formatAnalytics appends cdk-migrate info when CDK_CONTEXT_JSON is set', ()
   const original = process.env.CDK_CONTEXT_JSON;
   try {
     process.env.CDK_CONTEXT_JSON = JSON.stringify({ 'cdk-migrate': true });
-    const constructInfo: ConstructAnalytics[] = [{ fqn: 'aws-cdk-lib.Stack', version: '0.0.0', count: 1 }];
+    const constructInfo: ConstructAnalytics[] = [{ fqn: 'aws-cdk-lib.Stack', version: '0.0.0' }];
     const result = formatAnalytics(constructInfo);
     // Should have 3 colon-separated parts: v2:deflate64:<constructs>:<migrate-info>
     expect(result.split(':').length).toBe(4);

--- a/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
+++ b/packages/aws-cdk-lib/core/test/metadata-resource.test.ts
@@ -344,3 +344,20 @@ class ValidationPlugin implements IPolicyValidationPluginBeta1 {
     };
   }
 }
+
+test('formatAnalytics appends cdk-migrate info when CDK_CONTEXT_JSON is set', () => {
+  const original = process.env.CDK_CONTEXT_JSON;
+  try {
+    process.env.CDK_CONTEXT_JSON = JSON.stringify({ 'cdk-migrate': true });
+    const constructInfo: ConstructAnalytics[] = [{ fqn: 'aws-cdk-lib.Stack', version: '0.0.0', count: 1 }];
+    const result = formatAnalytics(constructInfo);
+    // Should have 3 colon-separated parts: v2:deflate64:<constructs>:<migrate-info>
+    expect(result.split(':').length).toBe(4);
+  } finally {
+    if (original === undefined) {
+      delete process.env.CDK_CONTEXT_JSON;
+    } else {
+      process.env.CDK_CONTEXT_JSON = original;
+    }
+  }
+});


### PR DESCRIPTION
Closes #37192
The .concat() result was not assigned back to the variable, so the cdk-migrate suffix was silently discarded. Strings are immutable in JavaScript.
Exemption Request: Internal telemetry fix, no CloudFormation output change.