### PR TITLE
feat(core): add constructPath to PolicyViolatingResource

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/synthesis.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis.ts
@@ -12,7 +12,6 @@ import { _convertCloudAssemblyBuilder } from '../../../cx-api/lib/legacy-moved';
 import { Annotations } from '../annotations';
 import { App } from '../app';
 import { _aspectTreeRevisionReader, AspectApplication, AspectPriority, Aspects } from '../aspect';
-import { CfnResource } from '../cfn-resource';
 import { AssumptionError, UnscopedValidationError } from '../errors';
 import { FeatureFlags } from '../feature-flags';
 import { FileSystem } from '../fs';
@@ -136,35 +135,16 @@ function collectAnnotationReport(root: IConstruct, outdir: string): NamedValidat
       const severity = entry.type === cxschema.ArtifactMetadataEntryType.ERROR ? 'error' : 'warning';
       const ruleName = extractRuleName(message, severity);
 
-      // Find the nearest CfnResource to map back to a logical ID
-      const resource = findNearestResource(construct);
-      let resourceLogicalId: string;
-      let templatePath: string;
-
-      if (resource) {
-        const stack = Stack.of(resource);
-        resourceLogicalId = stack.resolve(resource.logicalId);
-        templatePath = path.join(outdir, stack.templateFile);
-      } else {
-        // Construct is not associated with a CfnResource — use construct path as identifier
-        resourceLogicalId = construct.node.path;
-        try {
-          const stack = Stack.of(construct);
-          templatePath = path.join(outdir, stack.templateFile);
-        } catch (e: any) {
-          // Stack.of() throws when the construct is not inside a Stack
-          // (e.g. attached directly to App or Stage). Any other error
-          // is unexpected and should propagate.
-          if (e.message?.includes('should be created in the scope of a Stack')) {
-            templatePath = 'N/A';
-          } else {
-            throw e;
-          }
-        }
+      // Resolve template path if the construct is inside a Stack
+      let templatePath: string | undefined;
+      try {
+        templatePath = path.join(outdir, Stack.of(construct).templateFile);
+      } catch {
+        // Construct is not inside a Stack (e.g. attached to App or Stage)
       }
 
       const violatingResource: PolicyViolatingResource = {
-        resourceLogicalId,
+        constructPath: construct.node.path,
         templatePath,
         locations: [],
       };
@@ -222,38 +202,6 @@ function extractRuleName(message: string, severity: string): string {
     return ackMatch[1];
   }
   return `aws-cdk:${severity}`;
-}
-
-/**
- * Find the nearest CfnResource for a construct by checking itself,
- * its default child, or walking up the tree.
- */
-function findNearestResource(construct: IConstruct): CfnResource | undefined {
-  // Check if the construct itself is a CfnResource
-  if (CfnResource.isCfnResource(construct)) {
-    return construct;
-  }
-
-  // Check the default child
-  const defaultChild = construct.node.defaultChild;
-  if (defaultChild && CfnResource.isCfnResource(defaultChild)) {
-    return defaultChild;
-  }
-
-  // Walk up the tree to find the nearest CfnResource
-  let current = construct.node.scope;
-  while (current) {
-    if (CfnResource.isCfnResource(current)) {
-      return current;
-    }
-    const dc = current.node.defaultChild;
-    if (dc && CfnResource.isCfnResource(dc)) {
-      return dc;
-    }
-    current = current.node.scope;
-  }
-
-  return undefined;
 }
 
 /**

--- a/packages/aws-cdk-lib/core/lib/validation/private/report.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/report.ts
@@ -155,9 +155,9 @@ export class PolicyValidationReportFormatter {
         for (const construct of constructs) {
           output.push('');
           output.push(`    - Construct Path: ${construct.constructPath ?? 'N/A'}`);
-          output.push(`    - Template Path: ${construct.templatePath}`);
+          output.push(`    - Template Path: ${construct.templatePath ?? 'N/A'}`);
           output.push(`    - Creation Stack:\n\t${this.reportTrace.formatPrettyPrinted(construct.constructPath)}`);
-          output.push(`    - Resource ID: ${construct.resourceLogicalId}`);
+          output.push(`    - Resource ID: ${construct.resourceLogicalId ?? 'N/A'}`);
           if (construct.locations) {
             output.push('    - Template Locations:');
             for (const location of construct.locations) {
@@ -212,16 +212,22 @@ export class PolicyValidationReportFormatter {
             severity: violation.severity,
             violatingResources: violation.violatingResources,
             violatingConstructs: violation.violatingResources.map(resource => {
-              const constructPath = this.tree.getConstructByLogicalId(
-                path.basename(resource.templatePath),
-                resource.resourceLogicalId,
-              )?.node.path;
+              // Use constructPath from the input if provided (e.g. annotations),
+              // otherwise derive it from the logical ID via the construct tree.
+              const constructPath = resource.constructPath ?? (
+                resource.templatePath && resource.resourceLogicalId
+                  ? this.tree.getConstructByLogicalId(
+                    path.basename(resource.templatePath),
+                    resource.resourceLogicalId,
+                  )?.node.path
+                  : undefined
+              );
               return {
                 constructStack: constructPath ? this.reportTrace.formatJson(constructPath) : undefined,
                 constructPath: constructPath,
                 locations: resource.locations,
-                resourceLogicalId: resource.resourceLogicalId,
-                templatePath: resource.templatePath,
+                resourceLogicalId: resource.resourceLogicalId ?? 'N/A',
+                templatePath: resource.templatePath ?? 'N/A',
               };
             }),
           })),

--- a/packages/aws-cdk-lib/core/lib/validation/report.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/report.ts
@@ -49,8 +49,26 @@ export interface PolicyViolation {
 export interface PolicyViolatingResource {
   /**
    * The logical ID of the resource in the CloudFormation template.
+   *
+   * Required for plugin-sourced violations that operate on CloudFormation
+   * templates. Mutually exclusive with `constructPath`.
+   *
+   * @default - no resource logical ID
    */
