### PR TITLE
docs: fix incorrect indefinite article "a" → "an" before acronyms

### DIFF
--- a/packages/aws-cdk-lib/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/aws-cdk-lib/aws-appmesh/lib/tls-certificate.ts
@@ -52,7 +52,7 @@ export abstract class MutualTlsCertificate extends TlsCertificate {
 }
 
 /**
- * Represents a ACM provided TLS certificate
+ * Represents an ACM provided TLS certificate
  */
 class AcmTlsCertificate extends TlsCertificate {
   /**

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -1510,7 +1510,7 @@ When this feature flag is disabled, it will keep the root account principal in t
 
 Flag type: New default behavior
 
-When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+When this feature flag is enabled, remove the default deployment alarm settings when creating an AWS ECS service.
 
 
 | Since | Unset behaves like | Recommended value |

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -1185,7 +1185,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.ApiDefault,
     summary: 'When enabled, remove default deployment alarm settings',
     detailsMd: `
-      When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+      When this feature flag is enabled, remove the default deployment alarm settings when creating an AWS ECS service.
     `,
     introducedIn: { v2: '2.143.0' },
     recommendedValue: true,


### PR DESCRIPTION
### Reason for this change

Incorrect indefinite article "a" is used before acronyms that start with a vowel sound ("ACM", "AWS").

### Description of changes

- `aws-appmesh/lib/tls-certificate.ts`: "a ACM" → "an ACM"
- `cx-api/lib/features.ts`: "a AWS" → "an AWS"

### Description of how you validated changes

Comment-only changes. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*