### PR TITLE
docs: fix incorrect indefinite articles ("a" → "an") before acronyms in README files

### DIFF
--- a/packages/aws-cdk-lib/aws-apigatewayv2-integrations/README.md
+++ b/packages/aws-cdk-lib/aws-apigatewayv2-integrations/README.md
@@ -164,7 +164,7 @@ httpApi.addRoutes({
 SQS integrations enable integrating an HTTP API route with AWS SQS.
 This allows the HTTP API to send, receive and delete messages from an SQS queue.
 
-The following code configures a SQS integrations:
+The following code configures an SQS integrations:
 
 ```ts
 import * as sqs from 'aws-cdk-lib/aws-sqs';
@@ -453,7 +453,7 @@ webSocketApi.addRoute('sendMessage', {
 AWS type integrations enable integrating with any supported AWS service. This is only supported for WebSocket APIs. When a client 
 connects/disconnects or sends a message specific to a route, the API Gateway service forwards the request to the specified AWS service.
 
-The following code configures a `$connect` route with a AWS integration that integrates with a dynamodb table. On websocket api connect,
+The following code configures a `$connect` route with an AWS integration that integrates with a dynamodb table. On websocket api connect,
 it will write new entry to the dynamodb table. 
 
 ```ts

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/README.md
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/README.md
@@ -5,7 +5,7 @@ S3 buckets, Elastic Load Balancing v2 load balancers, or any other domain name.
 
 ## S3 Bucket
 
-An S3 bucket can be used as an origin. An S3 bucket origin can either be configured using a standard S3 bucket or using a S3 bucket that's configured as a website endpoint (see AWS docs for [Using an S3 Bucket](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#using-s3-as-origin)).
+An S3 bucket can be used as an origin. An S3 bucket origin can either be configured using a standard S3 bucket or using an S3 bucket that's configured as a website endpoint (see AWS docs for [Using an S3 Bucket](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#using-s3-as-origin)).
 
 > Note: `S3Origin` has been deprecated. Use `S3BucketOrigin` for standard S3 origins and `S3StaticWebsiteOrigin` for static website S3 origins.
 
@@ -424,7 +424,7 @@ S3 bucket to allow the OAI read access:
 
 See AWS docs on [Giving an origin access identity permission to read files in the Amazon S3 bucket](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#private-content-restricting-access-to-s3-oai) for more details.
 
-### Setting up a S3 origin with no origin access control
+### Setting up an S3 origin with no origin access control
 
 To setup a standard S3 origin with no access control (no OAI nor OAC), use `origins.S3BucketOrigin.withBucketDefaults()`:
 

--- a/packages/aws-cdk-lib/aws-codebuild/README.md
+++ b/packages/aws-cdk-lib/aws-codebuild/README.md
@@ -883,7 +883,7 @@ by events via an event rule.
 ### Using Project as an event target
 
 The `aws-cdk-lib/aws-events-targets.CodeBuildProject` allows using an AWS CodeBuild
-project as a AWS CloudWatch event rule target:
+project as an AWS CloudWatch event rule target:
 
 ```ts
 // start build when a commit is pushed

--- a/packages/aws-cdk-lib/aws-config/README.md
+++ b/packages/aws-cdk-lib/aws-config/README.md
@@ -78,7 +78,7 @@ new config.CloudFormationStackDriftDetectionCheck(this, 'Drift', {
 
 #### CloudFormation Stack notifications
 
-Checks whether your CloudFormation stacks are sending event notifications to a SNS topic.
+Checks whether your CloudFormation stacks are sending event notifications to an SNS topic.
 
 ```ts
 // topics to which CloudFormation stacks may send event notifications

--- a/packages/aws-cdk-lib/aws-events/README.md
+++ b/packages/aws-cdk-lib/aws-events/README.md
@@ -65,7 +65,7 @@ const onCommitRule = repo.onCommit('OnCommit', {
 
 You can add additional targets, with optional [input
 transformer](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_InputTransformer.html)
-using `eventRule.addTarget(target[, input])`. For example, we can add a SNS
+using `eventRule.addTarget(target[, input])`. For example, we can add an SNS
 topic target which formats a human-readable message for the commit.
 
 For example, this adds an SNS topic as a target:

--- a/packages/aws-cdk-lib/aws-lambda-destinations/README.md
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/README.md
@@ -14,7 +14,7 @@ The following destinations are supported
 * EventBridge event bus
 * S3 bucket
 
-Example with a SNS topic for successful invocations:
+Example with an SNS topic for successful invocations:
 
 ```ts
 // An sns topic for successful invocations of a lambda function
@@ -31,7 +31,7 @@ const myFn = new lambda.Function(this, 'Fn', {
 })
 ```
 
-Example with a SQS queue for unsuccessful invocations:
+Example with an SQS queue for unsuccessful invocations:
 
 ```ts
 // An sqs queue for unsuccessful invocations of a lambda function

--- a/packages/aws-cdk-lib/aws-logs/README.md
+++ b/packages/aws-cdk-lib/aws-logs/README.md
@@ -85,7 +85,7 @@ Account ID strings. Non-ARN principals, like Service principals or Any principal
 ## Encrypting Log Groups
 
 By default, log group data is always encrypted in CloudWatch Logs. You have the
-option to encrypt log group data using a AWS KMS customer master key (CMK) should
+option to encrypt log group data using an AWS KMS customer master key (CMK) should
 you not wish to use the default AWS encryption. Keep in mind that if you decide to
 encrypt a log group, any service or IAM identity that needs to read the encrypted
 log streams in the future will require the same CMK to decrypt the data.

--- a/packages/aws-cdk-lib/aws-scheduler-targets/README.md
+++ b/packages/aws-cdk-lib/aws-scheduler-targets/README.md
@@ -322,7 +322,7 @@ new Schedule(this, 'Schedule', {
 });
 ```
 
-The code snippet below creates an event rule with a EC2 task definition and cluster as the target which is called every hour by EventBridge Scheduler.
+The code snippet below creates an event rule with an EC2 task definition and cluster as the target which is called every hour by EventBridge Scheduler.
 
 ```ts
 import * as ecs from 'aws-cdk-lib/aws-ecs';

--- a/packages/aws-cdk-lib/aws-servicecatalog/README.md
+++ b/packages/aws-cdk-lib/aws-servicecatalog/README.md
@@ -175,8 +175,8 @@ const product = new servicecatalog.CloudFormationProduct(this, 'Product', {
 
 ### Using Assets in your Product Stack
 
-You can reference assets in a Product Stack. For example, we can add a handler to a Lambda function or a S3 Asset directly from a local asset file.
-In this case, you must provide a S3 Bucket with a bucketName to store your assets.
+You can reference assets in a Product Stack. For example, we can add a handler to a Lambda function or an S3 Asset directly from a local asset file.
+In this case, you must provide an S3 Bucket with a bucketName to store your assets.
 
 ```ts
 import * as lambda from 'aws-cdk-lib/aws-lambda';

--- a/packages/aws-cdk-lib/aws-stepfunctions/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions/README.md
@@ -947,8 +947,8 @@ distributedMap.itemProcessor(new sfn.Pass(this, 'Pass State'));
   });
   distributedMap.itemProcessor(new sfn.Pass(this, 'Pass'));
   ```
-* Objects in a S3 bucket with an optional prefix.
-  * When `DistributedMap` is required to iterate over objects stored in a S3 bucket, then an object of `S3ObjectsItemReader` can be passed to `itemReader` to configure the iterator source. Note that `S3ObjectsItemReader` will default to use Distributed map's query language. If the
+* Objects in an S3 bucket with an optional prefix.
+  * When `DistributedMap` is required to iterate over objects stored in an S3 bucket, then an object of `S3ObjectsItemReader` can be passed to `itemReader` to configure the iterator source. Note that `S3ObjectsItemReader` will default to use Distributed map's query language. If the
   map does not specify a query language, then it falls back to the State machine's query language. An exmaple of using `S3ObjectsItemReader`
   is as follows:
   ```ts
@@ -997,7 +997,7 @@ distributedMap.itemProcessor(new sfn.Pass(this, 'Pass State'));
   ```
   * Both `bucket` and `bucketNamePath` are mutually exclusive.
 * JSON array in a JSON file stored in S3
-  * When `DistributedMap` is required to iterate over a JSON array stored in a JSON file in a S3 bucket, then an object of `S3JsonItemReader` can be passed to `itemReader` to configure the iterator source as follows:
+  * When `DistributedMap` is required to iterate over a JSON array stored in a JSON file in an S3 bucket, then an object of `S3JsonItemReader` can be passed to `itemReader` to configure the iterator source as follows:
   ```ts
   import * as s3 from 'aws-cdk-lib/aws-s3';
 

--- a/packages/aws-cdk-lib/custom-resources/README.md
+++ b/packages/aws-cdk-lib/custom-resources/README.md
@@ -450,7 +450,7 @@ const myProvider = new cr.Provider(this, 'MyProvider', {
 
 ### Customizing Provider Function environment encryption key
 
-Sometimes it may be useful to manually set a AWS KMS key for the Provider Function Lambda and therefore
+Sometimes it may be useful to manually set an AWS KMS key for the Provider Function Lambda and therefore
 be able to view, manage and audit the key usage.
 
 ```ts
@@ -983,7 +983,7 @@ new s3deploy.BucketDeployment(nestedStackB, "s3deployB", {
 
 ### Setting Log Group Removal Policy
 
-The `addLogRetentionLifetime` method of `CustomResourceConfig` will associate a log group with a AWS-vended custom resource lambda.
+The `addLogRetentionLifetime` method of `CustomResourceConfig` will associate a log group with an AWS-vended custom resource lambda.
 The `addRemovalPolicy` method will configure the custom resource lambda log group removal policy to `DESTROY`.
 ```ts
 import * as cdk from 'aws-cdk-lib';

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -32,7 +32,7 @@ _cdk.json_
 
 * `@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption`
 
-Enable this feature flag to restrict the decryption of a SQS queue, which is subscribed to a SNS topic, to
+Enable this feature flag to restrict the decryption of an SQS queue, which is subscribed to an SNS topic, to
 only the topic which it is subscribed to and not the whole SNS service of an account.
 
 Previously the decryption was only restricted to the SNS service principal. To make the SQS subscription more
@@ -345,7 +345,7 @@ _cdk.json_
 
 When enabled, the default volume type of the EBS volume will be GP3.
 
-When this featuer flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
+When this feature flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
 
 _cdk.json_
 
@@ -361,7 +361,7 @@ _cdk.json_
 
 When enabled, remove default deployment alarm settings.
 
-When this featuer flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+When this feature flag is enabled, remove the default deployment alarm settings when creating an AWS ECS service.
 
 _cdk.json_
 


### PR DESCRIPTION
### Description

Fix incorrect indefinite articles before acronyms that begin with a vowel sound in 12 README files.

Changes:
- `a AWS` → `an AWS`
- `a S3` → `an S3`
- `a SNS` → `an SNS`
- `a SQS` → `an SQS`
- `a EC2` → `an EC2`
- `a ECS` → `an ECS`

Also fixes two typos of `featuer` → `feature` in `cx-api/README.md`.

### Reason

Acronyms like AWS, S3, SNS, SQS, EC2, and ECS begin with vowel sounds when spoken, so they require "an" rather than "a".

### Affected Modules
- `aws-apigatewayv2-integrations`
- `aws-cloudfront-origins`
- `aws-codebuild`
- `aws-config`
- `aws-events`
- `aws-lambda-destinations`
- `aws-logs`
- `aws-scheduler-targets`
- `aws-servicecatalog`
- `aws-stepfunctions`
- `custom-resources`
- `cx-api`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license