### PR TITLE
chore: upgrade cloud-assembly-schema packages to fix build

### DIFF
--- a/packages/@aws-cdk/cx-api/package.json
+++ b/packages/@aws-cdk/cx-api/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "semver": "^7.7.4",
-    "@aws-cdk/cloud-assembly-api": "^2.2.0"
+    "@aws-cdk/cloud-assembly-api": "^2.2.2"
   },
   "peerDependencies": {
     "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
@@ -89,7 +89,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/cloud-assembly-schema": "^53.17.0",
+    "@aws-cdk/cloud-assembly-schema": "^53.18.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "@types/mock-fs": "^4.13.4",

--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -117,10 +117,10 @@
     "mime-types"
   ],
   "dependencies": {
-    "@aws-cdk/cloud-assembly-api": "^2.2.0",
+    "@aws-cdk/cloud-assembly-api": "^2.2.2",
     "@aws-cdk/asset-awscli-v1": "2.2.273",
     "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-    "@aws-cdk/cloud-assembly-schema": "^53.17.0",
+    "@aws-cdk/cloud-assembly-schema": "^53.18.0",
     "@balena/dockerignore": "^1.0.2",
     "case": "1.6.3",
     "fs-extra": "^11.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,18 +66,18 @@
     "@aws-cdk/service-spec-types" "^0.0.240"
     "@cdklabs/tskb" "^0.0.4"
 
-"@aws-cdk/cloud-assembly-api@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.0.tgz#ef3f2f3f774b5802dabef1beeac6a28f41539715"
-  integrity sha512-u1iNQd7BNxTuSdIjbhoxqOxsYqi3kqj+SST0g1V1g24e/XY3FoiP8SFbiVd/+uLVNVY6mLGJ6+Mx3J5ZEkTFrg==
+"@aws-cdk/cloud-assembly-api@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.2.tgz#79001c2af7a21fba3ced65042fdffb4fff7a1978"
+  integrity sha512-iiypKqfpHMqQ9z6Nwxx42Ha4NCevLVDQ8sphIbqHxSJE5kDe/DCzvh8b2HtlAshWjo44HMhYdfKNLR96S3T4sA==
   dependencies:
     jsonschema "~1.4.1"
     semver "^7.7.4"
 
-"@aws-cdk/cloud-assembly-schema@^53.17.0":
-  version "53.17.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.17.0.tgz#03c28a0a376ed9d58e968d4d987e43bb1bc6be26"
-  integrity sha512-JB9L4JCbZeYbMJPs7OKV+7YaxKwk4i2tlI5PCSfCzk4DJvprhCO2TYcqbqo3Y1YWZyyY/SEPLWdorG7b88fUSA==
+"@aws-cdk/cloud-assembly-schema@^53.18.0":
+  version "53.18.0"
+  resolved "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.18.0.tgz#193533d3821291053891879ba15a6d8bbdf646de"
+  integrity sha512-/fa6rOpokkfa5tVIdhsaexQq5MVVTSsZSD1Tu45YcrdyGRusGrM9RlPMCPrwvMS1UfdVFBhcgO9dl9ODWAWOeQ==
   dependencies:
     jsonschema "~1.4.1"
     semver "^7.7.4"


### PR DESCRIPTION
Update to the latest version of affected packages to fix a Java compilation failure.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
