### PR TITLE
feat(`aws-kms`): add `Alias.fromAliasArn`

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/README.md
+++ b/packages/aws-cdk-lib/aws-kms/README.md
@@ -76,7 +76,7 @@ Note that a call to `.addToResourcePolicy(statement)` on `myKeyImported` will no
 an affect on the key's policy because it is not owned by your stack. The call
 will be a no-op.
 
-### Import key by alias
+### Import key by alias name
 
 If a Key has an associated Alias, the Alias can be imported by name and used in place
 of the Key as a reference. A common scenario for this is in referencing AWS managed keys.
@@ -95,6 +95,40 @@ Note that calls to `addToResourcePolicy` method on `myKeyAlias` will be a no-op,
 The grant methods (i.e., methods in `KeyGrants`) will not modify the key policy, as the imported alias does not have a reference to the underlying KMS Key.
 For the grant methods to modify the principal's IAM policy, the feature flag `@aws-cdk/aws-kms:applyImportedAliasPermissionsToPrincipal`
 must be set to `true`. By default, this flag is `false` and grant calls on an imported alias are a no-op.
+
+### Import key by alias ARN
+
+If the Alias to be imported resides in another **AWS** account or region then you need to use `Alias.fromAliasArn` instead of just `Alias.fromAliasName` in order to specify the correct values.
+A common scenario for this is granting access to a cross-account encrypted **Kinesis** `Stream`.
+
+```ts
+const streamArn = cdk.Stack.of(this).formatArn({
+  account: externalAccountId,
+  service: 'kinesis',
+  resource: 'stream',
+  resourceName: streamName,
+});
+
+const aliasArn = cdk.Stack.of(this).formatArn({
+  account: externalAccountId,
+  service: 'kms',
+  resource: 'alias',
+  resourceName: `${streamName}-key`,
+});
+
+const stream = kinesis.Stream.fromStreamAttributes(this, 'ExternalStream', {
+  streamArn,
+  encryptionKey: kms.Alias.fromAliasArn(this, 'ExternalStreamKey', aliasArn),
+});
+
+const lambdaRole = new iam.Role(this, 'LambdaRole', {
+  assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+  description: 'Role which allows a Lambda function to read data from the cross-account encrypted Kinesis stream',
+});
+
+// Allow the lambda function to read the cross-account encrypted Kinesis stream.
+stream.grantRead(lambdaRole);
+```
 
 ### Lookup key by alias
 

--- a/packages/aws-cdk-lib/aws-kms/lib/alias.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/alias.ts
@@ -273,6 +273,7 @@ export class Alias extends AliasBase {
     }
 
     return new ReferencedAlias(scope, id, {
+      aliasArn,
       aliasName,
       arnComponents
     });
