### PR TITLE
feat(rds): Add support for 'iam-auth' on Master user for DatabaseClus…

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/cluster.ts
@@ -10,8 +10,8 @@ import type { IParameterGroup } from './parameter-group';
 import { ParameterGroup } from './parameter-group';
 import { DATA_API_ACTIONS } from './perms';
 import { applyDefaultRotationOptions, defaultDeletionProtection, renderCredentials, setupS3ImportExport, helperRemovalPolicy, renderUnless, renderSnapshotCredentials } from './private/util';
-import type { BackupProps, Credentials, InstanceProps, RotationSingleUserOptions, RotationMultiUserOptions, SnapshotCredentials, EngineLifecycleSupport } from './props';
-import { PerformanceInsightRetention } from './props';
+import type { BackupProps, InstanceProps, RotationSingleUserOptions, RotationMultiUserOptions, SnapshotCredentials, EngineLifecycleSupport } from './props';
+import { Credentials, MasterUserAuthenticationType, PerformanceInsightRetention } from './props';
 import type { DatabaseProxyOptions } from './proxy';
 import { DatabaseProxy, ProxyTarget } from './proxy';
 import type { CfnDBClusterProps } from './rds.generated';
@@ -370,6 +370,21 @@ interface DatabaseClusterBaseProps {
    * @default false
    */
   readonly iamAuthentication?: boolean;
+
+  /**
+   * Specifies the authentication type for the master user of the database cluster.
+   *
+   * When set to `MasterUserAuthenticationType.IAM`, the master user authenticates
+   * using IAM database authentication instead of a password. No master user password
+   * or Secrets Manager secret will be generated.
+   *
+   * When using IAM master user authentication, `iamAuthentication` must also be enabled.
+   *
+   * @see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
+   *
+   * @default - password authentication is used for the master user
+   */
+  readonly masterUserAuthenticationType?: MasterUserAuthenticationType;
 
   /**
    * Whether to enable storage encryption.
@@ -961,6 +976,7 @@ abstract class DatabaseClusterNew extends DatabaseClusterBase {
       associatedRoles: clusterAssociatedRoles.length > 0 ? clusterAssociatedRoles : undefined,
       deletionProtection: defaultDeletionProtection(props.deletionProtection, props.removalPolicy),
       enableIamDatabaseAuthentication: props.iamAuthentication,
+      masterUserAuthenticationType: props.masterUserAuthenticationType,
       enableHttpEndpoint: Lazy.any({ produce: () => this.enableDataApi }),
       networkType: props.networkType,
       serverlessV2ScalingConfiguration: Lazy.any({
@@ -1483,16 +1499,35 @@ export class DatabaseCluster extends DatabaseClusterNew {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    const credentials = renderCredentials(this, props.engine, props.credentials);
-    const secret = credentials.secret;
+    const isIamMasterAuth = props.masterUserAuthenticationType === MasterUserAuthenticationType.IAM;
+
+    // Validate IAM master user authentication requirements
+    if (isIamMasterAuth) {
+      if (props.credentials?.password) {
+        throw new ValidationError(lit`IamMasterAuthCannotHavePassword`, 'masterUserAuthenticationType IAM cannot be used with an explicit password in credentials', this);
+      }
+      if (props.credentials?.secret) {
+        throw new ValidationError(lit`IamMasterAuthCannotHaveSecret`, 'masterUserAuthenticationType IAM cannot be used with an explicit secret in credentials', this);
+      }
+      if (!props.iamAuthentication) {
+        throw new ValidationError(lit`IamMasterAuthRequiresIamAuthentication`, 'iamAuthentication must be enabled when masterUserAuthenticationType is IAM', this);
+      }
+    }
 
     const canHaveCredentials = props.replicationSourceIdentifier == undefined;
+
+    // For IAM master auth we only need the username — skip secret/password generation
+    const username = props.credentials?.username ?? props.engine.defaultUsername ?? 'admin';
+    const credentials = isIamMasterAuth
+      ? Credentials.fromUsername(username)
+      : renderCredentials(this, props.engine, props.credentials);
+    const secret = isIamMasterAuth ? undefined : credentials.secret;
 
     const cluster = new CfnDBCluster(this, 'Resource', {
       ...this.newCfnProps,
       // Admin
       masterUsername: canHaveCredentials ? credentials.username : undefined,
-      masterUserPassword: canHaveCredentials ? credentials.password?.unsafeUnwrap() : undefined,
+      masterUserPassword: canHaveCredentials && !isIamMasterAuth ? credentials.password?.unsafeUnwrap() : undefined,
       replicationSourceIdentifier: props.replicationSourceIdentifier,
     });
 

--- a/packages/aws-cdk-lib/aws-rds/lib/props.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/props.ts
@@ -593,6 +593,28 @@ export enum PerformanceInsightRetention {
 }
 
 /**
+ * The authentication type for the master user of a database cluster.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-masteruserauthenticationtype
+ */
+export enum MasterUserAuthenticationType {
+  /**
+   * Use standard database authentication with a password.
+   *
+   * This is the default behavior.
+   */
+  PASSWORD = 'password',
+
+  /**
+   * Use IAM database authentication for the master user.
+   *
+   * When this is set, no master user password or secret is generated.
+   * The `iamAuthentication` property must also be enabled on the cluster.
+   */
+  IAM = 'iam-db-auth',
+}
+
+/**
  * Engine lifecycle support for Amazon RDS and Amazon Aurora
  */
 export enum EngineLifecycleSupport {

--- a/packages/aws-cdk-lib/aws-rds/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/cluster.test.ts
@@ -23,6 +23,7 @@ import {
   DBClusterStorageType,
   DatabaseInsightsMode,
   EngineLifecycleSupport,
+  MasterUserAuthenticationType,
 } from '../lib';
 
 describe('cluster new api', () => {
@@ -5851,6 +5852,184 @@ test.each([
   Template.fromStack(stack).hasResource('AWS::RDS::DBSubnetGroup', {
     DeletionPolicy: subnetValue,
     UpdateReplacePolicy: subnetValue,
+  });
+});
+
+describe('masterUserAuthenticationType', () => {
+  test('IAM master user authentication sets MasterUserAuthenticationType and omits MasterUserPassword', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // WHEN
+    new DatabaseCluster(stack, 'Database', {
+      engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+      writer: ClusterInstance.serverlessV2('writer'),
+      vpc,
+      iamAuthentication: true,
+      masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+    });
+
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserAuthenticationType: 'iam-db-auth',
+      EnableIAMDatabaseAuthentication: true,
+      MasterUsername: 'postgres',
+    });
+    // No MasterUserPassword should be set
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserPassword: Match.absent(),
+    });
+    // No Secret should be created
+    template.resourceCountIs('AWS::SecretsManager::Secret', 0);
+  });
+
+  test('IAM master user authentication with custom username', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // WHEN
+    new DatabaseCluster(stack, 'Database', {
+      engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+      writer: ClusterInstance.serverlessV2('writer'),
+      vpc,
+      iamAuthentication: true,
+      masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+      credentials: Credentials.fromUsername('myadmin'),
+    });
+
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserAuthenticationType: 'iam-db-auth',
+      MasterUsername: 'myadmin',
+      MasterUserPassword: Match.absent(),
+    });
+    template.resourceCountIs('AWS::SecretsManager::Secret', 0);
+  });
+
+  test('IAM master user authentication with custom username from Credentials.fromGeneratedSecret', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // WHEN
+    new DatabaseCluster(stack, 'Database', {
+      engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+      writer: ClusterInstance.serverlessV2('writer'),
+      vpc,
+      iamAuthentication: true,
+      masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+      credentials: Credentials.fromGeneratedSecret('myadmin'),
+    });
+
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserAuthenticationType: 'iam-db-auth',
+      MasterUsername: 'myadmin',
+      MasterUserPassword: Match.absent(),
+    });
+    template.resourceCountIs('AWS::SecretsManager::Secret', 0);
+  });
+
+  test('PASSWORD master user authentication behaves like default', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // WHEN
+    new DatabaseCluster(stack, 'Database', {
+      engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+      writer: ClusterInstance.serverlessV2('writer'),
+      vpc,
+      masterUserAuthenticationType: MasterUserAuthenticationType.PASSWORD,
+    });
+
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserAuthenticationType: 'password',
+    });
+    // Password should be set
+    template.hasResourceProperties('AWS::RDS::DBCluster', {
+      MasterUserPassword: Match.anyValue(),
+    });
+    // Secret should be created
+    template.resourceCountIs('AWS::SecretsManager::Secret', 1);
+  });
+
+  test('fails when IAM master auth is used without iamAuthentication', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // THEN
+    expect(() => {
+      new DatabaseCluster(stack, 'Database', {
+        engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+        writer: ClusterInstance.serverlessV2('writer'),
+        vpc,
+        masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+      });
+    }).toThrow(/iamAuthentication must be enabled when masterUserAuthenticationType is IAM/);
+  });
+
+  test('fails when IAM master auth is used with explicit password', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // THEN
+    expect(() => {
+      new DatabaseCluster(stack, 'Database', {
+        engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+        writer: ClusterInstance.serverlessV2('writer'),
+        vpc,
+        iamAuthentication: true,
+        masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+        credentials: Credentials.fromPassword('admin', cdk.SecretValue.unsafePlainText('password')),
+      });
+    }).toThrow(/masterUserAuthenticationType IAM cannot be used with an explicit password/);
+  });
+
+  test('fails when IAM master auth is used with explicit secret', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+    const secret = new DatabaseSecret(stack, 'Secret', { username: 'admin' });
+
+    // THEN
+    expect(() => {
+      new DatabaseCluster(stack, 'Database', {
+        engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+        writer: ClusterInstance.serverlessV2('writer'),
+        vpc,
+        iamAuthentication: true,
+        masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+        credentials: Credentials.fromSecret(secret),
+      });
+    }).toThrow(/masterUserAuthenticationType IAM cannot be used with an explicit secret/);
+  });
+
+  test('cluster with IAM master auth has no secret property', () => {
+    // GIVEN
+    const stack = testStack();
+    const vpc = new ec2.Vpc(stack, 'VPC');
+
+    // WHEN
+    const cluster = new DatabaseCluster(stack, 'Database', {
+      engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_17_4 }),
+      writer: ClusterInstance.serverlessV2('writer'),
+      vpc,
+      iamAuthentication: true,
+      masterUserAuthenticationType: MasterUserAuthenticationType.IAM,
+    });
+
+    // THEN
+    expect(cluster.secret).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Add support for `masterUserAuthenticationType` passthrough to the `DatabaseCluster` construct.

### Issue # (if applicable)

Closes ##37658

### Reason for this change

Addresses the lack of `iam-auth` within the `DatabaseCluster` construct.  The actual nuance here was a password was always being synthesized which broke configuring `iam-auth` for the mater user.

### Description of changes

- Added props for `masterUserAuthenticationType`
- Wired to construct

### Describe any new or updated permissions being added

None.


### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
