### PR TITLE
chore(secretsmanager): Update SecretRotationApplication semantic versions

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-docdb/test/integ.cluster-rotation.lit.js.snapshot/aws-cdk-docdb-cluster-rotation.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-docdb/test/integ.cluster-rotation.lit.js.snapshot/aws-cdk-docdb-cluster-rotation.template.json
@@ -691,15 +691,15 @@
   "DatabaseRotationSingleUserSARMapping9AEB3E55": {
    "aws": {
     "applicationId": "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerMongoDBRotationSingleUser",
-    "semanticVersion": "1.1.618"
+    "semanticVersion": "1.1.650"
    },
    "aws-cn": {
     "applicationId": "arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/SecretsManagerMongoDBRotationSingleUser",
-    "semanticVersion": "1.1.237"
+    "semanticVersion": "1.1.421"
    },
    "aws-us-gov": {
     "applicationId": "arn:aws-us-gov:serverlessrepo:us-gov-west-1:023102451235:applications/SecretsManagerMongoDBRotationSingleUser",
-    "semanticVersion": "1.1.213"
+    "semanticVersion": "1.1.397"
    }
   }
  },

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-rds/test/integ.cluster-rotation.lit.js.snapshot/aws-cdk-rds-cluster-rotation.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-rds/test/integ.cluster-rotation.lit.js.snapshot/aws-cdk-rds-cluster-rotation.template.json
@@ -1204,29 +1204,29 @@
   "DatabaseRotationSingleUserSARMapping9AEB3E55": {
    "aws": {
     "applicationId": "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.618"
+    "semanticVersion": "1.1.650"
    },
    "aws-cn": {
     "applicationId": "arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.237"
+    "semanticVersion": "1.1.421"
    },
    "aws-us-gov": {
     "applicationId": "arn:aws-us-gov:serverlessrepo:us-gov-west-1:023102451235:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.213"
+    "semanticVersion": "1.1.397"
    }
   },
   "CustomRotationOptionsRotationSingleUserSARMapping635D6F45": {
    "aws": {
     "applicationId": "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.618"
+    "semanticVersion": "1.1.650"
    },
    "aws-cn": {
     "applicationId": "arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.237"
+    "semanticVersion": "1.1.421"
    },
    "aws-us-gov": {
     "applicationId": "arn:aws-us-gov:serverlessrepo:us-gov-west-1:023102451235:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.213"
+    "semanticVersion": "1.1.397"
    }
   }
  },

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-rds/test/integ.cluster-snapshot.js.snapshot/aws-cdk-rds-cluster-snapshot.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-rds/test/integ.cluster-snapshot.js.snapshot/aws-cdk-rds-cluster-snapshot.template.json
@@ -2148,15 +2148,15 @@
   "RestoredClusterRotationSingleUserSARMappingD8A0064F": {
    "aws": {
     "applicationId": "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.618"
+    "semanticVersion": "1.1.650"
    },
    "aws-cn": {
     "applicationId": "arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.237"
+    "semanticVersion": "1.1.421"
    },
    "aws-us-gov": {
     "applicationId": "arn:aws-us-gov:serverlessrepo:us-gov-west-1:023102451235:applications/SecretsManagerRDSMySQLRotationSingleUser",
-    "semanticVersion": "1.1.213"
+    "semanticVersion": "1.1.397"
    }
   }
  },

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
@@ -8,103 +8,151 @@ import { Names, Stack, CfnMapping, Aws, RemovalPolicy, ValidationError, Unscoped
 import { lit } from '../../core/lib/private/literal-string';
 
 /**
- * Options for a SecretRotationApplication
- */
-export interface SecretRotationApplicationOptions {
-  /**
-   * Whether the rotation application uses the mutli user scheme
-   *
-   * @default false
-   */
-  readonly isMultiUser?: boolean;
-}
-
-/**
  * A secret rotation serverless application.
  */
 export class SecretRotationApplication {
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS MariaDB using the single user rotation scheme
    */
-  public static readonly MARIADB_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSMariaDBRotationSingleUser', '1.1.618');
+  public static readonly MARIADB_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSMariaDBRotationSingleUser', {
+    'aws': '1.1.649',
+    'aws-cn': '1.1.423',
+    'aws-us-gov': '1.1.399',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS MariaDB using the multi user rotation scheme
    */
-  public static readonly MARIADB_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSMariaDBRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly MARIADB_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSMariaDBRotationMultiUser', {
+    'aws': '1.1.649',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS MySQL using the single user rotation scheme
    */
-  public static readonly MYSQL_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSMySQLRotationSingleUser', '1.1.618');
+  public static readonly MYSQL_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSMySQLRotationSingleUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS MySQL using the multi user rotation scheme
    */
-  public static readonly MYSQL_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSMySQLRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly MYSQL_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSMySQLRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS Oracle using the single user rotation scheme
    */
-  public static readonly ORACLE_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSOracleRotationSingleUser', '1.1.618');
+  public static readonly ORACLE_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSOracleRotationSingleUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS Oracle using the multi user rotation scheme
    */
-  public static readonly ORACLE_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSOracleRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly ORACLE_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSOracleRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using the single user rotation scheme
    */
-  public static readonly POSTGRES_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSPostgreSQLRotationSingleUser', '1.1.618');
+  public static readonly POSTGRES_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSPostgreSQLRotationSingleUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using the multi user rotation scheme
    */
-  public static readonly POSTGRES_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSPostgreSQLRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly POSTGRES_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSPostgreSQLRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS SQL Server using the single user rotation scheme
    */
-  public static readonly SQLSERVER_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSSQLServerRotationSingleUser', '1.1.618');
+  public static readonly SQLSERVER_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSSQLServerRotationSingleUser', {
+    'aws': '1.1.649',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS SQL Server using the multi user rotation scheme
    */
-  public static readonly SQLSERVER_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSSQLServerRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly SQLSERVER_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSSQLServerRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for Amazon Redshift using the single user rotation scheme
    */
-  public static readonly REDSHIFT_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRedshiftRotationSingleUser', '1.1.618');
+  public static readonly REDSHIFT_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRedshiftRotationSingleUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for Amazon Redshift using the multi user rotation scheme
    */
-  public static readonly REDSHIFT_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRedshiftRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly REDSHIFT_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRedshiftRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
   });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for MongoDB using the single user rotation scheme
    */
