### PR TITLE
fix(cloudfront): skip cachePolicyName length validation for unresolved tokens

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/cache-policy.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/cache-policy.ts
@@ -178,7 +178,7 @@ export class CachePolicy extends Resource implements ICachePolicy {
       throw new ValidationError(lit`CachepolicynameOnlyInclude`, `'cachePolicyName' can only include '-', '_', and alphanumeric characters, got: '${cachePolicyName}'`, this);
     }
 
-    if (cachePolicyName.length > 128) {
+    if (!Token.isUnresolved(cachePolicyName) && cachePolicyName.length > 128) {
       throw new ValidationError(lit`CachepolicynameCannotLongerThan`, `'cachePolicyName' cannot be longer than 128 characters, got: '${cachePolicyName.length}'`, this);
     }
 

--- a/packages/aws-cdk-lib/aws-cloudfront/test/cache-policy.test.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/test/cache-policy.test.ts
@@ -108,6 +108,12 @@ describe('CachePolicy', () => {
     })).not.toThrow();
   });
 
+  test('does not throw if cachePolicyName is a token even when it resolves to over 128 characters', () => {
+    expect(() => new CachePolicy(stack, 'CachePolicy', {
+      cachePolicyName: Lazy.string({ produce: () => 'a'.repeat(129) }),
+    })).not.toThrow();
+  });
+
   test('throws on long comment over 128 characters', () => {
     const errorMessage = /'comment' cannot be longer than 128 characters, got: 129/;
     expect(() => new CachePolicy(stack, 'CachePolicy1', { comment: 'a'.repeat(129) })).toThrow(errorMessage);


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

When `cachePolicyName` is a CDK Token (e.g. `Lazy.string`, `Aws.STACK_NAME`, or any CloudFormation intrinsic), calling `.length` on the token-encoded string evaluates the length of the token marker at synthesis time, not the actual resolved value. This means the 128-character length validation can silently pass for tokens that resolve to names longer than 128 characters, or—if the marker string happens to be long—incorrectly throw for valid token values.

The adjacent regex validation on the same property already guards with `Token.isUnresolved()` (line 177), but the length check below it does not.

This pattern has been fixed for similar validations in other modules: ACM `domainName` (#23567) and CloudFront `webAclId` (#34102).

### Description of changes

Added `!Token.isUnresolved(cachePolicyName)` guard before the `cachePolicyName.length > 128` check in `CachePolicy` constructor, consistent with the existing regex check directly above it.

Added a unit test that verifies no error is thrown when `cachePolicyName` is a `Lazy.string` token that resolves to a string longer than 128 characters.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- Added a unit test: `does not throw if cachePolicyName is a token even when it resolves to over 128 characters`
- Existing tests for length validation and character validation continue to cover the non-token path

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*