### PR TITLE
docs: fix grammar errors in JSDoc comments and README

### DIFF
--- a/packages/aws-cdk-lib/aws-config/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-config/lib/rule.ts
@@ -819,7 +819,7 @@ export class ManagedRuleIdentifiers {
   public static readonly CLB_MULTIPLE_AZ = 'CLB_MULTIPLE_AZ';
   /**
    * Checks whether an AWS CloudFormation stack's actual configuration differs, or has drifted,
-   * from it's expected configuration.
+   * from its expected configuration.
    * @see https://docs.aws.amazon.com/config/latest/developerguide/cloudformation-stack-drift-detection-check.html
    */
   public static readonly CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK = 'CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK';

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -2014,7 +2014,7 @@ Step Functions supports [AWS Step Functions](https://docs.aws.amazon.com/step-fu
 
 You can manage [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) executions.
 
-AWS Step Functions supports it's own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
+AWS Step Functions supports its own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
 
 ```ts
 // Define a state machine with one Pass state

--- a/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
@@ -115,7 +115,7 @@ export class CfnParameter extends CfnElement {
 
   /**
    * Creates a parameter construct.
-   * Note that the name (logical ID) of the parameter will derive from it's `coname` and location
+   * Note that the name (logical ID) of the parameter will derive from its `name` and location
    * within the stack. Therefore, it is recommended that parameters are defined at the stack level.
    *
    * @param scope The parent construct.


### PR DESCRIPTION
### Reason for this change

Several JSDoc comments and README files contain grammar errors where "it's" (contraction of "it is") is used instead of "its" (possessive form). One instance also contains a typo (`coname` → `name`).

### Description of changes

- `aws-config/lib/rule.ts`: "from it's expected" → "from its expected"
- `core/lib/cfn-parameter.ts`: "from it's \`coname\`" → "from its \`name\`" (grammar + typo)
- `aws-stepfunctions-tasks/README.md`: "it's own" → "its own"

### Description of how you validated changes

Comment/documentation-only changes. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*