### PR TITLE
fix(ecs): enableDeploymentAlarms now correctly adds additional alarms

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
@@ -1087,7 +1087,7 @@ export abstract class BaseService extends Resource
     } else {
       // If deployment alarms have previously been enabled, we only need to add
       // the new alarm names, since rollback behaviors can't be updated/mixed.
-      this.deploymentAlarms.alarmNames.concat(alarmNames);
+      this.deploymentAlarms.alarmNames.push(...alarmNames);
     }
   }
 

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
@@ -4617,6 +4617,16 @@ describe('ec2 service', () => {
 });
 
 test('enableDeploymentAlarms called twice adds all alarms', () => {
+  const stack = new cdk.Stack();
+  const vpc = new ec2.Vpc(stack, 'MyVpc', {});
+  const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+  addDefaultCapacityProvider(cluster, stack, vpc);
+  const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+  taskDefinition.addContainer('web', {
+    image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+    memoryLimitMiB: 512,
+  });
+
   const alarm1 = cloudwatch.Alarm.fromAlarmArn(stack, 'alarm1', 'arn:aws:cloudwatch:us-east-1:1234567890:alarm:alarm1');
   const alarm2 = cloudwatch.Alarm.fromAlarmArn(stack, 'alarm2', 'arn:aws:cloudwatch:us-east-1:1234567890:alarm:alarm2');
 

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
@@ -4615,3 +4615,25 @@ describe('ec2 service', () => {
     });
   });
 });
+
+test('enableDeploymentAlarms called twice adds all alarms', () => {
+  const alarm1 = cloudwatch.Alarm.fromAlarmArn(stack, 'alarm1', 'arn:aws:cloudwatch:us-east-1:1234567890:alarm:alarm1');
+  const alarm2 = cloudwatch.Alarm.fromAlarmArn(stack, 'alarm2', 'arn:aws:cloudwatch:us-east-1:1234567890:alarm:alarm2');
+
+  const service = new ecs.Ec2Service(stack, 'Ec2Service', {
+    cluster,
+    taskDefinition,
+  });
+  service.enableDeploymentAlarms([alarm1.alarmName]);
+  service.enableDeploymentAlarms([alarm2.alarmName]);
+
+  Template.fromStack(stack).hasResourceProperties('AWS::ECS::Service', {
+    DeploymentConfiguration: {
+      Alarms: {
+        Enable: true,
+        Rollback: true,
+        AlarmNames: [alarm1.alarmName, alarm2.alarmName],
+      },
+    },
+  });
+});


### PR DESCRIPTION
Closes #36308
Array.concat() returns a new array without modifying the original. The result was not assigned, so additional alarms were silently ignored. Use push() instead.
Exemption Request: Covered by unit test that verifies correct alarm names in CloudFormation output.