### PR TITLE
chore(prlint): remove dead CLI integ test rule and label

### DIFF
--- a/.github/workflows/request-cli-integ-test.yml
+++ b/.github/workflows/request-cli-integ-test.yml
@@ -60,14 +60,3 @@ jobs:
           git config --global user.name 'aws-cdk-automation'
           git config --global user.email 'aws-cdk-automation@users.noreply.github.com'
           git push --force --atomic https://github.com/${{ github.repository }}.git FETCH_HEAD:test-main-pipeline
-      - name: Explain next steps
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
-        with:
-          message: |
-            :arrow_right: **PR build request submitted to `test-main-pipeline`** :arrow_left:
-
-            A maintainer must now check the pipeline and add the `pr-linter/cli-integ-tested` label once the pipeline succeeds.
-          comment-tag: request-cli-integ-test
-          mode: recreate
-          # Post as our automation user
-          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/tools/@aws-cdk/prlint/README.md
+++ b/tools/@aws-cdk/prlint/README.md
@@ -15,9 +15,8 @@ The first part of the GitHub Action validates whether the pull request adheres
 4. No breaking changes announced for stable modules.
 5. Title prefix and scope is formatted correctly.
 6. The PR is not opened from the main branch of the author's fork.
-7. Changes to the cli have been run through the test pipeline where cli integ tests are run (indicated by the label `pr-linter/cli-integ-tested`).
-8. No manual changes to `packages/aws-cdk-lib/region-info/build-tools/metadata.ts` file.
-9. The size of the PR (number of lines added or removed) does not exceed the 
+7. No manual changes to `packages/aws-cdk-lib/region-info/build-tools/metadata.ts` file.
+8. The size of the PR (number of lines added or removed) does not exceed the 
    pre-defined threshold of 1000.
 
 > These rules are currently hard coded, in the future, we should consider using [danger.js](https://danger.systems/js/).

--- a/tools/@aws-cdk/prlint/constants.ts
+++ b/tools/@aws-cdk/prlint/constants.ts
@@ -11,7 +11,6 @@ export enum Exemption {
   TEST = 'pr-linter/exempt-test',
   INTEG_TEST = 'pr-linter/exempt-integ-test',
   BREAKING_CHANGE = 'pr-linter/exempt-breaking-change',
-  CLI_INTEG_TESTED = 'pr-linter/cli-integ-tested',
   ANALYTICS_METADATA_CHANGE = 'pr-linter/analytics-metadata-change',
   REQUEST_CLARIFICATION = 'pr/reviewer-clarification-requested',
   REQUEST_EXEMPTION = 'pr-linter/exemption-requested',

--- a/tools/@aws-cdk/prlint/lint.ts
+++ b/tools/@aws-cdk/prlint/lint.ts
@@ -233,14 +233,6 @@ export class PullRequestLinter extends PullRequestLinterBase {
 
     validationCollector.validateRuleSet({
       exemption: either(
-        exemptByLabel(Exemption.CLI_INTEG_TESTED),
-        exemptIfAutomationUser(),
-      ),
-      testRuleSet: [{ test: noCliChanges }],
-    });
-
-    validationCollector.validateRuleSet({
-      exemption: either(
         exemptByLabel(Exemption.ANALYTICS_METADATA_CHANGE),
         exemptIfAutomationUser(),
       ),
@@ -554,17 +546,6 @@ function assertStability(pr: GitHubPr, _files: GitHubFile[]): TestResult {
   const breakingStable = breakingModules(title, body ?? '').filter(mod => 'stable' === moduleStability(findModulePath(mod)));
   result.assessFailure(breakingStable.length > 0, `Breaking changes in stable modules [${breakingStable.join(', ')}] is disallowed.`);
   return result;
-}
-
-function noCliChanges(pr: GitHubPr, files: GitHubFile[]): TestResult {
-  const branch = `pull/${pr.number}/head`;
-
-  const cliCodeChanged = files.some(f => f.filename.toLowerCase().includes('packages/aws-cdk/lib/') && f.filename.endsWith('.ts'));
-
-  return TestResult.fromFailure(
-    cliCodeChanged,
-    `CLI code has changed. A maintainer must run the code through the testing pipeline (git fetch origin ${branch} && git push -f origin FETCH_HEAD:test-main-pipeline), then add the '${Exemption.CLI_INTEG_TESTED}' label when the pipeline succeeds.`,
-  );
 }
 
 function noMetadataChanges(_pr: GitHubPr, files: GitHubFile[]): TestResult {

--- a/tools/@aws-cdk/prlint/test/lint.test.ts
+++ b/tools/@aws-cdk/prlint/test/lint.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { CODECOV_CHECKS } from '../constants';
-import type { GitHubFile, GitHubLabel, GitHubPr } from '../github';
+import type { GitHubFile, GitHubPr } from '../github';
 import { PullRequestLinter } from '../lint';
 import type { OctoMock } from './octomock';
 import { createOctomock } from './octomock';
@@ -545,50 +545,6 @@ describe('integration tests required on features', () => {
     const prlinter = configureMock(issue, files);
     expect(legacyValidatePullRequestTarget(await prlinter)).resolves;
   });
-
-  describe('CLI file changed', () => {
-    const labels: GitHubLabel[] = [];
-    const issue = {
-      number: 23,
-      title: 'chore(cli): change the help or something',
-      body: `
-        description of the commit
-        closes #123456789
-      `,
-      labels,
-      user: {
-        login: 'author',
-      },
-    };
-    const files = [{ filename: 'packages/aws-cdk/lib/cdk-toolkit.ts' }];
-
-    test('no label throws error', async () => {
-      const prLinter = configureMock(issue, files);
-      await expect(legacyValidatePullRequestTarget(prLinter)).rejects.toThrow(/CLI code has changed. A maintainer must/);
-    });
-
-    test('with label no error', async () => {
-      labels.push({ name: 'pr-linter/cli-integ-tested' });
-      const prLinter = configureMock(issue, files);
-      // THEN: no exception
-      await legacyValidatePullRequestTarget(prLinter);
-    });
-
-    test('with aws-cdk-automation author', async () => {
-      // GIVEN: Remove exemption
-      labels.pop();
-      // Verify no labels added
-      expect(labels).toEqual([]);
-      issue.user.login = 'aws-cdk-automation';
-
-      // WHEN
-      const prLinter = configureMock(issue, files);
-      await legacyValidatePullRequestTarget(prLinter);
-
-      // THEN: no exception
-    });
-  });
-
   describe('assess needs review', () => {
     const pr = {
       title: 'chore(s3): something',


### PR DESCRIPTION
### Reason for this change

The CDK CLI was extracted to [aws/aws-cdk-cli](https://github.com/aws/aws-cdk-cli), so `packages/aws-cdk/lib/` no longer exists in this repo. The `noCliChanges` PR linter rule checked for changes in that path, meaning it could never fire. The `pr-linter/cli-integ-tested` exemption label and the workflow comment ([example](https://github.com/aws/aws-cdk/pull/37539#issuecomment-4215575192)) asking maintainers to add it were dead code.

### Description of changes

- Remove `noCliChanges` function and its validation rule from `lint.ts`
- Remove `CLI_INTEG_TESTED` from the `Exemption` enum in `constants.ts`
- Remove the comment step from `request-cli-integ-test.yml` workflow (the pipeline push to `test-main-pipeline` is unchanged — it still runs for `features.ts` changes)
- Remove associated tests and README entry

### Description of how you validated changes

Confirmed `packages/aws-cdk/lib/` does not exist in the repo. Grep for all references to `CLI_INTEG_TESTED`, `cli-integ-tested`, and `noCliChanges` — all removed or in generated `.js`/`.d.ts` files that will be regenerated on build.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*