### PR TITLE
fix(core): default docker bundling --user to host uid:gid

### DIFF
--- a/packages/aws-cdk-lib/core/lib/bundling.ts
+++ b/packages/aws-cdk-lib/core/lib/bundling.ts
@@ -280,9 +280,16 @@ export class BundlingDockerImage {
       ...options.platform
         ? ['--platform', options.platform]
         : [],
-      ...options.user
-        ? ['-u', options.user]
-        : [],
+      ...((): string[] => {
+        // If the caller explicitly provided a user, always honor it.
+        // Otherwise, default to the host's uid:gid on POSIX so that files
+        // produced inside the container (e.g. bundling output) are owned
+        // by the user invoking CDK rather than by `root`. On Windows uids
+        // are not meaningful, so we fall back to the prior behavior of
+        // letting Docker pick the image default. See aws/aws-cdk#32834.
+        const user = options.user ?? defaultDockerUser();
+        return user ? ['-u', user] : [];
+      })(),
       ...options.volumesFrom
         ? flatten(options.volumesFrom.map(v => ['--volumes-from', v]))
         : [],
@@ -554,7 +561,10 @@ export interface DockerRunOptions {
   /**
    * The user to use when running the container.
    *
-   * @default - root or image default
+   * @default - On POSIX hosts, defaults to `${uid}:${gid}` of the current
+   * process so that files written inside the container are owned by the
+   * invoking user rather than `root`. On Windows hosts, no `--user` flag is
+   * passed and Docker uses the image default.
    */
   readonly user?: string;
 
@@ -663,6 +673,37 @@ export interface DockerBuildOptions {
 
 function flatten(x: string[][]) {
   return Array.prototype.concat([], ...x);
+}
+
+/**
+ * Computes the default Docker `--user` value for `docker run`.
+ *
+ * Returns `${uid}:${gid}` of the current process on POSIX hosts so that any
+ * files created inside the container land on the host owned by the caller,
+ * not `root` (the typical container default). Returns `undefined` on Windows
+ * where uids/gids are not meaningful and `process.getuid` is not exposed.
+ *
+ * Callers may override this by passing an explicit `user` in `DockerRunOptions`.
+ */
+function defaultDockerUser(): string | undefined {
+  if (process.platform === 'win32') {
+    return undefined;
+  }
+  // process.getuid / getgid are only present on POSIX. Guard anyway in case
+  // a future runtime lacks them so we degrade gracefully (no `--user` flag).
+  const getuid = (process as { getuid?: () => number }).getuid;
+  const getgid = (process as { getgid?: () => number }).getgid;
+  if (typeof getuid !== 'function' || typeof getgid !== 'function') {
+    return undefined;
+  }
+  const uid = getuid.call(process);
+  const gid = getgid.call(process);
+  // -1 indicates the value is unknown (matches os.userInfo() behavior on
+  // Windows, but kept here as a defensive check on other platforms too).
+  if (uid < 0 || gid < 0) {
+    return undefined;
+  }
+  return `${uid}:${gid}`;
 }
 
 function isSeLinux(): boolean {

--- a/packages/aws-cdk-lib/core/test/bundling.test.ts
+++ b/packages/aws-cdk-lib/core/test/bundling.test.ts
@@ -47,6 +47,9 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset', () => {
+    // Stubbed as win32 so the new POSIX uid:gid default does not apply
+    // and these args remain focused on the build flags under test.
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -88,6 +91,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with cache disabled', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -125,6 +129,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with platform', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -161,6 +166,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with cache-to & cache-from', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -206,6 +212,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with target stage', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -242,6 +249,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with network', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -750,6 +758,7 @@ describe('bundling', () => {
   });
 
   test('bundling with image from asset with build contexts', () => {
+    sinon.stub(process, 'platform').value('win32');
     const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
@@ -842,5 +851,125 @@ describe('bundling', () => {
 
     // THEN
     expect(fromSrc).toEqual('src=path.json');
+  });
+
+  // Coverage for aws/aws-cdk#32834: bundling output should be owned by the
+  // invoking user, not `root`. We verify the docker run argv carries
+  // `-u <uid>:<gid>` on POSIX hosts and omits `-u` on Windows.
+  describe('default --user (issue #32834)', () => {
+    test('defaults --user to host uid:gid on linux', () => {
+      sinon.stub(process, 'platform').value('linux');
+      sinon.stub(process, 'getuid').value(() => 4242);
+      sinon.stub(process, 'getgid').value(() => 5353);
+      const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+        status: 0,
+        stderr: Buffer.from(''),
+        stdout: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const image = DockerImage.fromRegistry('alpine');
+      image.run();
+
+      expect(spawnSyncStub.calledWith(dockerCmd, [
+        'run', '--rm',
+        '-u', '4242:5353',
+        'alpine',
+      ])).toEqual(true);
+    });
+
+    test('defaults --user to host uid:gid on darwin', () => {
+      sinon.stub(process, 'platform').value('darwin');
+      sinon.stub(process, 'getuid').value(() => 501);
+      sinon.stub(process, 'getgid').value(() => 20);
+      const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+        status: 0,
+        stderr: Buffer.from(''),
+        stdout: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const image = DockerImage.fromRegistry('alpine');
+      image.run();
+
+      expect(spawnSyncStub.calledWith(dockerCmd, [
+        'run', '--rm',
+        '-u', '501:20',
+        'alpine',
+      ])).toEqual(true);
+    });
+
+    test('omits --user on win32', () => {
+      sinon.stub(process, 'platform').value('win32');
+      // Even if getuid is somehow exposed on win32, we should not emit -u.
+      sinon.stub(process, 'getuid').value(() => 1000);
+      sinon.stub(process, 'getgid').value(() => 1000);
+      const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+        status: 0,
+        stderr: Buffer.from(''),
+        stdout: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const image = DockerImage.fromRegistry('alpine');
+      image.run();
+
+      expect(spawnSyncStub.calledWith(dockerCmd, [
+        'run', '--rm',
+        'alpine',
+      ])).toEqual(true);
+    });
+
+    test('caller-supplied user is preserved over default', () => {
+      sinon.stub(process, 'platform').value('linux');
+      sinon.stub(process, 'getuid').value(() => 4242);
+      sinon.stub(process, 'getgid').value(() => 5353);
+      const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+        status: 0,
+        stderr: Buffer.from(''),
+        stdout: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const image = DockerImage.fromRegistry('alpine');
+      image.run({ user: 'root' });
+
+      expect(spawnSyncStub.calledWith(dockerCmd, [
+        'run', '--rm',
+        '-u', 'root',
+        'alpine',
+      ])).toEqual(true);
+    });
+
+    test('omits --user when getuid/getgid are unavailable', () => {
+      sinon.stub(process, 'platform').value('linux');
+      // Simulate a runtime that doesn't expose getuid/getgid (defensive path).
+      sinon.stub(process, 'getuid').value(undefined as unknown as () => number);
+      sinon.stub(process, 'getgid').value(undefined as unknown as () => number);
+      const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+        status: 0,
+        stderr: Buffer.from(''),
+        stdout: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const image = DockerImage.fromRegistry('alpine');
+      image.run();
+
+      expect(spawnSyncStub.calledWith(dockerCmd, [
+        'run', '--rm',
+        'alpine',
+      ])).toEqual(true);
+    });
   });
 });


### PR DESCRIPTION
### Issue
Closes #32834

### Reason for this change
On Linux (notably GitHub Actions where the Docker daemon runs as root), bundling output files end up owned by root, so the calling user cannot clean them up. The asset-staging path already handles this via `AssetBundlingBindMount.determineUser()`, but `DockerImage.run()` does not pass a default `--user` when called directly.

### Description of changes
- `DockerImage.run()` now defaults `--user` to `${uid}:${gid}` of the invoking process on POSIX hosts.
- Windows hosts and runtimes without `process.getuid` / `process.getgid` skip the flag (no-op fallback).
- Caller-supplied `options.user` is always honored.

### Description of how you validated changes
Added focused unit tests under `core/test/bundling.test.ts` covering Linux/macOS defaults, Windows omission, caller overrides, and missing `getuid`/`getgid`. All existing core, asset-staging, staging, lambda-nodejs and s3-assets tests continue to pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
