### PR TITLE
docs: update HTTP to HTTPS for external links in JSDoc

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/json-schema.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/json-schema.ts
@@ -21,7 +21,7 @@ export enum JsonSchemaType {
  * Represents a JSON schema definition of the structure of a
  * REST API model. Copied from npm module jsonschema.
  *
- * @see http://json-schema.org/
+ * @see https://json-schema.org/
  * @see https://github.com/tdegrunt/jsonschema
  */
 export interface JsonSchema {

--- a/packages/aws-cdk-lib/aws-autoscaling/lib/schedule.ts
+++ b/packages/aws-cdk-lib/aws-autoscaling/lib/schedule.ts
@@ -10,7 +10,7 @@ export abstract class Schedule {
    * Construct a schedule from a literal schedule expression
    *
    * @param expression The expression to use. Must be in a format that AutoScaling will recognize
-   * @see http://crontab.org/
+   * @see https://crontab.org/
    */
   public static expression(expression: string): Schedule {
     return new LiteralSchedule(expression);
@@ -61,7 +61,7 @@ export abstract class Schedule {
  * All fields are strings so you can use complex expressions. Absence of
  * a field implies '*' or '?', whichever one is appropriate.
  *
- * @see http://crontab.org/
+ * @see https://crontab.org/
  */
 export interface CronOptions {
   /**

--- a/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/instance.ts
@@ -375,7 +375,7 @@ export interface InstanceProps {
    * Whether "Detailed Monitoring" is enabled for this instance
    * Keep in mind that Detailed Monitoring results in extra charges
    *
-   * @see http://aws.amazon.com/cloudwatch/pricing/
+   * @see https://aws.amazon.com/cloudwatch/pricing/
    * @default - false
    */
   readonly detailedMonitoring?: boolean;

--- a/packages/aws-cdk-lib/aws-eks-v2/lib/oidc-provider.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/lib/oidc-provider.ts
@@ -43,7 +43,7 @@ export interface OidcProviderNativeProps extends OpenIdConnectProviderProps {}
  * This implementation has default values for thumbprints and clientIds props
  * that will be compatible with the eks cluster
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * @resource AWS::CloudFormation::CustomResource
@@ -84,7 +84,7 @@ export class OpenIdConnectProvider extends iam.OpenIdConnectProvider {
  * This implementation uses the native CloudFormation resource and has default
  * values for thumbprints and clientIds props that will be compatible with the eks cluster.
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * @resource AWS::IAM::OIDCProvider

--- a/packages/aws-cdk-lib/aws-eks/lib/oidc-provider.ts
+++ b/packages/aws-cdk-lib/aws-eks/lib/oidc-provider.ts
@@ -43,7 +43,7 @@ export interface OidcProviderNativeProps extends OpenIdConnectProviderProps {}
  * This implementation has default values for thumbprints and clientIds props
  * that will be compatible with the eks cluster
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * **For new projects, it is recommended to use `OidcProviderNative` instead which creates the OIDC provider using the native CloudFormation resource (AWS::IAM::OIDCProvider).**
@@ -85,7 +85,7 @@ export class OpenIdConnectProvider extends iam.OpenIdConnectProvider {
  * This implementation uses the native CloudFormation resource and has default
  * values for thumbprints and clientIds props that will be compatible with the eks cluster.
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * @resource AWS::IAM::OIDCProvider

--- a/packages/aws-cdk-lib/aws-iam/lib/oidc-provider-native.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/oidc-provider-native.ts
@@ -131,7 +131,7 @@ export interface OidcProviderNativeProps {
  * requires access to AWS resources, but you don't want to create custom sign-in
  * code or manage your own user identities.
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * @resource AWS::IAM::OIDCProvider

--- a/packages/aws-cdk-lib/aws-iam/lib/oidc-provider.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/oidc-provider.ts
@@ -117,7 +117,7 @@ export interface OpenIdConnectProviderProps {
  * 2. Discuss with the CDK team before proceeding
  * 3. Ensure any changes maintain strict backward compatibility
  *
- * @see http://openid.net/connect
+ * @see https://openid.net/connect
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
  *
  * @resource AWS::CloudFormation::CustomResource


### PR DESCRIPTION
Updates HTTP links to HTTPS for AWS documentation and external references in JSDoc @see tags and inline comments.

Consolidates the following closed PRs into a single review:
- #37424, #37531

All changes are documentation-only. No code behavior changes.