### PR TITLE
docs(sns): add specific IAM action details to grant method documentation

### DIFF
--- a/packages/aws-cdk-lib/aws-sns/lib/topic-base.ts
+++ b/packages/aws-cdk-lib/aws-sns/lib/topic-base.ts
@@ -225,7 +225,9 @@ export abstract class TopicBase extends Resource implements ITopic, IEncryptedRe
   }
 
   /**
-   * Grant topic publishing permissions to the given identity
+   * Grant topic publishing permissions to the given identity.
+   *
+   * This grants the `sns:Publish` action on this topic's ARN.
    *
    * The use of this method is discouraged. Please use `grants.publish()` instead.
    *
@@ -236,7 +238,9 @@ export abstract class TopicBase extends Resource implements ITopic, IEncryptedRe
   }
 
   /**
-   * Grant topic subscribing permissions to the given identity
+   * Grant topic subscribing permissions to the given identity.
+   *
+   * This grants the `sns:Subscribe` action on this topic's ARN.
    *
    * The use of this method is discouraged. Please use `grants.subscribe()` instead.
    *


### PR DESCRIPTION
Closes #35736
Added explicit mention of which IAM actions are granted by grantPublish (sns:Publish) and grantSubscribe (sns:Subscribe).
Exemption Request: Documentation-only change.