-  public static readonly MONGODB_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerMongoDBRotationSingleUser', '1.1.618');
+  public static readonly MONGODB_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerMongoDBRotationSingleUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.421',
+    'aws-us-gov': '1.1.397',
+  });
 
   /**
    * Conducts an AWS SecretsManager secret rotation for MongoDB using the multi user rotation scheme
    */
-  public static readonly MONGODB_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerMongoDBRotationMultiUser', '1.1.618', {
-    isMultiUser: true,
+  public static readonly MONGODB_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerMongoDBRotationMultiUser', {
+    'aws': '1.1.650',
+    'aws-cn': '1.1.422',
+    'aws-us-gov': '1.1.398',
+  });
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS Db2 using the single user rotation scheme
+   */
+  public static readonly DB2_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationSingleUser', {
+    'aws': '1.1.250',
+    'aws-cn': '1.1.223',
+    'aws-us-gov': '1.1.199',
+  });
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS Db2 using the multi user rotation scheme
+   */
+  public static readonly DB2_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationMultiUser', {
+    'aws': '1.1.251',
+    'aws-cn': '1.1.221',
+    'aws-us-gov': '1.1.197',
   });
 
   /**
@@ -131,13 +179,23 @@ export class SecretRotationApplication {
    */
   private readonly applicationName: string;
 
-  constructor(applicationId: string, semanticVersion: string, options?: SecretRotationApplicationOptions) {
-    // partitions are handled explicitly via applicationArnForPartition()
-    // eslint-disable-next-line @cdklabs/no-literal-partition
-    this.applicationId = `arn:aws:serverlessrepo:us-east-1:297356227824:applications/${applicationId}`;
-    this.semanticVersion = semanticVersion;
-    this.applicationName = applicationId;
-    this.isMultiUser = options && options.isMultiUser;
+  private readonly partitionalSematicVersions: { [partition: string]: string };
+
+  /**
+   * @param applicationName - The name of the rotation application
+   * @param semanticVersions - Per-partition semantic versions
+   */
+  constructor(applicationName: string, semanticVersions: { [partition: string]: string }) {
+    this.applicationName = applicationName;
+    this.isMultiUser = applicationName.endsWith('MultiUser');
+    if (!this.isMultiUser && !applicationName.endsWith('SingleUser')) {
+      throw new UnscopedValidationError(lit`InvalidApplicationId`, `applicationName must end with 'SingleUser' or 'MultiUser': ${applicationName}`);
+    }
+    this.partitionalSematicVersions = semanticVersions;
+
+    // Constants that are stored for backwards compatibility
+    this.semanticVersion = this.semanticVersionForPartition('aws');
+    this.applicationId = this.applicationArnForPartition('aws');
   }
 
   /**
@@ -146,7 +204,8 @@ export class SecretRotationApplication {
    */
   public applicationArnForPartition(partition: string) {
     if (partition === 'aws') {
-      return this.applicationId;
+      // eslint-disable-next-line @cdklabs/no-literal-partition
+      return `arn:aws:serverlessrepo:us-east-1:297356227824:applications/${this.applicationName}`;
     } else if (partition === 'aws-cn') {
       return `arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/${this.applicationName}`;
     } else if (partition === 'aws-us-gov') {
@@ -161,12 +220,8 @@ export class SecretRotationApplication {
    * Can be used in combination with a `CfnMapping` to automatically select the correct version based on the current partition.
    */
   public semanticVersionForPartition(partition: string) {
-    if (partition === 'aws') {
-      return this.semanticVersion;
-    } else if (partition === 'aws-cn') {
-      return '1.1.237';
-    } else if (partition === 'aws-us-gov') {
-      return '1.1.213';
+    if (this.partitionalSematicVersions.hasOwnProperty(partition)) {
+      return this.partitionalSematicVersions[partition];
     } else {
       throw new UnscopedValidationError(lit`UnsupportedPartition`, `unsupported partition: ${partition}`);
     }


### PR DESCRIPTION
Update the semantic versions for the SecretsManager rotation serverless applications
 - The latest semantic versions use Python 3.12 for the rotation lambda functions
 - The latest semantic versions have fixes for a CWE related to logging raw input to the rotation functions

Add SecretRotationApplications for RDS IBM Db2 secret rotation
 - These rotation applications are the most recent secret rotation applications

### Issue # (if applicable)

Closes #37462.

### Reason for this change
This PR will use the latest serverless application repository semantic versions for the rotation applications.

### Description of changes
Updated the version numbers for all SecretRotationApplication and added support for inconsistent versioning in each of the three supported partitions 

### Describe any new or updated permissions being added
None


### Description of how you validated changes

Unit tests have been updated to match the new semantic versions.

### Checklist
- [ x ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
