### PR TITLE
test(lambda): add direct coverage for grantInvokeLatestVersion resource grants

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -636,6 +636,42 @@ describe('function', () => {
           runtime: lambda.Runtime.PYTHON_3_9,
         });
       });
+      
+    describe('grantInvokeLatestVersion', () => {
+      test('grants both $LATEST and unqualified function ARNs', () => {
+        // GIVEN
+        const stack = new cdk.Stack();
+        
+        const fn = new lambda.Function(stack, 'MyLambda', {
+          code: new lambda.InlineCode('foo'),
+          handler: 'index.handler',
+          runtime: lambda.Runtime.NODEJS_LATEST,
+        });
+        
+        const role = new iam.Role(stack, 'MyRole', {
+          assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+        
+        // WHEN
+        fn.grantInvokeLatestVersion(role);
+        
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+          PolicyDocument: {
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Action: 'lambda:InvokeFunction',
+                Effect: 'Allow',
+                Resource: Match.arrayWith([
+                  { 'Fn::GetAtt': ['MyLambdaCCE802FB', 'Arn'] },
+                  { 'Fn::Join': ['', [{ 'Fn::GetAtt': ['MyLambdaCCE802FB', 'Arn'] }, ':$LATEST']] },
+                ]),
+              }),
+            ]),
+          },
+        });
+      });
+    });
 
       describe('permissions on functions', () => {
         test('without lambda:InvokeFunction', () => {


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Add a unit test for `grantInvokeLatestVersion()`.

>to invoke the latest version or the unqualified Lambda ARN, use grantInvokeLatestVersion(grantee)

Lambda README:
https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda-readme.html

This behavior is part of the API contract and is worth pinning directly in a
unit test.

### Description of changes

Verify that the synthesized IAM policy grants `lambda:InvokeFunction` with
`Effect: Allow` for both:
- the unqualified function ARN
- the `$LATEST` qualified ARN

### Describe any new or updated permissions being added

N/A


### Description of how you validated changes

Added a regression unit test for `grantInvokeLatestVersion()` in `packages/aws-cdk-lib/aws-lambda/test/function.test.ts`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
