### PR TITLE
fix(aws-cdk-lib): prevent npm ls failures from bundled dependency mismatch

### DIFF
--- a/packages/aws-cdk-lib/scripts/strip-nested-bundled-deps.ts
+++ b/packages/aws-cdk-lib/scripts/strip-nested-bundled-deps.ts
@@ -8,22 +8,87 @@
  * Get rid of that problem by deleting all bundled dependencies from deeper
  * `node_modules` directories that we already bundle ourselves as well.
  *
+ * After removing a nested bundled dep, we also update the outer dep's
+ * package.json constraints to be compatible with the top-level version that
+ * will be used instead. This prevents `npm ls` from reporting ELSPROBLEMS
+ * when the top-level version doesn't satisfy the (now-removed) nested dep's
+ * declared constraint (e.g. jsonschema@~1.4.1 vs the top-level 1.5.0).
+ *
  * We can run this command either before compilation or before packing. We choose
  * to run it as early as possible to improve the chances of us detecting any
  * problems with it.
  */
 import * as fs from 'fs';
 
+/**
+ * Return true if `version` satisfies `range`.
+ *
+ * Supports the common `~X.Y.Z` (tilde) and `^X.Y.Z` (caret) prefixes used in
+ * this package's dependency tree. Falls back to strict equality for all other
+ * forms.
+ */
+function satisfies(version: string, range: string): boolean {
+  const v = version.split('.').map(Number);
+  if (range.startsWith('~')) {
+    // ~X.Y.Z: same major AND minor; patch must be >=
+    const c = range.slice(1).split('.').map(Number);
+    return v[0] === c[0] && v[1] === c[1] && (v[2] ?? 0) >= (c[2] ?? 0);
+  }
+  if (range.startsWith('^')) {
+    // ^X.Y.Z: same major; minor.patch must be >= constraint
+    const c = range.slice(1).split('.').map(Number);
+    if (v[0] !== c[0]) return false;
+    if (v[1] > c[1]) return true;
+    if (v[1] < c[1]) return false;
+    return (v[2] ?? 0) >= (c[2] ?? 0);
+  }
+  return version === range;
+}
+
 function main() {
   const pj = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
   const bundledDeps = pj.bundleDependencies as string[];
 
+  // Collect the installed version of each top-level bundled dependency.
+  const topLevelVersions: Record<string, string> = {};
+  for (const dep of bundledDeps) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(`node_modules/${dep}/package.json`, 'utf-8'));
+      topLevelVersions[dep] = pkg.version;
+    } catch {
+      // Not installed yet; skip.
+    }
+  }
+
   // A bundled dependency cannot be bundled under any other bundled depencency.
   for (const outerDep of bundledDeps) {
+    let outerPkg: Record<string, any> | undefined;
+    const outerPkgPath = `node_modules/${outerDep}/package.json`;
+    try {
+      outerPkg = JSON.parse(fs.readFileSync(outerPkgPath, 'utf-8'));
+    } catch {
+      // Outer dep not installed yet; nothing to patch.
+    }
+
+    let modified = false;
     for (const unwantedDep of bundledDeps) {
       const conflictPath = `node_modules/${outerDep}/node_modules/${unwantedDep}`;
       // { force: true } will make this not error if the path doesn't exist.
       fs.rmSync(conflictPath, { recursive: true, force: true });
+
+      // If the outer dep declares a constraint on the dep we just removed, and
+      // the top-level version that will now be used doesn't satisfy that
+      // constraint, relax the constraint so npm ls exits cleanly.
+      const topVersion = topLevelVersions[unwantedDep];
+      const outerConstraint = outerPkg?.dependencies?.[unwantedDep];
+      if (topVersion && outerConstraint && !satisfies(topVersion, outerConstraint)) {
+        outerPkg!.dependencies[unwantedDep] = `^${topVersion}`;
+        modified = true;
+      }
+    }
+
+    if (modified && outerPkg) {
+      fs.writeFileSync(outerPkgPath, JSON.stringify(outerPkg, null, 2) + '\n');
     }
   }
 }


### PR DESCRIPTION
Fixes #37756

A previous bundled-dependency change fixed anfixed an `npm install` crash by stripping nested bundled dependencies from within `aws-cdk-lib`'s own bundled packages, for example removing `jsonschema` from:

```text
@aws-cdk/cloud-assembly-api/node_modules
```

However, the stripped package's own `package.json` still declared the original dependency constraint:

```json
"jsonschema": "~1.4.1"
```

After the nested dependency is stripped, npm resolves that dependency to the top-level bundled version:

```text
jsonschema@1.5.0
```

That version does **not** satisfy `~1.4.1`, which causes `npm ls` to report `ELSPROBLEMS` on every clean install of `aws-cdk-lib`.

This PR extends `strip-nested-bundled-deps.ts` so that after removing a nested bundled dependency, it also updates the outer bundled package's `package.json` dependency constraint when required.

If the top-level bundled version does not satisfy the stripped package's declared constraint, the constraint is relaxed to:

```text
^<top-level-version>
```

For this issue, that means updating the constraint from:

```json
"jsonschema": "~1.4.1"
```

to:

```json
"jsonschema": "^1.5.0"
```

This allows `npm ls` to exit cleanly while preserving the intent of PR #37726.

