### PR TITLE
fix(cloudfront): warn when minimumProtocolVersion is set without custom certificate

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -394,6 +394,10 @@ export class Distribution extends Resource implements IDistribution {
     this.httpVersion = props.httpVersion ?? HttpVersion.HTTP2;
     this.validateGrpc(props.defaultBehavior);
 
+    if (props.minimumProtocolVersion && !this.certificate) {
+      Annotations.of(this).addWarningV2('@aws-cdk/aws-cloudfront:minProtocolVersionIgnored', 'The \'minimumProtocolVersion\' property is only applicable when a custom SSL/TLS certificate is configured. Without a certificate, CloudFront uses its default security policy.');
+    }
+
     const originId = this.addOrigin(props.defaultBehavior.origin);
     this.defaultBehavior = new CacheBehavior(originId, { pathPattern: '*', ...props.defaultBehavior });
     if (props.additionalBehaviors) {

--- a/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
@@ -1702,3 +1702,15 @@ describe('gRPC', () => {
     }).toThrow(msg);
   });
 });
+
+test('warns when minimumProtocolVersion is set without custom certificate', () => {
+  const app = new App();
+  const stack = new Stack(app, 'Stack');
+  new Distribution(stack, 'Dist', {
+    defaultBehavior: { origin: defaultOrigin() },
+    minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2019,
+  });
+
+  const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('minimumProtocolVersion'));
+  expect(warnings.length).toBeGreaterThanOrEqual(1);
+});

--- a/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/test/distribution.test.ts
@@ -1704,13 +1704,13 @@ describe('gRPC', () => {
 });
 
 test('warns when minimumProtocolVersion is set without custom certificate', () => {
-  const app = new App();
-  const stack = new Stack(app, 'Stack');
-  new Distribution(stack, 'Dist', {
+  const testApp = new App();
+  const testStack = new Stack(testApp, 'Stack');
+  new Distribution(testStack, 'Dist', {
     defaultBehavior: { origin: defaultOrigin() },
     minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2019,
   });
 
-  const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('minimumProtocolVersion'));
+  const warnings = Annotations.fromStack(testStack).findWarning('*', Match.stringLikeRegexp('minimumProtocolVersion'));
   expect(warnings.length).toBeGreaterThanOrEqual(1);
 });


### PR DESCRIPTION
Closes #35404
The minimumProtocolVersion property is only applicable when a custom SSL/TLS certificate is configured. Added a warning annotation.
Exemption Request: Warning annotation only, no CloudFormation output change.