-  readonly resourceLogicalId: string;
+  readonly resourceLogicalId?: string;
+
+  /**
+   * The construct path of the violating construct.
+   *
+   * Use this for violations that originate from constructs rather than
+   * CloudFormation resources (e.g. annotations added via `Annotations.of()`
+   * or `Validations.of()`). When provided, the report will use this path
+   * directly instead of deriving it from the resource logical ID.
+   * Mutually exclusive with `resourceLogicalId`.
+   *
+   * @default - construct path is derived from the resource logical ID
+   */
+  readonly constructPath?: string;
 
   /**
    * The locations in the CloudFormation template that pose the violations.
@@ -59,8 +77,10 @@ export interface PolicyViolatingResource {
 
   /**
    * The path to the CloudFormation template that contains this resource
+   *
+   * @default - no template path
    */
-  readonly templatePath: string;
+  readonly templatePath?: string;
 }
 
 /**
@@ -161,8 +181,17 @@ export interface PolicyViolationBeta1 {
 export interface PolicyViolatingResourceBeta1 {
   /**
    * The logical ID of the resource in the CloudFormation template.
+   *
+   * @default - no resource logical ID
    */
-  readonly resourceLogicalId: string;
+  readonly resourceLogicalId?: string;
+
+  /**
+   * The construct path of the violating construct.
+   *
+   * @default - construct path is derived from the resource logical ID
+   */
+  readonly constructPath?: string;
 
   /**
    * The locations in the CloudFormation template that pose the violations.
@@ -171,8 +200,10 @@ export interface PolicyViolatingResourceBeta1 {
 
   /**
    * The path to the CloudFormation template that contains this resource
+   *
+   * @default - no template path
    */
