### PR TITLE
chore(core): migrate off of `Beta1` properties internally

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/stack-metadata.ts
+++ b/packages/aws-cdk-lib/core/lib/private/stack-metadata.ts
@@ -7,7 +7,7 @@ import { RESOURCE_SYMBOL } from '../constants';
 import { MetadataType } from '../metadata-type';
 import type { Resource } from '../resource';
 import { Stage } from '../stage';
-import type { IPolicyValidationPluginBeta1 } from '../validation';
+import type { IPolicyValidationPlugin } from '../validation';
 import { ALLOWED_FQN_PREFIXES } from './constants';
 
 // These metadata types are always included
@@ -169,7 +169,7 @@ function addValidationPluginInfo(scope: IConstruct, allConstructInfos: Construct
  *
  * where <rule-ids> is a pipe-separated list of rule IDs.
  */
-function pluginFqn(plugin: IPolicyValidationPluginBeta1): string {
+function pluginFqn(plugin: IPolicyValidationPlugin): string {
   let components = [
     'policyValidation',
     plugin.name,

--- a/packages/aws-cdk-lib/core/lib/private/synthesis.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis.ts
@@ -15,7 +15,7 @@ import { Stack } from '../stack';
 import type { ISynthesisSession } from '../stack-synthesizers/types';
 import type { StageSynthesisOptions } from '../stage';
 import { Stage } from '../stage';
-import type { IPolicyValidationPluginBeta1 } from '../validation';
+import type { IPolicyValidationPlugin } from '../validation';
 import { generateFeatureFlagReport } from './feature-flag-report';
 import { lit } from './literal-string';
 import { ConstructTree } from '../validation/private/construct-tree';
@@ -104,7 +104,7 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
   if (!App.isApp(root)) return;
   let hash: string | undefined;
   const assemblies = getAssemblies(root, assembly);
-  const templatePathsByPlugin: Map<IPolicyValidationPluginBeta1, string[]> = new Map();
+  const templatePathsByPlugin: Map<IPolicyValidationPlugin, string[]> = new Map();
   visitAssemblies(root, 'post', construct => {
     if (Stage.isStage(construct)) {
       for (const plugin of construct.policyValidationBeta1) {

--- a/packages/aws-cdk-lib/core/lib/stage.ts
+++ b/packages/aws-cdk-lib/core/lib/stage.ts
@@ -6,7 +6,7 @@ import { FeatureFlags } from './feature-flags';
 import type { PermissionsBoundary } from './permissions-boundary';
 import { synthesize } from './private/synthesis';
 import { type IPropertyInjector, PropertyInjectors } from './prop-injectors';
-import type { IPolicyValidationPluginBeta1 } from './validation';
+import type { IPolicyValidationPlugin, IPolicyValidationPluginBeta1 } from './validation';
 import * as public_cxapi from '../../cx-api';
 import { _convertCloudAssembly, _convertCloudAssemblyBuilder } from '../../cx-api';
 import { lit } from './private/literal-string';
@@ -185,10 +185,10 @@ export class Stage extends Construct {
    * @default - no validation plugins are used
    */
   public get policyValidationBeta1(): IPolicyValidationPluginBeta1[] {
-    return [...this._policyValidationBeta1];
+    return [...this._policyValidation];
   }
 
-  private readonly _policyValidationBeta1: IPolicyValidationPluginBeta1[] = [];
+  private readonly _policyValidation: IPolicyValidationPlugin[] = [];
 
   constructor(scope: Construct, id: string, props: StageProps = {}) {
     super(scope, id);
@@ -216,7 +216,7 @@ export class Stage extends Construct {
     this.stageName = [this.parentStage?.stageName, props.stageName ?? id].filter(x => x).join('-');
 
     if (props.policyValidationBeta1) {
-      this._policyValidationBeta1.push(...props.policyValidationBeta1);
+      this._policyValidation.push(...props.policyValidationBeta1);
     }
   }
 
@@ -225,8 +225,8 @@ export class Stage extends Construct {
    *
    * @internal
    */
-  public _addValidationPlugins(...plugins: IPolicyValidationPluginBeta1[]): void {
-    this._policyValidationBeta1.push(...plugins);
+  public _addValidationPlugins(...plugins: IPolicyValidationPlugin[]): void {
+    this._policyValidation.push(...plugins);
   }
 
   /**

--- a/packages/aws-cdk-lib/core/lib/validation/private/report.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/report.ts
@@ -8,7 +8,7 @@ import * as report from '../report';
 /**
  * Validation produced by the validation plugin, in construct terms.
  */
-export interface PolicyViolationConstructAware extends report.PolicyViolationBeta1 {
+export interface PolicyViolationConstructAware extends report.PolicyViolation {
   /**
    * The constructs violating this rule.
    */
@@ -18,7 +18,7 @@ export interface PolicyViolationConstructAware extends report.PolicyViolationBet
 /**
  * Construct violating a specific rule.
  */
-export interface ValidationViolatingConstruct extends report.PolicyViolatingResourceBeta1 {
+export interface ValidationViolatingConstruct extends report.PolicyViolatingResource {
   /**
    * The construct path as defined in the application.
    *
@@ -77,7 +77,7 @@ export interface PolicyValidationReportSummary {
   /**
    * The final status of the validation (pass/fail)
    */
-  readonly status: report.PolicyValidationReportStatusBeta1;
+  readonly status: report.PolicyValidationReportStatus;
 
   /**
    * The name of the plugin that created the report
@@ -96,7 +96,7 @@ export interface PolicyValidationReportSummary {
 /**
  * The report containing the name of the plugin that created it.
  */
-export interface NamedValidationPluginReport extends report.PolicyValidationPluginReportBeta1 {
+export interface NamedValidationPluginReport extends report.PolicyValidationPluginReport {
   /**
    * The name of the plugin that created the report
    */
@@ -196,7 +196,7 @@ export class PolicyValidationReportFormatter {
           version: rep.pluginVersion,
           summary: {
             pluginName: rep.pluginName,
-            status: rep.success ? report.PolicyValidationReportStatusBeta1.SUCCESS : report.PolicyValidationReportStatusBeta1.FAILURE,
+            status: rep.success ? report.PolicyValidationReportStatus.SUCCESS : report.PolicyValidationReportStatus.FAILURE,
             metadata: rep.metadata,
           },
           violations: rep.violations.map(violation => ({

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Construct } from 'constructs';
 import { table } from 'table';
 import * as core from '../../lib';
-import type { PolicyValidationPluginReportBeta1, PolicyViolationBeta1 } from '../../lib';
+import type { PolicyValidationPluginReport, PolicyViolation } from '../../lib';
 
 let consoleErrorMock: jest.SpyInstance;
 beforeEach(() => {
@@ -996,15 +996,15 @@ Policy Validation Report Summary
   });
 });
 
-class FakePlugin implements core.IPolicyValidationPluginBeta1 {
+class FakePlugin implements core.IPolicyValidationPlugin {
   constructor(
     public readonly name: string,
-    private readonly violations: PolicyViolationBeta1[],
+    private readonly violations: PolicyViolation[],
     public readonly version?: string,
     public readonly ruleIds?: string []) {
   }
 
-  validate(_context: core.IPolicyValidationContextBeta1): PolicyValidationPluginReportBeta1 {
+  validate(_context: core.IPolicyValidationContext): PolicyValidationPluginReport {
     return {
       success: this.violations.length === 0,
       violations: this.violations,
@@ -1013,10 +1013,10 @@ class FakePlugin implements core.IPolicyValidationPluginBeta1 {
   }
 }
 
-class RoguePlugin implements core.IPolicyValidationPluginBeta1 {
+class RoguePlugin implements core.IPolicyValidationPlugin {
   public readonly name = 'rogue-plugin';
 
-  validate(context: core.IPolicyValidationContextBeta1): PolicyValidationPluginReportBeta1 {
+  validate(context: core.IPolicyValidationContext): PolicyValidationPluginReport {
     const templatePath = context.templatePaths[0];
     fs.writeFileSync(templatePath, 'malicious data');
     return {
@@ -1026,10 +1026,10 @@ class RoguePlugin implements core.IPolicyValidationPluginBeta1 {
   }
 }
 
-class BrokenPlugin implements core.IPolicyValidationPluginBeta1 {
+class BrokenPlugin implements core.IPolicyValidationPlugin {
   public readonly name = 'broken-plugin';
 
-  validate(_context: core.IPolicyValidationContextBeta1): PolicyValidationPluginReportBeta1 {
+  validate(_context: core.IPolicyValidationContext): PolicyValidationPluginReport {
     throw new Error('Something went wrong');
   }
 }


### PR DESCRIPTION
### Reason for this change

The internal validation pipeline (`synthesis.ts`, `private/report.ts`, `stack-metadata.ts`) and test helpers use the deprecated `Beta1` interfaces (`IPolicyValidationPluginBeta1`, `PolicyViolationBeta1`, etc.) since #37613 graduated them.

### Description of changes

Migrate internal code and test helpers from deprecated `Beta1` validation interfaces to their stable equivalents

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