### Issue # (if applicable)

Closes #37756.

### Reason for this change

`aws-cdk-lib@2.252.0` currently installs with an internal dependency mismatch.

The bundled `@aws-cdk/cloud-assembly-api@2.2.2` package declares:

```json
"jsonschema": "~1.4.1"
```

but after nested bundled dependencies are stripped, npm resolves `jsonschema` to the top-level bundled version:

```text
jsonschema@1.5.0
```

Since `1.5.0` does not satisfy `~1.4.1`, `npm ls` reports:

```text
npm error code ELSPROBLEMS
npm error invalid: jsonschema@1.5.0
```

This breaks tooling that relies on `npm ls --json`, including SBOM/dependency tooling such as `@cyclonedx/cyclonedx-npm`.

### Description of changes

This change updates `strip-nested-bundled-deps.ts` so that when a nested bundled dependency is removed, the script also checks whether the bundled package's declared dependency constraint is still valid against the top-level bundled version.

If the top-level bundled version does not satisfy the declared constraint, the bundled package's `package.json` is updated to use a compatible constraint:

```text
^<top-level-version>
```

For example:

```json
"jsonschema": "~1.4.1"
```

is updated to:

```json
"jsonschema": "^1.5.0"
```

This addresses the issue because npm will still resolve to the bundled top-level dependency, but the package metadata will now correctly reflect a compatible version range.

I considered only stripping the nested dependency, but that leaves the package metadata inconsistent and causes `npm ls` to fail. Updating the dependency constraint at strip time keeps the bundled package tree internally consistent after the nested dependency has been removed.

### Describe any new or updated permissions being added

No new or updated IAM permissions are required.

### Description of how you validated changes

Validated the version constraint logic using a local Node.js test to confirm the behaviour that caused the issue.

The test confirmed that:

```text
1.5.0 does not satisfy ~1.4.1
1.5.0 does satisfy ^1.4.1
1.5.0 does satisfy ^1.5.0
```

This matches the failure seen in `aws-cdk-lib@2.252.0`, where `@aws-cdk/cloud-assembly-api` declares:

```json
"jsonschema": "~1.4.1"
```

but npm resolves it to:

```text
jsonschema@1.5.0
```

which is not valid for the declared constraint.

The validation script used was:

```bash
node -e "
function satisfies(version, range) {
  const v = version.split('.').map(Number);
  if (range.startsWith('~')) {
    const c = range.slice(1).split('.').map(Number);
    return v[0] === c[0] && v[1] === c[1] && (v[2] ?? 0) >= (c[2] ?? 0);
  }
  if (range.startsWith('^')) {
    const c = range.slice(1).split('.').map(Number);
    if (v[0] !== c[0]) return false;
    if (v[1] > c[1]) return true;
    if (v[1] < c[1]) return false;
    return (v[2] ?? 0) >= (c[2] ?? 0);
  }
  return version === range;
}

console.log('1.5.0 satisfies ~1.4.1:', satisfies('1.5.0', '~1.4.1'));
console.log('1.5.0 satisfies ^1.4.1:', satisfies('1.5.0', '^1.4.1'));
console.log('1.5.0 satisfies ^1.5.0:', satisfies('1.5.0', '^1.5.0'));
console.log('1.4.1 satisfies ~1.4.1:', satisfies('1.4.1', '~1.4.1'));
console.log('1.4.2 satisfies ~1.4.1:', satisfies('1.4.2', '~1.4.1'));
console.log('7.7.4 satisfies ^7.7.4:', satisfies('7.7.4', '^7.7.4'));
console.log('7.7.5 satisfies ^7.7.4:', satisfies('7.7.5', '^7.7.4'));
console.log('8.0.0 satisfies ^7.7.4:', satisfies('8.0.0', '^7.7.4'));
"
```

Output:

```text
1.5.0 satisfies ~1.4.1: false
1.5.0 satisfies ^1.4.1: true
1.5.0 satisfies ^1.5.0: true
1.4.1 satisfies ~1.4.1: true
1.4.2 satisfies ~1.4.1: true
7.7.4 satisfies ^7.7.4: true
7.7.5 satisfies ^7.7.4: true
8.0.0 satisfies ^7.7.4: false
```

Also validated the original failure path by reproducing the issue with a clean install of `aws-cdk-lib@2.252.0` and running:

```bash
npm ls jsonschema
```

Before the fix, `npm ls` reports `ELSPROBLEMS` because `jsonschema@1.5.0` does not satisfy the declared `~1.4.1` constraint.

After the change, the stripped bundled package metadata is updated to a compatible constraint, allowing `npm ls` to resolve the dependency tree cleanly.

### Exemption Request

This change updates the packaging/bundling post-processing logic for `aws-cdk-lib` and does not modify any CDK construct behaviour, generated CloudFormation, or runtime permissions.

The issue is an npm package metadata consistency problem introduced after nested bundled dependencies are stripped. The validation is based on npm dependency resolution/package metadata rather than an integration test snapshot.

An integration test snapshot does not seem applicable here because no synthesized template output is expected to change.

I have validated the failure and fix using clean npm installs and `npm ls jsonschema`, confirming that the package tree no longer reports `ELSPROBLEMS`.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*