-  readonly templatePath: string;
+  readonly templatePath?: string;
 }
 
 /**

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -5,7 +5,6 @@ import { Construct } from 'constructs';
 import { table } from 'table';
 import * as core from '../../lib';
 import * as cxapi from '../../../cx-api';
-import type { PolicyValidationPluginReport, PolicyViolation } from '../../lib';
 
 let consoleErrorMock: jest.SpyInstance;
 beforeEach(() => {
@@ -980,8 +979,10 @@ Policy Validation Report Summary
       const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
       expect(output).toContain('Construct Annotations');
       expect(output).toContain('my-lib:OrphanWarning');
-      // Without a CfnResource, resourceLogicalId falls back to construct path
-      expect(output).toContain('Resource ID: MyStack/Orphan');
+      // Construct path is provided directly
+      expect(output).toContain('Construct Path: MyStack/Orphan');
+      // Resource ID is N/A for annotation-sourced violations
+      expect(output).toContain('Resource ID: N/A');
       // templatePath should still resolve via Stack.of()
       expect(output).toContain('Template Path:');
       expect(output).toContain('MyStack.template.json');
@@ -1225,12 +1226,12 @@ Policy Validation Report Summary
 class FakePlugin implements core.IPolicyValidationPlugin {
   constructor(
     public readonly name: string,
-    private readonly violations: PolicyViolation[],
+    private readonly violations: core.PolicyViolation[],
     public readonly version?: string,
     public readonly ruleIds?: string []) {
   }
 
-  validate(_context: core.IPolicyValidationContext): PolicyValidationPluginReport {
+  validate(_context: core.IPolicyValidationContext): core.PolicyValidationPluginReport {
     return {
       success: this.violations.length === 0,
       violations: this.violations,
@@ -1242,7 +1243,7 @@ class FakePlugin implements core.IPolicyValidationPlugin {
 class RoguePlugin implements core.IPolicyValidationPlugin {
   public readonly name = 'rogue-plugin';
 
-  validate(context: core.IPolicyValidationContext): PolicyValidationPluginReport {
+  validate(context: core.IPolicyValidationContext): core.PolicyValidationPluginReport {
     const templatePath = context.templatePaths[0];
     fs.writeFileSync(templatePath, 'malicious data');
     return {
@@ -1255,7 +1256,7 @@ class RoguePlugin implements core.IPolicyValidationPlugin {
 class BrokenPlugin implements core.IPolicyValidationPlugin {
   public readonly name = 'broken-plugin';
 
-  validate(_context: core.IPolicyValidationContext): PolicyValidationPluginReport {
+  validate(_context: core.IPolicyValidationContext): core.PolicyValidationPluginReport {
     throw new Error('Something went wrong');
   }
 }


### PR DESCRIPTION
### Reason for this change

Follow-up to #37712 addressing [rix0rrr's review feedback](https://github.com/aws/aws-cdk/pull/37712#discussion_r3166508133) about the `findNearestResource()` workaround that maps annotations on L2 constructs down to their CfnResource logical IDs.

### Description of changes

Adds an optional `constructPath` field to `PolicyViolatingResource` so annotation-sourced violations can identify the violating construct directly, without needing to find the nearest CfnResource.

- **`report.ts`**: Add `constructPath?: string` to `PolicyViolatingResource` (purely additive, non-breaking)
- **`synthesis.ts`**: Update `collectAnnotationReport()` to set `constructPath` directly. Remove `findNearestResource()` entirely — it is no longer needed. `resourceLogicalId` is set to `'N/A'` and `templatePath` falls back to `'N/A'` for constructs outside a Stack.
- **`private/report.ts`**: Update `formatJson()` to use `constructPath` from the input when available, falling back to the existing `getConstructByLogicalId()` lookup for plugin violations. Pretty-print handles `'N/A'` values naturally.
- **Beta1 interfaces are not modified** — `resourceLogicalId` and `templatePath` remain required on the graduated interface for backwards compatibility.

### Description of how you validated changes

- `tsc --noEmit` passes
- All 36 validation tests pass (updated orphan construct test to expect `Resource ID: N/A` and `Construct Path: MyStack/Orphan`)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*