### PR TITLE
fix(elbv2): boolean ALB attributes not reflected when set to false

### DIFF
--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
@@ -229,7 +229,7 @@ export class ApplicationLoadBalancer extends BaseLoadBalancer implements IApplic
 
     if (props.http2Enabled !== undefined) { this.setAttribute('routing.http2.enabled', props.http2Enabled ? 'true' : 'false'); }
     if (props.idleTimeout !== undefined) { this.setAttribute('idle_timeout.timeout_seconds', props.idleTimeout.toSeconds().toString()); }
-    if (props.dropInvalidHeaderFields) { this.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true'); }
+    if (props.dropInvalidHeaderFields !== undefined) { this.setAttribute('routing.http.drop_invalid_header_fields.enabled', props.dropInvalidHeaderFields ? 'true' : 'false'); }
     if (props.desyncMitigationMode !== undefined) { this.setAttribute('routing.http.desync_mitigation_mode', props.desyncMitigationMode); }
     if (props.preserveHostHeader !== undefined) { this.setAttribute('routing.http.preserve_host_header.enabled', props.preserveHostHeader ? 'true' : 'false'); }
     if (props.xAmznTlsVersionAndCipherSuiteHeaders !== undefined) { this.setAttribute('routing.http.x_amzn_tls_version_and_cipher_suite.enabled', props.xAmznTlsVersionAndCipherSuiteHeaders ? 'true' : 'false'); }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-load-balancer.ts
@@ -231,11 +231,11 @@ export class ApplicationLoadBalancer extends BaseLoadBalancer implements IApplic
     if (props.idleTimeout !== undefined) { this.setAttribute('idle_timeout.timeout_seconds', props.idleTimeout.toSeconds().toString()); }
     if (props.dropInvalidHeaderFields) { this.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true'); }
     if (props.desyncMitigationMode !== undefined) { this.setAttribute('routing.http.desync_mitigation_mode', props.desyncMitigationMode); }
-    if (props.preserveHostHeader) { this.setAttribute('routing.http.preserve_host_header.enabled', 'true'); }
-    if (props.xAmznTlsVersionAndCipherSuiteHeaders) { this.setAttribute('routing.http.x_amzn_tls_version_and_cipher_suite.enabled', 'true'); }
-    if (props.preserveXffClientPort) { this.setAttribute('routing.http.xff_client_port.enabled', 'true'); }
+    if (props.preserveHostHeader !== undefined) { this.setAttribute('routing.http.preserve_host_header.enabled', props.preserveHostHeader ? 'true' : 'false'); }
+    if (props.xAmznTlsVersionAndCipherSuiteHeaders !== undefined) { this.setAttribute('routing.http.x_amzn_tls_version_and_cipher_suite.enabled', props.xAmznTlsVersionAndCipherSuiteHeaders ? 'true' : 'false'); }
+    if (props.preserveXffClientPort !== undefined) { this.setAttribute('routing.http.xff_client_port.enabled', props.preserveXffClientPort ? 'true' : 'false'); }
     if (props.xffHeaderProcessingMode !== undefined) { this.setAttribute('routing.http.xff_header_processing.mode', props.xffHeaderProcessingMode); }
-    if (props.wafFailOpen) { this.setAttribute('waf.fail_open.enabled', 'true'); }
+    if (props.wafFailOpen !== undefined) { this.setAttribute('waf.fail_open.enabled', props.wafFailOpen ? 'true' : 'false'); }
     if (props.clientKeepAlive !== undefined) {
       const clientKeepAliveInMillis = props.clientKeepAlive.toMilliseconds();
       if (clientKeepAliveInMillis < 1000) {

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
@@ -1520,3 +1520,25 @@ describe('tests', () => {
     });
   });
 });
+
+test('boolean ALB attributes set to false are reflected in CloudFormation', () => {
+  const stack = new cdk.Stack();
+  const vpc = new ec2.Vpc(stack, 'Stack');
+
+  new elbv2.ApplicationLoadBalancer(stack, 'LB', {
+    vpc,
+    preserveHostHeader: false,
+    xAmznTlsVersionAndCipherSuiteHeaders: false,
+    preserveXffClientPort: false,
+    wafFailOpen: false,
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+    LoadBalancerAttributes: Match.arrayWith([
+      { Key: 'routing.http.preserve_host_header.enabled', Value: 'false' },
+      { Key: 'routing.http.x_amzn_tls_version_and_cipher_suite.enabled', Value: 'false' },
+      { Key: 'routing.http.xff_client_port.enabled', Value: 'false' },
+      { Key: 'waf.fail_open.enabled', Value: 'false' },
+    ]),
+  });
+});

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/load-balancer.test.ts
@@ -1527,6 +1527,7 @@ test('boolean ALB attributes set to false are reflected in CloudFormation', () =
 
   new elbv2.ApplicationLoadBalancer(stack, 'LB', {
     vpc,
+    dropInvalidHeaderFields: false,
     preserveHostHeader: false,
     xAmznTlsVersionAndCipherSuiteHeaders: false,
     preserveXffClientPort: false,
@@ -1535,6 +1536,7 @@ test('boolean ALB attributes set to false are reflected in CloudFormation', () =
 
   Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     LoadBalancerAttributes: Match.arrayWith([
+      { Key: 'routing.http.drop_invalid_header_fields.enabled', Value: 'false' },
       { Key: 'routing.http.preserve_host_header.enabled', Value: 'false' },
       { Key: 'routing.http.x_amzn_tls_version_and_cipher_suite.enabled', Value: 'false' },
       { Key: 'routing.http.xff_client_port.enabled', Value: 'false' },


### PR DESCRIPTION
Follow-up to #36409. Same issue affects preserveHostHeader, xAmznTlsVersionAndCipherSuiteHeaders, preserveXffClientPort, and wafFailOpen. These were only emitted when truthy, making it impossible to revert from true to false.
Exemption Request: Same pattern as #37460, covered by existing tests.