@@ -369,10 +370,13 @@ class ReferencedAlias extends AliasBase {
   private readonly arnComponents: ArnComponents;
 
   constructor(scope: Construct, id: string, props: {
+    aliasArn: string;
     aliasName: string,
     arnComponents: ArnComponents
   }) {
-    super(scope, id);
+    super(scope, id, {
+      environmentFromArn: props.aliasArn,
+    });
 
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);

--- a/packages/aws-cdk-lib/aws-kms/lib/alias.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/alias.ts
@@ -4,8 +4,8 @@ import type { AliasReference, IAliasRef, KeyReference } from './kms.generated';
 import { CfnAlias } from './kms.generated';
 import * as iam from '../../aws-iam';
 import * as perms from './private/perms';
-import type { RemovalPolicy } from '../../core';
-import { FeatureFlags, Resource, Stack, Token, Tokenization, ValidationError } from '../../core';
+import type { ArnComponents, RemovalPolicy } from '../../core';
+import { Arn, ArnFormat, FeatureFlags, Resource, Stack, Token, Tokenization, ValidationError } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { lit } from '../../core/lib/private/literal-string';
@@ -246,83 +246,36 @@ export class Alias extends AliasBase {
    * @param aliasName The full name of the KMS Alias (e.g., 'alias/aws/s3', 'alias/myKeyAlias').
    */
   public static fromAliasName(scope: Construct, id: string, aliasName: string): IAlias {
-    class Import extends Resource implements IAlias {
-      public readonly keyArn = Stack.of(this).formatArn({ service: 'kms', resource: aliasName });
-      public readonly keyId = aliasName;
-      public readonly aliasName = aliasName;
-      public get aliasTargetKey(): IKey { throw new ValidationError(lit`CannotAccessAliasTargetKey`, 'Cannot access aliasTargetKey on an Alias imported by Alias.fromAliasName().', this); }
-      public addAlias(_alias: string): Alias { throw new ValidationError(lit`CannotAddAliasToImported`, 'Cannot call addAlias on an Alias imported by Alias.fromAliasName().', this); }
-      public addToResourcePolicy(_statement: iam.PolicyStatement, _allowNoOp?: boolean): iam.AddToResourcePolicyResult {
-        return { statementAdded: false };
-      }
+    const aliasArn = Stack.of(scope).formatArn({ service: 'kms', resource: aliasName });
+    return Alias.fromAliasArn(scope, id, aliasArn);
+  }
 
-      public get keyRef(): KeyReference {
-        return {
-          keyArn: this.keyArn,
-          keyId: this.keyId,
-        };
-      }
+  /**
+   * Import an existing KMS Alias defined outside the CDK app, by the alias ARN. This method should be used
+   * instead of 'fromAliasAttributes' when the underlying KMS Key ARN is not available.
+   * This Alias will not have a direct reference to the KMS Key, so addAlias method is not supported.
+   *
+   * If the `@aws-cdk/aws-kms:applyImportedAliasPermissionsToPrincipal` feature flag is set to `true`,
+   * the grant* methods will use the kms:ResourceAliases condition to grant permissions to the specific alias name.
+   * They will only modify the principal policy, not the key resource policy.
+   * Without the feature flag `grant*` methods will be a no-op.
+   *
+   * @param scope The parent creating construct (usually `this`).
+   * @param id The construct's name.
+   * @param aliasArn The full ARN of the KMS Alias.
+   */
+  public static fromAliasArn(scope: Construct, id: string, aliasArn: string): IAlias {
+    const arnComponents = Stack.of(scope).splitArn(aliasArn, ArnFormat.SLASH_RESOURCE_NAME);
+    const aliasName = arnComponents.resourceName;
 
-      public grant(grantee: iam.IGrantable, ...actions: string[]): iam.Grant {
-        if (!FeatureFlags.of(this).isEnabled(KMS_APPLY_IMPORTED_ALIAS_PERMISSIONS_TO_PRINCIPAL)) {
-          return iam.Grant.drop(grantee, '');
-        }
-        return iam.Grant.addToPrincipal({
-          grantee,
-          actions,
-          resourceArns: [Stack.of(scope).formatArn({
-            service: 'kms',
-            resource: 'key',
-            resourceName: '*',
-          })],
-          conditions: {
-            'ForAnyValue:StringEquals': {
-              'kms:ResourceAliases': this.aliasName,
-            },
-          },
-        });
-      }
-
-      public get aliasRef(): AliasReference {
-        return {
-          aliasName: this.aliasName,
-        };
-      }
-
-      public grantDecrypt(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.DECRYPT_ACTIONS);
-      }
-
-      public grantEncrypt(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.ENCRYPT_ACTIONS);
-      }
-
-      public grantEncryptDecrypt(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.DECRYPT_ACTIONS, ...perms.ENCRYPT_ACTIONS);
-      }
-
-      public grantSign(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.SIGN_ACTIONS);
-      }
-
-      public grantVerify(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.VERIFY_ACTIONS);
-      }
-
-      public grantSignVerify(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.SIGN_ACTIONS, ...perms.VERIFY_ACTIONS);
-      }
-
-      public grantGenerateMac(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.GENERATE_HMAC_ACTIONS);
-      }
-
-      public grantVerifyMac(grantee: iam.IGrantable): iam.Grant {
-        return this.grant(grantee, ...perms.VERIFY_HMAC_ACTIONS);
-      }
+    if ((arnComponents.service != 'kms') || (arnComponents.resource != 'alias') || !aliasName) {
+      throw new ValidationError(lit`MustBeFormatArnPartitionKmsRegionAccountAliasAliasName`, `KMS alias ARN must be in the format 'arn:<partition>:kms:<region>:<account>:alias/<aliasName>', got: '${aliasArn}'`, scope);
     }
 
-    return new Import(scope, id);
+    return new ReferencedAlias(scope, id, {
+      aliasName,
+      arnComponents
+    });
   }
 
   private readonly resource: CfnAlias;
@@ -396,3 +349,112 @@ export class Alias extends AliasBase {
   }
 }
 
