### PR TITLE
docs: fix grammar errors and typos in README files

### DIFF
--- a/packages/@aws-cdk/integ-tests-alpha/README.md
+++ b/packages/@aws-cdk/integ-tests-alpha/README.md
@@ -219,7 +219,7 @@ new AwsApiCall(myAppStack, 'GetObject', {
 
 ### DeployAssert
 
-Assertions are created by using the `DeployAssert` construct. This construct creates it's own `Stack` separate from
+Assertions are created by using the `DeployAssert` construct. This construct creates its own `Stack` separate from
 any stacks that you create as part of your integration tests. This `Stack` is treated differently from other stacks
 by the `integ-runner` tool. For example, this stack will not be diffed by the `integ-runner`.
 

--- a/packages/aws-cdk-lib/aws-apigateway/README.md
+++ b/packages/aws-cdk-lib/aws-apigateway/README.md
@@ -1416,7 +1416,7 @@ new apigateway.RestApi(this, 'books', {
 
 You can use the `methodOptions` property to configure
 [default method throttling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html#apigateway-api-level-throttling-in-usage-plan)
-for a stage. The following snippet configures the a stage that accepts
+for a stage. The following snippet configures a stage that accepts
 100 requests per minute, allowing burst up to 200 requests per minute.
 
 ```ts

--- a/packages/aws-cdk-lib/aws-config/README.md
+++ b/packages/aws-cdk-lib/aws-config/README.md
@@ -66,7 +66,7 @@ new config.AccessKeysRotated(this, 'AccessKeyRotated');
 #### CloudFormation Stack drift detection
 
 Checks whether your CloudFormation stack's actual configuration differs, or has drifted,
-from it's expected configuration.
+from its expected configuration.
 
 ```ts
 // compliant if stack's status is 'IN_SYNC'

--- a/packages/aws-cdk-lib/aws-kms/README.md
+++ b/packages/aws-cdk-lib/aws-kms/README.md
@@ -100,7 +100,7 @@ must be set to `true`. By default, this flag is `false` and grant calls on an im
 
 If you can't use a KMS key imported by alias (e.g. because you need access to the key id), you can lookup the key with `Key.fromLookup()`.
 
-In general, the preferred method would be to use `Alias.fromAliasName()` which returns an `IAlias` object which extends `IKey`. However, some services need to have access to the underlying key id. In this case, `Key.fromLookup()` allows to lookup the key id.
+In general, the preferred method would be to use `Alias.fromAliasName()` which returns an `IAlias` object which extends `IKey`. However, some services need to have access to the underlying key id. In this case, `Key.fromLookup()` allows you to look up the key id.
 
 The result of the `Key.fromLookup()` operation will be written to a file
 called `cdk.context.json`. You must commit this file to source control so

--- a/packages/aws-cdk-lib/aws-lambda-destinations/README.md
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/README.md
@@ -122,7 +122,7 @@ payload file in the configured bucket is `aws/lambda/async/<function-name>/YYYY/
 
 ### Auto-extract response payload with lambda destination
 
-The `responseOnly` option of `LambdaDestination` allows to auto-extract the response payload from the
+The `responseOnly` option of `LambdaDestination` allows you to auto-extract the response payload from the
 invocation record:
 
 ```ts
@@ -146,5 +146,5 @@ In the above example, `destinationFn` will be invoked with the payload returned 
 When used with `onFailure`, the destination function is invoked with the error object returned
 by the source function.
 
-Using the `responseOnly` option allows to easily chain asynchronous Lambda functions without
+Using the `responseOnly` option allows you to easily chain asynchronous Lambda functions without
 having to deal with data extraction in the runtime code.

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/README.md
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/README.md
@@ -238,7 +238,7 @@ new nodejs.NodejsFunction(this, 'my-handler', {
     charset: nodejs.Charset.UTF8, // do not escape non-ASCII characters, defaults to Charset.ASCII
     format: nodejs.OutputFormat.ESM, // ECMAScript module output format, defaults to OutputFormat.CJS (OutputFormat.ESM requires Node.js >= 14)
     mainFields: ['module', 'main'], // prefer ECMAScript versions of dependencies
-    inject: ['./my-shim.js', './other-shim.js'], // allows to automatically replace a global variable with an import from another file
+    inject: ['./my-shim.js', './other-shim.js'], // allows you to automatically replace a global variable with an import from another file
     esbuildArgs: { // Pass additional arguments to esbuild
       "--log-limit": "0",
       "--splitting": true,

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/README.md
@@ -2014,7 +2014,7 @@ Step Functions supports [AWS Step Functions](https://docs.aws.amazon.com/step-fu
 
 You can manage [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) executions.
 
-AWS Step Functions supports it's own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
+AWS Step Functions supports its own [`StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) API as a service integration.
 
 ```ts
 // Define a state machine with one Pass state

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -1477,7 +1477,7 @@ any prefix.
 
 Flag type: New default behavior
 
-When this featuer flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`.
+When this feature flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`.
 
 
 | Since | Unset behaves like | Recommended value |

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -345,7 +345,7 @@ _cdk.json_
 
 When enabled, the default volume type of the EBS volume will be GP3.
 
-When this featuer flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
+When this feature flag is enabled, the default volume type of the EBS volume will be `EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3`
 
 _cdk.json_
 
@@ -361,7 +361,7 @@ _cdk.json_
 
 When enabled, remove default deployment alarm settings.
 
-When this featuer flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
+When this feature flag is enabled, remove the default deployment alarm settings when creating a AWS ECS service.
 
 _cdk.json_
 

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -1174,7 +1174,7 @@ export const FLAGS: Record<string, FlagInfo> = {
     type: FlagType.ApiDefault,
     summary: 'When enabled, the default volume type of the EBS volume will be GP3',
     detailsMd: `
-      When this featuer flag is enabled, the default volume type of the EBS volume will be \`EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3\`.
+      When this feature flag is enabled, the default volume type of the EBS volume will be \`EbsDeviceVolumeType.GENERAL_PURPOSE_SSD_GP3\`.
     `,
     introducedIn: { v2: '2.140.0' },
     recommendedValue: true,


### PR DESCRIPTION
Fixes various grammar errors and typos in README files:
- "featuer" → "feature" (cx-api)
- "it's" → "its" (possessive)
- "allows to" → "allows you to"
- "the a stage" → "a stage" (apigateway)

Consolidates the following closed PRs into a single review:
- #37436, #37437, #37438, #37439

All changes are documentation-only (README files). No code behavior changes.