### PR TITLE
chore: include cfn-property-mixins in spec-update workflow gen step

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Build @aws-cdk/spec2cdk
         run: lerna run build --stream --no-progress --skip-nx-cache --scope @aws-cdk/spec2cdk
       - name: Generate code
-        run: lerna run gen --stream --no-progress --skip-nx-cache --scope aws-cdk-lib --scope @aws-cdk/mixins-preview
+        # All three scopes have gen scripts that update generated code and package.json exports
+        # from the service spec database. Missing any scope causes the PR build to fail with
+        # uncommitted changes detected by git diff-index.
+        run: lerna run gen --stream --no-progress --skip-nx-cache --scope aws-cdk-lib --scope @aws-cdk/mixins-preview --scope @aws-cdk/cfn-property-mixins
 
       # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
       # Creating a pull request requires write permissions and it's best to keep write privileges isolated.


### PR DESCRIPTION
### Issue

Fixes the recurring build failure on L1 spec update PRs (e.g. #37530) where `git diff-index` detects uncommitted changes in `packages/@aws-cdk/cfn-property-mixins/package.json`.

### Reason for this change

When `@aws-cdk/cfn-property-mixins` graduated from `mixins-preview` to a standalone package in #37215, it gained its own `gen` script that regenerates `package.json` exports from the service spec database. However, the `spec-update.yml` workflow was never updated to include it in the gen step.

When new CloudFormation services are added (e.g. `AWS::NovaAct`, `AWS::SecurityAgent`), the gen script adds export entries to `cfn-property-mixins/package.json`. Since these changes aren't included in the automation commit, the PR build fails the `git diff-index` check.

This is the same class of issue previously fixed in #36300 for `@aws-cdk/mixins-preview`.

### Description of changes

Added `--scope @aws-cdk/cfn-property-mixins` to the gen step in `.github/workflows/spec-update.yml`, and added a comment explaining why all three scopes are required.

### Description of how you validated changes

Confirmed the root cause by examining the [build logs for PR #37530](https://github.com/aws/aws-cdk/actions/runs/24179400660/job/70568296044) which show exactly `cfn-property-mixins/package.json` with 2 uncommitted insertions.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*