### PR TITLE
feat(aws-cdk-lib): add s3FilesVolumeConfiguration to Volume

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
@@ -653,6 +653,12 @@ export class TaskDefinition extends TaskDefinitionBase {
           transitEncryptionPort: spec.efsVolumeConfiguration.transitEncryptionPort,
 
         },
+        s3FilesVolumeConfiguration: spec.s3FilesVolumeConfiguration && {
+          fileSystemArn: spec.s3FilesVolumeConfiguration.fileSystemArn,
+          accessPointArn: spec.s3FilesVolumeConfiguration.accessPointArn,
+          rootDirectory: spec.s3FilesVolumeConfiguration.rootDirectory,
+          transitEncryptionPort: spec.s3FilesVolumeConfiguration.transitEncryptionPort,
+        },
       };
     }
   }
@@ -784,7 +790,7 @@ export class TaskDefinition extends TaskDefinitionBase {
     }
 
     // Other volume configurations must not be specified.
-    if (volume.host || volume.dockerVolumeConfiguration || volume.efsVolumeConfiguration) {
+    if (volume.host || volume.dockerVolumeConfiguration || volume.efsVolumeConfiguration || volume.s3FilesVolumeConfiguration) {
       throw new ValidationError(lit`VolumeConfigurationsSpecifiedConfiguredAtLaunch`, `Volume Configurations must not be specified for '${volume.name}' when 'configuredAtLaunch' is set to true`, this);
     }
   }
@@ -1164,6 +1170,19 @@ export interface Volume {
    * @default No Elastic FileSystem is setup
    */
   readonly efsVolumeConfiguration?: EfsVolumeConfiguration;
+
+  /**
+   * This property is specified when you are using Amazon S3 Files.
+   *
+   * When specifying Amazon S3 Files volumes in tasks using the Fargate launch type,
+   * Fargate creates a supervisor container that is responsible for managing the Amazon S3 Files volume.
+   * The supervisor container uses a small amount of the task's memory.
+   * The supervisor container is visible when querying the task metadata version 4 endpoint,
+   * but is not visible in CloudWatch Container Insights.
+   *
+   * @default No S3 FileSystem is setup
+   */
+  readonly s3FilesVolumeConfiguration?: S3FilesVolumeConfiguration;
 }
 
 /**
@@ -1324,6 +1343,36 @@ export interface EfsVolumeConfiguration {
    * @default No configuration.
    */
   readonly authorizationConfig?: AuthorizationConfig;
+}
+
+/**
+ * The configuration for an S3 Files volume.
+ */
+export interface S3FilesVolumeConfiguration {
+  /**
+   * The Amazon S3 Files file system ARN to use.
+   */
+  readonly fileSystemArn: string;
+  /**
+   * The Amazon S3 Files access point ARN to use.
+   *
+   * @default No access point configuration.
+   */
+  readonly accessPointArn?: string;
+  /**
+   * The directory within the Amazon S3 Files file system to mount as the root directory inside the host.
+   * Specifying / will have the same effect as omitting this parameter.
+   *
+   * @default The root of the Amazon S3 Files volume
+   */
+  readonly rootDirectory?: string;
+  /**
+   * The port to use when sending encrypted data between
+   * the Amazon ECS host and the Amazon S3 Files server. EFS mount helper uses.
+   *
+   * @default Port selection strategy that the Amazon EFS mount helper uses.
+   */
+  readonly transitEncryptionPort?: number;
 }
 
 /**

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-task-definition.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-task-definition.test.ts
@@ -1112,6 +1112,37 @@ describe('ec2 task definition', () => {
       });
     });
 
+    test('correctly sets s3FilesVolumeConfiguration', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const volume = {
+        name: 'scratch',
+        s3FilesVolumeConfiguration: {
+          fileSystemArn: 'arn:aws:s3files:us-east-1:012345678901:file-system/fs-12345678',
+        },
+      };
+
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef', {
+        volumes: [volume],
+      });
+
+      taskDefinition.addContainer('web', {
+        image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        memoryLimitMiB: 512,
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
+        Family: 'Ec2TaskDef',
+        Volumes: [{
+          Name: 'scratch',
+          S3FilesVolumeConfiguration: {
+            FileSystemArn: 'arn:aws:s3files:us-east-1:012345678901:file-system/fs-12345678',
+          },
+        }],
+      });
+    });
+
     test('correctly sets env variables when using EC2 capacity provider with AWSVPC mode - with no other user-defined env variables', () => {
       // GIVEN AWS-VPC network mode
       const stack = new cdk.Stack();

--- a/packages/aws-cdk-lib/aws-ecs/test/task-definition.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/task-definition.test.ts
@@ -1064,5 +1064,26 @@ describe('Managed Instances compatibility', () => {
         });
       }).toThrow("Volume Configurations must not be specified for 'my-volume' when 'configuredAtLaunch' is set to true");
     });
+
+    test('throws when volume with configuredAtLaunch has s3FilesVolumeConfiguration', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const taskDefinition = new ecs.TaskDefinition(stack, 'TD', {
+        cpu: '512',
+        memoryMiB: '512',
+        compatibility: ecs.Compatibility.FARGATE,
+      });
+
+      // THEN
+      expect(() => {
+        taskDefinition.addVolume({
+          name: 'my-volume',
+          configuredAtLaunch: true,
+          s3FilesVolumeConfiguration: {
+            fileSystemArn: 'arn:aws:s3files:us-east-1:012345678901:file-system/fs-12345678',
+          },
+        });
+      }).toThrow("Volume Configurations must not be specified for 'my-volume' when 'configuredAtLaunch' is set to true");
+    });
   });
 });


### PR DESCRIPTION
Add s3FilesVolumeConfiguration property to Volume to enable adding S3 Files volumes to ECS task definitions.

### Reason for this change

CloudFormation L1 constructs exist for S3 Files support in ECS. This changes updates the L2 construct to support S3 Files volumes.

### Description of changes

Added s3FilesVolumeConfiguration property to Volume input and updated supporting code to support populating the field on the L1 construct.


### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Added new unit tests.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