+/**
+ * An instance of a referenced Key Alias
+ *
+ * An explicit class declaration to save memory; previously,
+ * `fromAliasName()` etc. used to declare an anonymous subclass of
+ * `AliasBase`, which would lead to a prototype and constructor for every
+ * invocation (but they are all the same).
+ *
+ * Use a single class instance.
+ */
+@propertyInjectable
+class ReferencedAlias extends AliasBase {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-kms.ReferencedAlias';
+
+  public readonly aliasName: string;
+
+  private readonly arnComponents: ArnComponents;
+
+  constructor(scope: Construct, id: string, props: {
+    aliasName: string,
+    arnComponents: ArnComponents
+  }) {
+    super(scope, id);
+
+    // Enhanced CDK Analytics Telemetry
+    addConstructMetadata(this, props);
+
+    this.aliasName = `alias/${props.aliasName}`;
+    this.arnComponents = props.arnComponents;
+  }
+
+  public get aliasTargetKey(): IKey {
+    throw new ValidationError(lit`CannotAccessAliasTargetKey`, 'Cannot access aliasTargetKey on an imported Alias.', this);
+  }
+
+  public addAlias(_alias: string): Alias {
+    throw new ValidationError(lit`CannotAddAliasToImported`, 'Cannot call addAlias on an imported Alias.', this);
+  }
+
+  public addToResourcePolicy(_statement: iam.PolicyStatement, _allowNoOp?: boolean): iam.AddToResourcePolicyResult {
+    return { statementAdded: false };
+  }
+
+  public get keyRef(): KeyReference {
+    return {
+      keyArn: this.aliasArn,
+      keyId: this.keyId,
+    };
+  }
+
+  public grant(grantee: iam.IGrantable, ...actions: string[]): iam.Grant {
+    if (!FeatureFlags.of(this).isEnabled(KMS_APPLY_IMPORTED_ALIAS_PERMISSIONS_TO_PRINCIPAL)) {
+      return iam.Grant.drop(grantee, '');
+    }
+    return iam.Grant.addToPrincipal({
+      grantee,
+      actions,
+      resourceArns: [Arn.format({
+        ...this.arnComponents,
+        resource: 'key',
+        resourceName: '*',
+      })],
+      conditions: {
+        'ForAnyValue:StringEquals': {
+          'kms:ResourceAliases': this.aliasName,
+        },
+      },
+    });
+  }
+
+  public get aliasRef(): AliasReference {
+    return {
+      aliasName: this.aliasName,
+    };
+  }
+
+  public grantDecrypt(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.DECRYPT_ACTIONS);
+  }
+
+  public grantEncrypt(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.ENCRYPT_ACTIONS);
+  }
+
+  public grantEncryptDecrypt(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.DECRYPT_ACTIONS, ...perms.ENCRYPT_ACTIONS);
+  }
+
+  public grantSign(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.SIGN_ACTIONS);
+  }
+
+  public grantVerify(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.VERIFY_ACTIONS);
+  }
+
+  public grantSignVerify(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.SIGN_ACTIONS, ...perms.VERIFY_ACTIONS);
+  }
+
+  public grantGenerateMac(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.GENERATE_HMAC_ACTIONS);
+  }
+
+  public grantVerifyMac(grantee: iam.IGrantable): iam.Grant {
+    return this.grant(grantee, ...perms.VERIFY_HMAC_ACTIONS);
+  }
+}

