### PR TITLE
docs: fix grammar errors and typos in source comments

### DIFF
--- a/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
@@ -530,7 +530,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
   const subnetCidrBlock = new CidrBlock(cidrRange);
   const allCidrs: CidrBlock[] = [];
 
-  // Secondary IP addresses assoicated using user defined IPv4 range
+  // Secondary IP addresses associated using user defined IPv4 range
   if (vpc.secondaryCidrBlock) {
     for (const ipAddress of vpc.secondaryCidrBlock) {
       if (ipAddress.cidrBlock) {
@@ -541,7 +541,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
     allCidrs.push(...cidrs);
   }
 
-  // Secondary IP addresses assoicated using IPAM IPv4 range
+  // Secondary IP addresses associated using IPAM IPv4 range
   if (vpc.ipv4IpamProvisionedCidrs) {
     const cidrs = vpc.ipv4IpamProvisionedCidrs.map(cidr => new CidrBlock(cidr));
     allCidrs.push(...cidrs);

--- a/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
+++ b/packages/@aws-cdk/aws-ec2-alpha/lib/subnet-v2.ts
@@ -531,7 +531,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
   const subnetCidrBlock = new CidrBlock(cidrRange);
   const allCidrs: CidrBlock[] = [];
 
-  // Secondary IP addresses assoicated using user defined IPv4 range
+  // Secondary IP addresses associated using user defined IPv4 range
   if (vpc.secondaryCidrBlock) {
     for (const ipAddress of vpc.secondaryCidrBlock) {
       if (ipAddress.cidrBlock) {
@@ -542,7 +542,7 @@ function checkCidrRanges(vpc: IVpcV2, cidrRange: string) {
     allCidrs.push(...cidrs);
   }
 
-  // Secondary IP addresses assoicated using IPAM IPv4 range
+  // Secondary IP addresses associated using IPAM IPv4 range
   if (vpc.ipv4IpamProvisionedCidrs) {
     const cidrs = vpc.ipv4IpamProvisionedCidrs.map(cidr => new CidrBlock(cidr));
     allCidrs.push(...cidrs);

--- a/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/triggers/workflow.ts
@@ -388,7 +388,7 @@ export class Workflow extends WorkflowBase {
   }
 
   /**
-   * Import an workflow from it's name
+   * Import a workflow from its name
    */
   public static fromWorkflowArn(scope: constructs.Construct, id: string, workflowArn: string): IWorkflow {
     return this.fromWorkflowAttributes(scope, id, {

--- a/packages/@aws-cdk/aws-imagebuilder-alpha/lib/workflow.ts
+++ b/packages/@aws-cdk/aws-imagebuilder-alpha/lib/workflow.ts
@@ -204,7 +204,7 @@ export enum WorkflowAction {
   EXECUTE_COMPONENTS = 'ExecuteComponents',
 
   /**
-   * The ExecuteStateMachine action executes a the state machine provided and waits for completion as part of the
+   * The ExecuteStateMachine action executes the state machine provided and waits for completion as part of the
    * workflow
    */
   EXECUTE_STATE_MACHINE = 'ExecuteStateMachine',

--- a/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/lib/types.ts
+++ b/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/lib/types.ts
@@ -107,7 +107,7 @@ export class Runtime {
   /** SQL Version 1.0 */
   public static readonly SQL_1_0 = Runtime.of('SQL-1_0');
 
-  /** Create a new Runtime with with an arbitrary Flink version string */
+  /** Create a new Runtime with an arbitrary Flink version string */
   public static of(value: string) {
     return new Runtime(value);
   }

--- a/packages/@aws-cdk/aws-msk-alpha/lib/cluster.ts
+++ b/packages/@aws-cdk/aws-msk-alpha/lib/cluster.ts
@@ -778,7 +778,7 @@ export class Cluster extends ClusterBase {
    *
    * Uses a Custom Resource to make an API call to `describeCluster` using the Javascript SDK
    *
-   * @param responseField Field to return from API call. eg. ZookeeperConnectString, ZookeeperConnectStringTls
+   * @param responseField Field to return from API call. e.g. ZookeeperConnectString, ZookeeperConnectStringTls
    * @returns - The connection string to use to connect to the Apache ZooKeeper cluster.
    */
   private _zookeeperConnectionString(responseField: string): string {
@@ -835,7 +835,7 @@ export class Cluster extends ClusterBase {
    *
    * Uses a Custom Resource to make an API call to `getBootstrapBrokers` using the Javascript SDK
    *
-   * @param responseField Field to return from API call. eg. BootstrapBrokerStringSaslScram, BootstrapBrokerString
+   * @param responseField Field to return from API call. e.g. BootstrapBrokerStringSaslScram, BootstrapBrokerString
    * @returns - A string containing one or more hostname:port pairs.
    */
   private _bootstrapBrokers(responseField: string): string {

--- a/packages/@aws-cdk/aws-s3tables-alpha/lib/permissions.ts
+++ b/packages/@aws-cdk/aws-s3tables-alpha/lib/permissions.ts
@@ -1,12 +1,12 @@
 // Table Bucket
-// Read priveleges
+// Read privileges
 export const TABLE_BUCKET_READ_ACCESS = [
   's3tables:Get*',
   's3tables:ListNamespaces',
   's3tables:ListTables',
 ];
 
-// Write priveleges
+// Write privileges
 export const TABLE_BUCKET_WRITE_ACCESS = [
   's3tables:PutTableData',
   's3tables:UpdateTableMetadataLocation',
@@ -23,11 +23,11 @@ export const TABLE_BUCKET_READ_WRITE_ACCESS = [...new Set([
 ])];
 
 // Table
-// Read priveleges
+// Read privileges
 export const TABLE_READ_ACCESS = [
   's3tables:Get*',
 ];
-// Write priveleges
+// Write privileges
 export const TABLE_WRITE_ACCESS = [
   's3tables:PutTableData',
   's3tables:UpdateTableMetadataLocation',

--- a/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
+++ b/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
@@ -41,7 +41,7 @@ export interface LambdaFunctionProviderProps {
  */
 class LambdaFunctionProvider extends Construct {
   /**
-   * A Reference to the provider lambda exeuction role ARN
+   * A Reference to the provider lambda execution role ARN
    */
   public readonly roleArn: Reference;
 

--- a/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
+++ b/packages/@aws-cdk/integ-tests-alpha/lib/assertions/providers/provider.ts
@@ -54,7 +54,7 @@ export interface LambdaFunctionProviderProps extends ProviderOptions {
  */
 class LambdaFunctionProvider extends Construct {
   /**
-   * A Reference to the provider lambda exeuction role ARN
+   * A Reference to the provider lambda execution role ARN
    */
   public readonly roleArn: Reference;
 

--- a/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
+++ b/packages/@aws-cdk/mixins-preview/lib/services/aws-logs/logs-delivery.ts
@@ -46,7 +46,7 @@ export interface RecordFieldDeliveryProps {
   /**
    * RecordFields the user has defined to be used in log delivery
    *
-   * @defualt - no fields were provided
+   * @default - no fields were provided
    */
   readonly providedFields?: string[];
   /**
@@ -64,7 +64,7 @@ export interface DeliveryProps extends RecordFieldDeliveryProps {
   /**
    * Format of the logs that are sent to the delivery destination specified
    *
-   * @defualt - undefined, use whatever default the delivery destination specifies
+   * @default - undefined, use whatever default the delivery destination specifies
    */
   readonly outputFormat?: string;
 }

--- a/packages/aws-cdk-lib/assertions/lib/annotations.ts
+++ b/packages/aws-cdk-lib/assertions/lib/annotations.ts
@@ -61,7 +61,7 @@ export class Annotations {
   }
 
   /**
-   * Assert that an warning with the given message exists in the synthesized CDK `Stack`.
+   * Assert that a warning with the given message exists in the synthesized CDK `Stack`.
    *
    * @param constructPath the construct path to the warning, provide `'*'` to match all warnings in the template.
    * @param message the warning message as should be expected. This should be a string or Matcher object.
@@ -74,7 +74,7 @@ export class Annotations {
   }
 
   /**
-   * Assert that an warning with the given message does not exist in the synthesized CDK `Stack`.
+   * Assert that a warning with the given message does not exist in the synthesized CDK `Stack`.
    *
    * @param constructPath the construct path to the warning, provide `'*'` to match all warnings in the template.
    * @param message the warning message as should be expected. This should be a string or Matcher object.

--- a/packages/aws-cdk-lib/aws-apigateway/lib/lambda-api.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/lambda-api.ts
@@ -16,7 +16,7 @@ export interface LambdaRestApiProps extends RestApiProps {
   /**
    * The default Lambda function that handles all requests from this API.
    *
-   * This handler will be used as a the default integration for all methods in
+   * This handler will be used as the default integration for all methods in
    * this API, unless specified otherwise in `addMethod`.
    */
   readonly handler: lambda.IFunction;

--- a/packages/aws-cdk-lib/aws-apigateway/lib/stepfunctions-api.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/stepfunctions-api.ts
@@ -18,7 +18,7 @@ export interface StepFunctionsRestApiProps extends RestApiProps {
   /**
    * The default State Machine that handles all requests from this API.
    *
-   * This stateMachine will be used as a the default integration for all methods in
+   * This stateMachine will be used as the default integration for all methods in
    * this API, unless specified otherwise in `addMethod`.
    */
   readonly stateMachine: sfn.IStateMachine;

--- a/packages/aws-cdk-lib/aws-appsync/lib/eventapi.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/eventapi.ts
@@ -514,7 +514,7 @@ export interface EventApiAttributes {
   readonly apiName?: string;
 
   /**
-   * an unique AWS AppSync Event API identifier
+   * a unique AWS AppSync Event API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   readonly apiId: string;
@@ -580,7 +580,7 @@ export class EventApi extends EventApiBase {
   }
 
   /**
-   * an unique AWS AppSync Event API identifier
+   * a unique AWS AppSync Event API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public readonly apiId: string;

--- a/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi-base.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi-base.ts
@@ -172,7 +172,7 @@ export enum AuthorizationType {
 export interface IGraphqlApi extends IResource, IGraphQLApiRef {
 
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    *
    * @attribute
@@ -353,7 +353,7 @@ export interface IGraphqlApi extends IResource, IGraphQLApiRef {
  */
 export abstract class GraphqlApiBase extends Resource implements IGraphqlApi {
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public abstract readonly apiId: string;

--- a/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi.ts
+++ b/packages/aws-cdk-lib/aws-appsync/lib/graphqlapi.ts
@@ -532,7 +532,7 @@ export interface GraphqlApiProps {
  */
 export interface GraphqlApiAttributes {
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   readonly graphqlApiId: string;
@@ -622,7 +622,7 @@ export class GraphqlApi extends GraphqlApiBase {
   }
 
   /**
-   * an unique AWS AppSync GraphQL API identifier
+   * a unique AWS AppSync GraphQL API identifier
    * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
    */
   public readonly apiId: string;

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool-client.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool-client.ts
@@ -302,7 +302,7 @@ export interface UserPoolClientOptions {
 
   /**
    * Validity of the ID token.
-   * Values between 5 minutes and 1 day are valid. The duration can not be longer than the refresh token validity.
+   * Values between 5 minutes and 1 day are valid. The duration cannot be longer than the refresh token validity.
    * @see https://docs.aws.amazon.com/en_us/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-id-token
    * @default Duration.minutes(60)
    */
@@ -318,7 +318,7 @@ export interface UserPoolClientOptions {
 
   /**
    * Validity of the access token.
-   * Values between 5 minutes and 1 day are valid. The duration can not be longer than the refresh token validity.
+   * Values between 5 minutes and 1 day are valid. The duration cannot be longer than the refresh token validity.
    * @see https://docs.aws.amazon.com/en_us/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-access-token
    * @default Duration.minutes(60)
    */

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
@@ -479,7 +479,7 @@ export interface PasswordPolicy {
   /**
    * The number of previous passwords that you want Amazon Cognito to restrict each user from reusing.
    *
-   * `passwordHistorySize` can not be set when `featurePlan` is `FeaturePlan.LITE`.
+   * `passwordHistorySize` cannot be set when `featurePlan` is `FeaturePlan.LITE`.
    *
    * @default undefined - Cognito default setting is no restriction
    */

--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts
@@ -482,7 +482,7 @@ export interface PasswordPolicy {
   /**
    * The number of previous passwords that you want Amazon Cognito to restrict each user from reusing.
    *
-   * `passwordHistorySize` can not be set when `featurePlan` is `FeaturePlan.LITE`.
+   * `passwordHistorySize` cannot be set when `featurePlan` is `FeaturePlan.LITE`.
    *
    * @default undefined - Cognito default setting is no restriction
    */

--- a/packages/aws-cdk-lib/aws-config/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-config/lib/rule.ts
@@ -819,7 +819,7 @@ export class ManagedRuleIdentifiers {
   public static readonly CLB_MULTIPLE_AZ = 'CLB_MULTIPLE_AZ';
   /**
    * Checks whether an AWS CloudFormation stack's actual configuration differs, or has drifted,
-   * from it's expected configuration.
+   * from its expected configuration.
    * @see https://docs.aws.amazon.com/config/latest/developerguide/cloudformation-stack-drift-detection-check.html
    */
   public static readonly CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK = 'CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK';

--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/queue-processing-service-base.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/queue-processing-service-base.ts
@@ -348,7 +348,7 @@ export abstract class QueueProcessingServiceBase extends Construct {
       const errorProps = ['retentionPeriod', 'visibilityTimeout', 'maxReceiveCount'].filter(prop => props.hasOwnProperty(prop));
       throw new ValidationError(lit`OnlyQueue`, `${errorProps.join(', ')} can be set only when queue is not set. Specify them in the QueueProps of the queue`, this);
     }
-    // Create the SQS queue and it's corresponding DLQ if one is not provided
+    // Create the SQS queue and its corresponding DLQ if one is not provided
     if (props.queue) {
       this.sqsQueue = props.queue;
     } else {

--- a/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
@@ -1555,7 +1555,7 @@ export class Cluster extends ClusterBase {
    *
    * This method creates an `AccessEntry` construct that grants the specified IAM principal the cluster admin
    * access permissions. This allows the IAM principal to perform the actions permitted
-   * by the cluster admin acces.
+   * by the cluster admin access.
    * [disable-awslint:no-grants]
    *
    * @param id - The ID of the `AccessEntry` construct to be created.

--- a/packages/aws-cdk-lib/aws-fsx/README.md
+++ b/packages/aws-cdk-lib/aws-fsx/README.md
@@ -17,7 +17,7 @@ The open-source Lustre file system is designed for applications that require fas
 to keep up with your compute. Lustre was built to solve the problem of quickly and cheaply processing the world's
 ever-growing datasets. It's a widely used file system designed for the fastest computers in the world. It provides
 submillisecond latencies, up to hundreds of GBps of throughput, and up to millions of IOPS. For more information on
-Lustre, see the [Lustre website](http://lustre.org/).
+Lustre, see the [Lustre website](https://www.lustre.org/).
 
 As a fully managed service, Amazon FSx makes it easier for you to use Lustre for workloads where storage speed matters.
 Amazon FSx for Lustre eliminates the traditional complexity of setting up and managing Lustre file systems, enabling

--- a/packages/aws-cdk-lib/aws-iam/README.md
+++ b/packages/aws-cdk-lib/aws-iam/README.md
@@ -698,7 +698,7 @@ user identities. For more information about this scenario, see [About Web
 Identity Federation] and the relevant documentation in the [Amazon Cognito
 Identity Pools Developer Guide].
 
-[OpenID Connect]: http://openid.net/connect
+[OpenID Connect]: https://openid.net/connect
 [About Web Identity Federation]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 [Amazon Cognito Identity Pools Developer Guide]: https://docs.aws.amazon.com/cognito/latest/developerguide/open-id.html
 

--- a/packages/aws-cdk-lib/aws-iam/README.md
+++ b/packages/aws-cdk-lib/aws-iam/README.md
@@ -720,7 +720,7 @@ user identities. For more information about this scenario, see [About Web
 Identity Federation] and the relevant documentation in the [Amazon Cognito
 Identity Pools Developer Guide].
 
-[OpenID Connect]: http://openid.net/connect
+[OpenID Connect]: https://openid.net/connect
 [About Web Identity Federation]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 [Amazon Cognito Identity Pools Developer Guide]: https://docs.aws.amazon.com/cognito/latest/developerguide/open-id.html
 

--- a/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
@@ -102,7 +102,7 @@ export class ImportedRole extends Resource implements IRole, IComparablePrincipa
 
   @MethodMetadata()
   public addManagedPolicy(policy: IManagedPolicy): void {
-    // Using "Type Predicate" to confirm x is ManagedPolicy, which allows to avoid
+    // Using "Type Predicate" to confirm x is ManagedPolicy, which allows us to avoid
     // using try ... catch and throw error.
     const isManagedPolicy = (x: IManagedPolicy): x is ManagedPolicy => {
       return (x as ManagedPolicy).attachToRole !== undefined;

--- a/packages/aws-cdk-lib/aws-lambda/lib/function-base.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function-base.ts
@@ -49,7 +49,7 @@ export interface IFunction extends IResource, ec2.IConnectable, iam.IGrantable, 
   /**
    * Whether or not this Lambda function was bound to a VPC
    *
-   * If this is is `false`, trying to access the `connections` object will fail.
+   * If this is `false`, trying to access the `connections` object will fail.
    */
   readonly isBoundToVpc: boolean;
 
@@ -490,7 +490,7 @@ export abstract class FunctionBase extends Resource implements IFunction, ec2.IC
   /**
    * Whether or not this Lambda function was bound to a VPC
    *
-   * If this is is `false`, trying to access the `connections` object will fail.
+   * If this is `false`, trying to access the `connections` object will fail.
    */
   public get isBoundToVpc(): boolean {
     return !!this._connections;

--- a/packages/aws-cdk-lib/aws-rds/lib/props.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/props.ts
@@ -245,7 +245,7 @@ export abstract class Credentials {
    * @param secret The secret where the credentials are stored
    * @param username The username defined in the secret. If specified the username
    *   will be referenced as a string and not a dynamic reference to the username
-   *   field in the secret. This allows to replace the secret without replacing the
+   *   field in the secret. This allows you to replace the secret without replacing the
    *   instance or cluster.
    */
   public static fromSecret(secret: secretsmanager.ISecret, username?: string): Credentials {

--- a/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
@@ -71,7 +71,7 @@ export interface HostedZoneProps extends CommonHostedZoneProps {
  */
 export interface ZoneSigningOptions {
   /**
-   * The customer-managed KMS key that that will be used to sign the records.
+   * The customer-managed KMS key that will be used to sign the records.
    *
    * The KMS Key must be unique for each KSK within a hosted zone. Additionally, the
    * KMS key must be an asymetric customer-managed key using the ECC_NIST_P256 algorithm.

--- a/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
@@ -80,7 +80,7 @@ export interface HostedZoneProps extends CommonHostedZoneProps {
  */
 export interface ZoneSigningOptions {
   /**
-   * The customer-managed KMS key that that will be used to sign the records.
+   * The customer-managed KMS key that will be used to sign the records.
    *
    * The KMS Key must be unique for each KSK within a hosted zone. Additionally, the
    * KMS key must be an asymetric customer-managed key using the ECC_NIST_P256 algorithm.

--- a/packages/aws-cdk-lib/aws-route53/lib/key-signing-key.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/key-signing-key.ts
@@ -19,7 +19,7 @@ export interface KeySigningKeyProps {
   readonly hostedZone: IHostedZone;
 
   /**
-   * The customer-managed KMS key that that will be used to sign the records.
+   * The customer-managed KMS key that will be used to sign the records.
    *
    * The KMS Key must be unique for each KSK within a hosted zone. Additionally, the
    * KMS key must be an asymetric customer-managed key using the ECC_NIST_P256 algorithm.

--- a/packages/aws-cdk-lib/aws-route53/lib/record-set.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/record-set.ts
@@ -231,7 +231,7 @@ export interface RecordSetOptions {
   /**
    * Whether to delete the same record set in the hosted zone if it already exists (dangerous!)
    *
-   * This allows to deploy a new record set while minimizing the downtime because the
+   * This allows you to deploy a new record set while minimizing the downtime because the
    * new record set will be created immediately after the existing one is deleted. It
    * also avoids "manual" actions to delete existing record sets.
    *

--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/source.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/source.ts
@@ -268,7 +268,7 @@ export class Source {
    * Process objects such that it escapes token output suitable for JSON output.
    *
    * @param scope Parent construct scope
-   * @returns Object with with tokens escaped for JSON output.
+   * @returns Object with tokens escaped for JSON output.
    */
   private static escapeTokens(scope: Construct, obj: any): any {
     if (Token.isUnresolved(obj)) {

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -2594,7 +2594,7 @@ export class Bucket extends BucketBase {
       throw new ValidationError(lit`EncryptionkeySpecified`, `encryptionKey is specified, so 'encryption' must be set to KMS or DSSE (value: ${encryptionType})`, this);
     }
 
-    // if bucketKeyEnabled is set, encryption can not be BucketEncryption.UNENCRYPTED
+    // if bucketKeyEnabled is set, encryption cannot be BucketEncryption.UNENCRYPTED
     if (props.bucketKeyEnabled && encryptionType === BucketEncryption.UNENCRYPTED) {
       throw new ValidationError(lit`BucketKeyEnabledSpecifiedEncryption`, `bucketKeyEnabled is specified, so 'encryption' must be set to KMS, DSSE or S3 (value: ${encryptionType})`, this);
     }
@@ -3216,7 +3216,7 @@ export class Bucket extends BucketBase {
  */
 export enum BucketEncryption {
   /**
-   * Previous option. Buckets can not be unencrypted now.
+   * Previous option. Buckets cannot be unencrypted now.
    * @see https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
    * @deprecated S3 applies server-side encryption with SSE-S3 for every bucket
    * that default encryption is not configured.

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -2732,7 +2732,7 @@ export class Bucket extends BucketBase {
       throw new ValidationError(lit`EncryptionkeySpecified`, `encryptionKey is specified, so 'encryption' must be set to KMS or DSSE (value: ${encryptionType})`, this);
     }
 
-    // if bucketKeyEnabled is set, encryption can not be BucketEncryption.UNENCRYPTED
+    // if bucketKeyEnabled is set, encryption cannot be BucketEncryption.UNENCRYPTED
     if (props.bucketKeyEnabled && encryptionType === BucketEncryption.UNENCRYPTED) {
       throw new ValidationError(lit`BucketKeyEnabledSpecifiedEncryption`, `bucketKeyEnabled is specified, so 'encryption' must be set to KMS, DSSE or S3 (value: ${encryptionType})`, this);
     }
@@ -3355,7 +3355,7 @@ export class Bucket extends BucketBase {
  */
 export enum BucketEncryption {
   /**
-   * Previous option. Buckets can not be unencrypted now.
+   * Previous option. Buckets cannot be unencrypted now.
    * @see https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
    * @deprecated S3 applies server-side encryption with SSE-S3 for every bucket
    * that default encryption is not configured.

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
@@ -934,7 +934,7 @@ export class SecretTargetAttachment extends SecretBase implements ISecretTargetA
     this.encryptionKey = this.attachedSecret.encryptionKey;
     this.secretName = this.attachedSecret.secretName;
 
-    // This allows to reference the secret after attachment (dependency).
+    // This allows you to reference the secret after attachment (dependency).
     this.secretArn = attachment.ref;
     this.secretTargetAttachmentSecretArn = attachment.ref;
   }

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
@@ -941,7 +941,7 @@ export class SecretTargetAttachment extends SecretBase implements ISecretTargetA
     this.encryptionKey = this.attachedSecret.encryptionKey;
     this.secretName = this.attachedSecret.secretName;
 
-    // This allows to reference the secret after attachment (dependency).
+    // This allows you to reference the secret after attachment (dependency).
     this.secretArn = attachment.ref;
     this.secretTargetAttachmentSecretArn = attachment.ref;
   }

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -2014,7 +2014,7 @@ Step Functions supports [AWS Step Functions](https://docs.aws.amazon.com/step-fu
 
 You can manage [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) executions.
 
-AWS Step Functions supports it's own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
+AWS Step Functions supports its own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
 
 ```ts
 // Define a state machine with one Pass state

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -2041,7 +2041,7 @@ Step Functions supports [AWS Step Functions](https://docs.aws.amazon.com/step-fu
 
 You can manage [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) executions.
 
-AWS Step Functions supports it's own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
+AWS Step Functions supports its own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
 
 ```ts
 // Define a state machine with one Pass state

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-fleet-by-name.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-fleet-by-name.ts
@@ -50,17 +50,17 @@ export interface EmrModifyInstanceFleetByNameJsonataProps extends sfn.TaskStateJ
 export interface EmrModifyInstanceFleetByNameProps extends sfn.TaskStateBaseProps, EmrModifyInstanceFleetByNameOptions { }
 
 /**
- * A Step Functions Task to to modify an InstanceFleet on an EMR Cluster.
+ * A Step Functions Task to modify an InstanceFleet on an EMR Cluster.
  */
 export class EmrModifyInstanceFleetByName extends sfn.TaskStateBase {
   /**
-   * A Step Functions Task using JSONPath to to modify an InstanceFleet on an EMR Cluster.
+   * A Step Functions Task using JSONPath to modify an InstanceFleet on an EMR Cluster.
    */
   public static jsonPath(scope: Construct, id: string, props: EmrModifyInstanceFleetByNameJsonPathProps) {
     return new EmrModifyInstanceFleetByName(scope, id, props);
   }
   /**
-   * A Step Functions Task using JSONata to to modify an InstanceFleet on an EMR Cluster.
+   * A Step Functions Task using JSONata to modify an InstanceFleet on an EMR Cluster.
    */
   public static jsonata(scope: Construct, id: string, props: EmrModifyInstanceFleetByNameJsonataProps) {
     return new EmrModifyInstanceFleetByName(scope, id, {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-group-by-name.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-modify-instance-group-by-name.ts
@@ -47,7 +47,7 @@ export interface EmrModifyInstanceGroupByNameJsonataProps extends sfn.TaskStateJ
 export interface EmrModifyInstanceGroupByNameProps extends sfn.TaskStateBaseProps, EmrModifyInstanceGroupByNameOptions {}
 
 /**
- * A Step Functions Task to to modify an InstanceGroup on an EMR Cluster.
+ * A Step Functions Task to modify an InstanceGroup on an EMR Cluster.
  *
  */
 export class EmrModifyInstanceGroupByName extends sfn.TaskStateBase {

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-set-cluster-termination-protection.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/emr/emr-set-cluster-termination-protection.ts
@@ -32,7 +32,7 @@ export interface EmrSetClusterTerminationProtectionJsonataProps extends sfn.Task
 export interface EmrSetClusterTerminationProtectionProps extends sfn.TaskStateBaseProps, EmrSetClusterTerminationProtectionOptions { }
 
 /**
- * A Step Functions Task to to set Termination Protection on an EMR Cluster.
+ * A Step Functions Task to set Termination Protection on an EMR Cluster.
  */
 export class EmrSetClusterTerminationProtection extends sfn.TaskStateBase {
   /**

--- a/packages/aws-cdk-lib/core/lib/assets.ts
+++ b/packages/aws-cdk-lib/core/lib/assets.ts
@@ -334,7 +334,7 @@ export interface DockerImageAssetSource {
 export enum FileAssetPackaging {
   /**
    * The asset source path points to a directory, which should be archived using
-   * zip and and then uploaded to Amazon S3.
+   * zip and then uploaded to Amazon S3.
    */
   ZIP_DIRECTORY = 'zip',
 

--- a/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-parameter.ts
@@ -115,7 +115,7 @@ export class CfnParameter extends CfnElement {
 
   /**
    * Creates a parameter construct.
-   * Note that the name (logical ID) of the parameter will derive from it's `coname` and location
+   * Note that the name (logical ID) of the parameter will derive from its `coname` and location
    * within the stack. Therefore, it is recommended that parameters are defined at the stack level.
    *
    * @param scope The parent construct.

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
@@ -63,7 +63,7 @@ export interface CodeBuildStepProps extends ShellStepProps {
   /**
    * Policy statements to add to role used during the synth
    *
-   * Can be used to add acces to a CodeArtifact repository etc.
+   * Can be used to add access to a CodeArtifact repository etc.
    *
    * @default - No policy statements added to CodeBuild Project Role
    */


### PR DESCRIPTION
Fixes various grammar errors and typos in source comments and JSDoc:
- "can not" → "cannot"
- "a the" → "the"
- "allows to" → "allows you to"
- "an warning" → "a warning", "an unique" → "a unique"
- "that that" → "that"
- "it's" → "its" (possessive)
- Spelling: priveleges, acces, assoicated, exeuction, defualt
- "eg." → "e.g."
- Duplicate words removed

Consolidates the following closed PRs into a single review:
- #37400, #37420, #37422, #37423, #37426, #37427, #37428, #37429, #37440, #37441, #37442, #37443, #37444, #37445

All changes are documentation-only. No code behavior changes.