### PR TITLE
docs(route53-patterns): fix incorrect article "a ACM" → "an ACM" in JSDoc

### DIFF
--- a/packages/aws-cdk-lib/aws-route53-patterns/lib/website-redirect.ts
+++ b/packages/aws-cdk-lib/aws-route53-patterns/lib/website-redirect.ts
@@ -136,7 +136,7 @@ export class HttpsRedirect extends Construct {
    * _any_ region. So I could create a CloudFront distribution in `us-east-2` if I wanted
    * to (maybe the rest of my application lives there). The problem is that some supporting resources
    * that CloudFront uses (i.e. ACM Certificates) are required to exist in `us-east-1`. This means
-   * that if I want to create a CloudFront distribution in `us-east-2` I still need to create a ACM certificate in
+   * that if I want to create a CloudFront distribution in `us-east-2` I still need to create an ACM certificate in
    * `us-east-1`.
    *
    * In order to do this correctly we need to know which region the CloudFront distribution is being created in.


### PR DESCRIPTION
### Reason for this change

Incorrect indefinite article "a" is used before the acronym "ACM" which starts with a vowel sound.

### Description of changes

- `aws-route53-patterns/lib/website-redirect.ts`: "create a ACM certificate" → "create an ACM certificate"

### Description of how you validated changes

Comment-only change. No functional impact.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*