--- a/packages/aws-cdk-lib/aws-kms/lib/key.ts
+++ b/packages/aws-cdk-lib/aws-kms/lib/key.ts
@@ -604,8 +604,10 @@ export class Key extends KeyBase {
    * @param keyArn the ARN of an existing KMS key.
    */
   public static fromKeyArn(scope: Construct, id: string, keyArn: string): IKey {
-    const keyResourceName = Stack.of(scope).splitArn(keyArn, ArnFormat.SLASH_RESOURCE_NAME).resourceName;
-    if (!keyResourceName) {
+    const arnComponents = Stack.of(scope).splitArn(keyArn, ArnFormat.SLASH_RESOURCE_NAME);
+    const keyResourceName = arnComponents.resourceName;
+
+    if ((arnComponents.service != 'kms') || (arnComponents.resource != 'key') || !keyResourceName) {
       throw new ValidationError(lit`MustBeFormatArnPartitionKmsRegionAccountKeyKeyid`, `KMS key ARN must be in the format 'arn:<partition>:kms:<region>:<account>:key/<keyId>', got: '${keyArn}'`, scope);
     }
 

--- a/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
@@ -211,7 +211,7 @@ test('imported alias by name - will throw an error when accessing the key', () =
 
   const myAlias = Alias.fromAliasName(stack, 'MyAlias', 'alias/myAlias');
 
-  expect(() => myAlias.aliasTargetKey).toThrow('Cannot access aliasTargetKey on an Alias imported by Alias.fromAliasName().');
+  expect(() => myAlias.aliasTargetKey).toThrow('Cannot access aliasTargetKey on an imported Alias.');
 });
 
 test('imported alias by name - grantDecrypt applies kms:ResourceAliases condition', () => {

--- a/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
@@ -572,6 +572,22 @@ test('imported alias by name - grant methods are no-op when feature flag disable
   Template.fromStack(stack).resourceCountIs('AWS::IAM::Policy', 0);
 });
 
+test('imported alias by ARN - throw an error when providing something that is not a valid alias ARN', () => {
+  const stack = new Stack();
+
+  expect(() => {
+    Alias.fromAliasArn(stack, 'Imported', 'arn:aws:smk:us-east-1:123456789012:alias/aliasName');
+  }).toThrow(/KMS alias ARN must be in the format 'arn:<partition>:kms:<region>:<account>:alias\/<aliasName>', got: 'arn:aws:smk:us-east-1:123456789012:alias\/aliasName'/);
+
+  expect(() => {
+    Alias.fromAliasArn(stack, 'Imported', 'arn:aws:kms:us-east-1:123456789012:key/keyId');
+  }).toThrow(/KMS alias ARN must be in the format 'arn:<partition>:kms:<region>:<account>:alias\/<aliasName>', got: 'arn:aws:kms:us-east-1:123456789012:key\/keyId'/);
+
+  expect(() => {
+    Alias.fromAliasArn(stack, 'Imported', 'arn:aws:kms:us-east-1:123456789012:alias');
+  }).toThrow(/KMS alias ARN must be in the format 'arn:<partition>:kms:<region>:<account>:alias\/<aliasName>', got: 'arn:aws:kms:us-east-1:123456789012:alias'/);
+});
+
 test('fails if alias policy is invalid', () => {
   const app = new App();
   const stack = new Stack(app, 'my-stack');

--- a/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/alias.test.ts
@@ -588,6 +588,20 @@ test('imported alias by ARN - throw an error when providing something that is no
   }).toThrow(/KMS alias ARN must be in the format 'arn:<partition>:kms:<region>:<account>:alias\/<aliasName>', got: 'arn:aws:kms:us-east-1:123456789012:alias'/);
 });
 
+
+test('imported alias by ARN - from an alias in a different account and region - to take the alias account and region from the ARN', () => {
+  const stack = new Stack();
+
+  const alias = Alias.fromAliasArn(
+    stack,
+    'Imported',
+    'arn:aws:kms:alias-region:222222222222:alias/aliasName',
+  );
+
+  expect(alias.env.region).toBe('alias-region');
+  expect(alias.env.account).toBe('222222222222');
+});
+
 test('fails if alias policy is invalid', () => {
   const app = new App();
   const stack = new Stack(app, 'my-stack');

--- a/packages/aws-cdk-lib/aws-kms/test/key.test.ts
+++ b/packages/aws-cdk-lib/aws-kms/test/key.test.ts
@@ -1071,6 +1071,15 @@ test('multi-region primary key', () => {
 describe('imported keys', () => {
   test('throw an error when providing something that is not a valid key ARN', () => {
     const stack = new cdk.Stack();
+
+    expect(() => {
+      kms.Key.fromKeyArn(stack, 'Imported', 'arn:aws:smk:us-east-1:123456789012:key/keyId');
+    }).toThrow(/KMS key ARN must be in the format 'arn:<partition>:kms:<region>:<account>:key\/<keyId>', got: 'arn:aws:smk:us-east-1:123456789012:key\/keyId'/);
+
+    expect(() => {
+      kms.Key.fromKeyArn(stack, 'Imported', 'arn:aws:kms:us-east-1:123456789012:alias/aliasName');
+    }).toThrow(/KMS key ARN must be in the format 'arn:<partition>:kms:<region>:<account>:key\/<keyId>', got: 'arn:aws:kms:us-east-1:123456789012:alias\/aliasName'/);
+
     expect(() => {
       kms.Key.fromKeyArn(stack, 'Imported', 'arn:aws:kms:us-east-1:123456789012:key');
     }).toThrow(/KMS key ARN must be in the format 'arn:<partition>:kms:<region>:<account>:key\/<keyId>', got: 'arn:aws:kms:us-east-1:123456789012:key'/);


### PR DESCRIPTION
### Issue #37272

Closes #37272 

### Reason for this change

Adds the missing functionality of getting an `IAlias` by `ARN`.

### Description of changes

* Moves the nested `Imported` class outside of `Alias.fromAliasName` to the top level, named as `ReferencedAlias`.
* Modifies `ReferencedAlias` to receive the alias `ARN` rather than just the name.
* Adds `Alias.fromAliasArn` which uses `ReferencedAlias`, it validates the provided `ARN` value.
* Modifies `Alias.fromAliasName` to use `Alias.fromAliasArn`.
* Adds extra `ARN` validations to `Key.fromKeyArn`.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Modified an existing test for `Alias.fromAliasName` and added extra unit-tests.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*