### PR TITLE
feat(rds): add PostgreSQL instance engine versions 14.22, 15.17, 17.9, 18.3

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -1977,6 +1977,8 @@ export class PostgresEngineVersion {
   public static readonly VER_14_20 = PostgresEngineVersion.of('14.20', '14', { s3Import: true, s3Export: true });
   /** Version "14.21". */
   public static readonly VER_14_21 = PostgresEngineVersion.of('14.21', '14', { s3Import: true, s3Export: true });
+  /** Version "14.22". */
+  public static readonly VER_14_22 = PostgresEngineVersion.of('14.22', '14', { s3Import: true, s3Export: true });
 
   /** Version "15" (only a major version, without a specific minor version). */
   public static readonly VER_15 = PostgresEngineVersion.of('15', '15', { s3Import: true, s3Export: true });
@@ -2031,6 +2033,8 @@ export class PostgresEngineVersion {
   public static readonly VER_15_15 = PostgresEngineVersion.of('15.15', '15', { s3Import: true, s3Export: true });
   /** Version "15.16". */
   public static readonly VER_15_16 = PostgresEngineVersion.of('15.16', '15', { s3Import: true, s3Export: true });
+  /** Version "15.17". */
+  public static readonly VER_15_17 = PostgresEngineVersion.of('15.17', '15', { s3Import: true, s3Export: true });
 
   /** Version "16" (only a major version, without a specific minor version). */
   public static readonly VER_16 = PostgresEngineVersion.of('16', '16', { s3Import: true, s3Export: true });
@@ -2095,6 +2099,8 @@ export class PostgresEngineVersion {
   public static readonly VER_17_7 = PostgresEngineVersion.of('17.7', '17', { s3Import: true, s3Export: true });
   /** Version "17.8". */
   public static readonly VER_17_8 = PostgresEngineVersion.of('17.8', '17', { s3Import: true, s3Export: true });
+  /** Version "17.9". */
+  public static readonly VER_17_9 = PostgresEngineVersion.of('17.9', '17', { s3Import: true, s3Export: true });
 
   /** Version "18" (only a major version, without a specific minor version). */
   public static readonly VER_18 = PostgresEngineVersion.of('18', '18', { s3Import: true, s3Export: true });
@@ -2102,6 +2108,8 @@ export class PostgresEngineVersion {
   public static readonly VER_18_1 = PostgresEngineVersion.of('18.1', '18', { s3Import: true, s3Export: true });
   /** Version "18.2". */
   public static readonly VER_18_2 = PostgresEngineVersion.of('18.2', '18', { s3Import: true, s3Export: true });
+  /** Version "18.3". */
+  public static readonly VER_18_3 = PostgresEngineVersion.of('18.3', '18', { s3Import: true, s3Export: true });
 
   /**
    * Create a new PostgresEngineVersion with an arbitrary version.


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37713 

### Reason for this change

Versions for instance engine were missing
Duplicate of https://github.com/aws/aws-cdk/pull/37715 which was closed without being merged

### Description of changes

Added 4 new static readonly version constants to the PostgresEngineVersion class:

- VER_14_22
- VER_15_17
- VER_17_9
- VER_18_3

Each follows the established pattern with s3Import: true and s3Export: true.

### Description of how you validated changes

TypeScript syntax check: PASS
ESLint: PASS
Pattern matches all existing version constants exactly
Follows the same approach as PR https://github.com/aws/aws-cdk/pull/37488 (Aurora cluster-engine versions)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
