### PR TITLE
chore: run aws-cdk-lib gen before mixins gen in spec-update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -58,11 +58,13 @@ jobs:
       # Build @aws-cdk/spec2cdk and run L1 gen script to generate base files for new modules
       - name: Build @aws-cdk/spec2cdk
         run: lerna run build --stream --no-progress --skip-nx-cache --scope @aws-cdk/spec2cdk
-      - name: Generate code
-        # All three scopes have gen scripts that update generated code and package.json exports
-        # from the service spec database. Missing any scope causes the PR build to fail with
-        # uncommitted changes detected by git diff-index.
-        run: lerna run gen --stream --no-progress --skip-nx-cache --scope aws-cdk-lib --scope @aws-cdk/mixins-preview --scope @aws-cdk/cfn-property-mixins
+      # Generate L1 code for aws-cdk-lib first — this updates scope-map.json with new services.
+      # mixins-preview and cfn-property-mixins read scope-map.json during their gen, so they
+      # must run after aws-cdk-lib to see the new service entries.
+      - name: Generate L1 code
+        run: lerna run gen --stream --no-progress --skip-nx-cache --scope aws-cdk-lib
+      - name: Generate mixins
+        run: lerna run gen --stream --no-progress --skip-nx-cache --scope @aws-cdk/mixins-preview --scope @aws-cdk/cfn-property-mixins
 
       # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
       # Creating a pull request requires write permissions and it's best to keep write privileges isolated.


### PR DESCRIPTION
### Issue

Fixes the recurring build failure on L1 spec update PRs (e.g. #37530) where `git diff-index` detects uncommitted changes in `packages/@aws-cdk/cfn-property-mixins/package.json`.

Supersedes #37556 which added `cfn-property-mixins` to the gen step but didn't fix the ordering issue.

### Root Cause: Race Condition in Parallel Gen

The spec-update workflow runs `lerna run gen` for all three packages (`aws-cdk-lib`, `@aws-cdk/mixins-preview`, `@aws-cdk/cfn-property-mixins`) in a single command. Lerna executes them **in parallel**. This creates a race condition:

1. **`aws-cdk-lib` gen** writes new service entries (e.g. `aws-novaact`, `aws-securityagent`) to [`scope-map.json`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/scripts/scope-map.json) via [`writeModuleMap()`](https://github.com/aws/aws-cdk/blob/main/tools/%40aws-cdk/spec2cdk/lib/module-topology.ts#L126)

2. **`cfn-property-mixins` gen** reads `scope-map.json` via [`loadModuleMap()`](https://github.com/aws/aws-cdk/blob/main/tools/%40aws-cdk/spec2cdk/lib/module-topology.ts#L119-L121) to determine which services to generate exports for — see the [filter at line 23](https://github.com/aws/aws-cdk/blob/main/tools/%40aws-cdk/spec2cdk/lib/cfn-prop-mixins/generate.ts#L23): `if (moduleMap[service.name])`

3. **`mixins-preview` gen** has the [same dependency](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/mixins-preview/scripts/spec2logs/generate.ts#L6) on `scope-map.json`

### Evidence from workflow run [#354](https://github.com/aws/aws-cdk/actions/runs/24186251521/job/70591637015)

The gen step logs show `cfn-property-mixins` finished **before** `aws-cdk-lib`:

```
10:53:00 @aws-cdk/cfn-property-mixins:   Services: 278    ← finished first, read stale scope-map.json
10:53:05 aws-cdk-lib:                     Services: 282    ← finished second, wrote updated scope-map.json
```

`cfn-property-mixins` generated for 278 services because it read `scope-map.json` before `aws-cdk-lib` added the 4 new service entries. During the CI build, `cdk-build` runs gen again with the updated `scope-map.json`, producing 2 new export entries in `package.json` that weren't in the commit → `git diff-index` fails.

### Description of changes

Split the single `lerna run gen` command into two sequential steps:
1. **Generate L1 code** — runs gen for `aws-cdk-lib` only, which updates `scope-map.json`
2. **Generate mixins** — runs gen for `mixins-preview` and `cfn-property-mixins`, which now read the updated `scope-map.json`

### Description of how you validated changes

- Traced the full dependency chain through the codebase (links above)
- Confirmed the race condition from [workflow run #354 logs](https://github.com/aws/aws-cdk/actions/runs/24186251521/job/70591637015) showing 278 vs 282 services
- Confirmed the [CI build failure logs](https://github.com/aws/aws-cdk/actions/runs/24186453052/job/70592307695) show the same `cfn-property-mixins/package.json | 2 ++` after the workflow re-run

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*