### PR TITLE
docs(aws-ec2): clarify RouterType.GATEWAY supports Virtual Private Gateway

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -2400,7 +2400,7 @@ export enum RouterType {
   EGRESS_ONLY_INTERNET_GATEWAY = 'EgressOnlyInternetGateway',
 
   /**
-   * Internet Gateway
+   * Internet Gateway or Virtual Private Gateway
    */
   GATEWAY = 'Gateway',
 


### PR DESCRIPTION
﻿### Reason for this change

The JSDoc comment on `RouterType.GATEWAY` only mentions "Internet Gateway", but the underlying CloudFormation `GatewayId` property accepts both an Internet Gateway ID and a Virtual Private Gateway ID, per the [AWS::EC2::Route documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-route.html). This is misleading for users who want to add a route targeting a VGW.

### Description of changes

Updated the JSDoc summary for `RouterType.GATEWAY` in `packages/aws-cdk-lib/aws-ec2/lib/vpc.ts` to mention both Internet Gateway and Virtual Private Gateway.

### Description of how you validated changes

Documentation-only change. No runtime behavior is affected; no tests required.

Closes #37632

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.*
