### PR TITLE
refactor(core): migrate L2 constructs from Lazy to Box for mutable state

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/deployment.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/deployment.ts
@@ -163,7 +163,7 @@ interface LatestDeploymentResourceProps {
 }
 
 class LatestDeploymentResource extends CfnDeployment {
-  private readonly hashComponents: IArrayBox<any> = Box.fromArray<any>([], { omitEmpty: false });
+  private readonly hashComponents: IArrayBox<any> = Box.fromArray([], { omitEmpty: false });
   private readonly originalLogicalId: string;
   private readonly api: IRestApiRef;
 

--- a/packages/aws-cdk-lib/aws-apigateway/lib/method.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/method.ts
@@ -188,7 +188,7 @@ export class Method extends Resource {
    */
   public readonly api: IRestApi;
 
-  private readonly methodResponses: IArrayBox<MethodResponse> = Box.fromArray([]);
+  private readonly methodResponses: IArrayBox<MethodResponse> = Box.fromArray();
 
   constructor(scope: Construct, id: string, props: MethodProps) {
     super(scope, id);

--- a/packages/aws-cdk-lib/aws-apigateway/lib/restapi.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/restapi.ts
@@ -415,7 +415,7 @@ export abstract class RestApiBase extends Resource implements IRestApi, iam.IRes
 
   private _latestDeployment?: Deployment;
   private _domainName?: DomainName;
-  private allowedVpcEndpoints: ISetBox<ec2.IVPCEndpointRef> = Box.fromSet(new Set());
+  private allowedVpcEndpoints: ISetBox<ec2.IVPCEndpointRef> = Box.fromSet();
 
   private readonly _resourcePolicy: IBox<iam.PolicyDocument | undefined> = Box.fromValue<iam.PolicyDocument | undefined>(undefined);
 

--- a/packages/aws-cdk-lib/aws-apigateway/lib/usage-plan.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/usage-plan.ts
@@ -261,7 +261,7 @@ export class UsagePlan extends UsagePlanBase {
     addConstructMetadata(this, props);
     let resource: CfnUsagePlan;
 
-    this.apiStages = Box.fromArray<UsagePlanPerApiStage>([], { omitEmpty: false });
+    this.apiStages = Box.fromArray([], { omitEmpty: false });
 
     resource = new CfnUsagePlan(this, 'Resource', {
       apiStages: this.apiStages.derive(arr => this.renderApiStages(arr)),

--- a/packages/aws-cdk-lib/aws-applicationautoscaling/lib/scalable-target.ts
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/lib/scalable-target.ts
@@ -199,7 +199,7 @@ export class ScalableTarget extends Resource implements IScalableTarget {
     this._scalableDimension = props.scalableDimension;
     this._serviceNamespace = props.serviceNamespace;
 
-    this.actions = Box.fromArray([]);
+    this.actions = Box.fromArray();
 
     const resource = new CfnScalableTarget(this, 'Resource', {
       maxCapacity: props.maxCapacity,

--- a/packages/aws-cdk-lib/aws-appmesh/lib/virtual-node.ts
+++ b/packages/aws-cdk-lib/aws-appmesh/lib/virtual-node.ts
@@ -228,8 +228,8 @@ export class VirtualNode extends VirtualNodeBase {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    this.backends = Box.fromArray<CfnVirtualNode.BackendProperty>([]);
-    this.listeners = Box.fromArray<VirtualNodeListenerConfig>([]);
+    this.backends = Box.fromArray();
+    this.listeners = Box.fromArray();
 
     this.mesh = props.mesh;
     this.serviceDiscoveryConfig = props.serviceDiscovery?.bind(this);

--- a/packages/aws-cdk-lib/aws-autoscaling/lib/auto-scaling-group.ts
+++ b/packages/aws-cdk-lib/aws-autoscaling/lib/auto-scaling-group.ts
@@ -1474,7 +1474,7 @@ export class AutoScalingGroup extends AutoScalingGroupBase implements
   private readonly securityGroups?: IArrayBox<ec2.ISecurityGroup>;
   private readonly loadBalancerNames: IArrayBox<string>;
   private readonly targetGroupArns: IArrayBox<string>;
-  private readonly groupMetrics: IArrayBox<GroupMetrics> = Box.fromArray<GroupMetrics>([]);
+  private readonly groupMetrics: IArrayBox<GroupMetrics> = Box.fromArray();
   private readonly notifications: NotificationConfiguration[] = [];
   private readonly launchTemplate?: ec2.LaunchTemplate;
   private readonly _connections?: ec2.Connections;
@@ -1499,8 +1499,8 @@ export class AutoScalingGroup extends AutoScalingGroupBase implements
     addConstructMetadata(this, props);
 
     this._newInstancesProtectedFromScaleIn = Box.fromValue<boolean | undefined>(props.newInstancesProtectedFromScaleIn);
-    this.loadBalancerNames = Box.fromArray<string>([]);
-    this.targetGroupArns = Box.fromArray<string>([]);
+    this.loadBalancerNames = Box.fromArray();
+    this.targetGroupArns = Box.fromArray();
 
     if (props.initOptions && !props.init) {
       throw new ValidationError(lit`RequiresSettingInitoptionsRequires`, 'Setting \'initOptions\' requires that \'init\' is also set', this);

--- a/packages/aws-cdk-lib/aws-backup/lib/plan.ts
+++ b/packages/aws-cdk-lib/aws-backup/lib/plan.ts
@@ -169,7 +169,7 @@ export class BackupPlan extends Resource implements IBackupPlan {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    this.rules = Box.fromArray([]);
+    this.rules = Box.fromArray();
 
     const plan = new CfnBackupPlan(this, 'Resource', {
       backupPlan: {

--- a/packages/aws-cdk-lib/aws-backup/lib/selection.ts
+++ b/packages/aws-cdk-lib/aws-backup/lib/selection.ts
@@ -97,7 +97,7 @@ export class BackupSelection extends Resource implements iam.IGrantable {
    */
   public readonly grantPrincipal: iam.IPrincipal;
 
-  private readonly listOfTags: IArrayBox<CfnBackupSelection.ConditionResourceTypeProperty> = Box.fromArray([]);
+  private readonly listOfTags: IArrayBox<CfnBackupSelection.ConditionResourceTypeProperty> = Box.fromArray();
   private readonly resources: IArrayBox<string> = Box.fromArray([], { omitEmpty: false });
   private readonly backupableResourcesCollector = new BackupableResourcesCollector();
 

--- a/packages/aws-cdk-lib/aws-batch/lib/ecs-container-definition.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/ecs-container-definition.ts
@@ -9,7 +9,9 @@ import { LogGroup } from '../../aws-logs';
 import type * as secretsmanager from '../../aws-secretsmanager';
 import type * as ssm from '../../aws-ssm';
 import type { Size } from '../../core';
-import { Lazy, PhysicalName, UnscopedValidationError, ValidationError } from '../../core';
+import { PhysicalName, UnscopedValidationError, ValidationError } from '../../core';
+import type { IArrayBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import type { IFileSystemRef } from '../../interfaces/generated/aws-efs-interfaces.generated';
@@ -625,10 +627,14 @@ abstract class EcsContainerDefinitionBase extends Construct implements IEcsConta
   public readonly readonlyRootFilesystem?: boolean;
   public readonly secrets?: { [envVarName: string]: Secret };
   public readonly user?: string;
-  public readonly volumes: EcsVolume[];
   public readonly enableExecuteCommand?: boolean;
 
+  private readonly _volumes: IArrayBox<EcsVolume>;
   private readonly imageConfig: ecs.ContainerImageConfig;
+
+  public get volumes(): EcsVolume[] {
+    return this._volumes.getMutable();
+  }
 
   constructor(scope: Construct, id: string, props: EcsContainerDefinitionProps) {
     super(scope, id);
@@ -656,7 +662,7 @@ abstract class EcsContainerDefinitionBase extends Construct implements IEcsConta
     this.readonlyRootFilesystem = props.readonlyRootFilesystem ?? false;
     this.secrets = props.secrets;
     this.user = props.user;
-    this.volumes = props.volumes ?? [];
+    this._volumes = Box.fromArray(props.volumes ?? []);
 
     this.imageConfig = props.image.bind(this, {
       ...this as any,
@@ -691,53 +697,36 @@ abstract class EcsContainerDefinitionBase extends Construct implements IEcsConta
           valueFrom: secret.arn,
         };
       }) : undefined,
-      mountPoints: Lazy.any({
-        produce: () => {
-          if (this.volumes.length === 0) {
-            return undefined;
-          }
-          return this.volumes.map((volume) => {
-            return {
-              containerPath: volume.containerPath,
-              readOnly: volume.readonly,
-              sourceVolume: volume.name,
-            };
-          });
-        },
-      }),
-      volumes: Lazy.any({
-        produce: () => {
-          if (this.volumes.length === 0) {
-            return undefined;
-          }
+      mountPoints: this._volumes.map((volume) => ({
+        containerPath: volume.containerPath,
+        readOnly: volume.readonly,
+        sourceVolume: volume.name,
+      })),
+      volumes: this._volumes.map((volume) => {
+        if (EfsVolume.isEfsVolume(volume)) {
+          return {
+            name: volume.name,
+            efsVolumeConfiguration: {
+              fileSystemId: volume._fileSystemRef.fileSystemRef.fileSystemId,
+              rootDirectory: volume.rootDirectory,
+              transitEncryption: volume.enableTransitEncryption ? 'ENABLED' : (volume.enableTransitEncryption === false ? 'DISABLED' : undefined),
+              transitEncryptionPort: volume.transitEncryptionPort,
+              authorizationConfig: volume.accessPointId || volume.useJobRole ? {
+                accessPointId: volume.accessPointId,
+                iam: volume.useJobRole ? 'ENABLED' : (volume.useJobRole === false ? 'DISABLED' : undefined),
+              } : undefined,
+            },
+          };
+        } else if (HostVolume.isHostVolume(volume)) {
+          return {
+            name: volume.name,
+            host: {
+              sourcePath: volume.hostPath,
+            },
+          };
+        }
 
-          return this.volumes.map((volume) => {
-            if (EfsVolume.isEfsVolume(volume)) {
-              return {
-                name: volume.name,
-                efsVolumeConfiguration: {
-                  fileSystemId: volume._fileSystemRef.fileSystemRef.fileSystemId,
-                  rootDirectory: volume.rootDirectory,
-                  transitEncryption: volume.enableTransitEncryption ? 'ENABLED' : (volume.enableTransitEncryption === false ? 'DISABLED' : undefined),
-                  transitEncryptionPort: volume.transitEncryptionPort,
-                  authorizationConfig: volume.accessPointId || volume.useJobRole ? {
-                    accessPointId: volume.accessPointId,
-                    iam: volume.useJobRole ? 'ENABLED' : (volume.useJobRole === false ? 'DISABLED' : undefined),
-                  } : undefined,
-                },
-              };
-            } else if (HostVolume.isHostVolume(volume)) {
-              return {
-                name: volume.name,
-                host: {
-                  sourcePath: volume.hostPath,
-                },
-              };
-            }
-
-            throw new ValidationError(lit`UnsupportedVolumeEncountered`, 'unsupported Volume encountered', this);
-          });
-        },
+        throw new ValidationError(lit`UnsupportedVolumeEncountered`, 'unsupported Volume encountered', this);
       }),
       user: this.user,
       enableExecuteCommand: this.enableExecuteCommand,
@@ -745,7 +734,7 @@ abstract class EcsContainerDefinitionBase extends Construct implements IEcsConta
   }
 
   public addVolume(volume: EcsVolume): void {
-    this.volumes.push(volume);
+    this._volumes.push(volume);
   }
 
   /**
@@ -992,13 +981,18 @@ export class EcsEc2ContainerDefinition extends EcsContainerDefinitionBase implem
   public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-batch.EcsEc2ContainerDefinition';
 
   public readonly privileged?: boolean;
-  public readonly ulimits: Ulimit[];
   public readonly gpu?: number;
+
+  private readonly _ulimits: IArrayBox<Ulimit>;
+
+  public get ulimits(): Ulimit[] {
+    return this._ulimits.getMutable();
+  }
 
   constructor(scope: Construct, id: string, props: EcsEc2ContainerDefinitionProps) {
     super(scope, id, props);
     this.privileged = props.privileged;
-    this.ulimits = props.ulimits ?? [];
+    this._ulimits = Box.fromArray(props.ulimits ?? []);
     this.gpu = props.gpu;
   }
 
@@ -1008,19 +1002,11 @@ export class EcsEc2ContainerDefinition extends EcsContainerDefinitionBase implem
   public _renderContainerDefinition(): CfnJobDefinition.ContainerPropertiesProperty {
     return {
       ...super._renderContainerDefinition(),
-      ulimits: Lazy.any({
-        produce: () => {
-          if (this.ulimits.length === 0) {
-            return undefined;
-          }
-
-          return this.ulimits.map((ulimit) => ({
-            hardLimit: ulimit.hardLimit,
-            name: ulimit.name,
-            softLimit: ulimit.softLimit,
-          }));
-        },
-      }),
+      ulimits: this._ulimits.map((ulimit) => ({
+        hardLimit: ulimit.hardLimit,
+        name: ulimit.name,
+        softLimit: ulimit.softLimit,
+      })),
       privileged: this.privileged,
       resourceRequirements: this._renderResourceRequirements(),
     };
@@ -1030,7 +1016,7 @@ export class EcsEc2ContainerDefinition extends EcsContainerDefinitionBase implem
    * Add a ulimit to this container
    */
   addUlimit(ulimit: Ulimit): void {
-    this.ulimits.push(ulimit);
+    this._ulimits.push(ulimit);
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-batch/lib/eks-container-definition.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/eks-container-definition.ts
@@ -3,7 +3,8 @@ import { Construct } from 'constructs';
 import type { CfnJobDefinition } from './batch.generated';
 import type * as ecs from '../../aws-ecs';
 import type { Size } from '../../core';
-import { Lazy } from '../../core';
+import type { IArrayBox, IReadableBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 
 const EMPTY_DIR_VOLUME_SYMBOL = Symbol.for('aws-cdk-lib/aws-batch/lib/eks-container-definition.EmptyDirVolume');
@@ -557,9 +558,13 @@ export class EksContainerDefinition extends Construct implements IEksContainerDe
   public readonly runAsGroup?: number;
   public readonly runAsRoot?: boolean;
   public readonly runAsUser?: number;
-  public readonly volumes: EksVolume[];
+  private readonly _volumes: IArrayBox<EksVolume>;
 
   private readonly imageConfig: ecs.ContainerImageConfig;
+
+  public get volumes(): EksVolume[] {
+    return this._volumes.getMutable();
+  }
 
   constructor(scope: Construct, id: string, props: EksContainerDefinitionProps) {
     super(scope, id);
@@ -581,12 +586,19 @@ export class EksContainerDefinition extends Construct implements IEksContainerDe
     this.runAsGroup = props.runAsGroup;
     this.runAsRoot = props.runAsRoot;
     this.runAsUser = props.runAsUser;
-    this.volumes = props.volumes ?? [];
+    this._volumes = Box.fromArray(props.volumes ?? []);
     this.imageConfig = props.image.bind(this, this as any);
   }
 
   addVolume(volume: EksVolume) {
-    this.volumes.push(volume);
+    this._volumes.push(volume);
+  }
+
+  /**
+   * @internal
+   */
+  public _mapVolumes<B>(fn: (volume: EksVolume) => B): IReadableBox<Array<B>> {
+    return this._volumes.map(fn);
   }
 
   /**
@@ -625,20 +637,11 @@ export class EksContainerDefinition extends Construct implements IEksContainerDe
         runAsNonRoot: !this.runAsRoot,
         runAsUser: this.runAsUser,
       },
-      volumeMounts: Lazy.any({
-        produce: () => {
-          if (this.volumes.length === 0) {
-            return undefined;
-          }
-          return this.volumes.map((volume) => {
-            return {
-              name: volume.name,
-              mountPath: volume.containerPath,
-              readOnly: volume.readonly,
-            };
-          });
-        },
-      }),
+      volumeMounts: this._volumes.map((volume) => ({
+        name: volume.name,
+        mountPath: volume.containerPath,
+        readOnly: volume.readonly,
+      })),
     };
   }
 }

--- a/packages/aws-cdk-lib/aws-batch/lib/eks-job-definition.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/eks-job-definition.ts
@@ -4,7 +4,7 @@ import type { EksContainerDefinition } from './eks-container-definition';
 import { EmptyDirVolume, HostPathVolume, SecretPathVolume } from './eks-container-definition';
 import type { IJobDefinition, JobDefinitionProps } from './job-definition-base';
 import { baseJobDefinitionProperties, JobDefinitionBase } from './job-definition-base';
-import { ArnFormat, Lazy, Stack, ValidationError } from '../../core';
+import { ArnFormat, Stack, ValidationError } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { lit } from '../../core/lib/private/literal-string';
@@ -193,42 +193,35 @@ export class EksJobDefinition extends JobDefinitionBase implements IEksJobDefini
           dnsPolicy: this.dnsPolicy,
           hostNetwork: this.useHostNetwork,
           serviceAccountName: this.serviceAccount,
-          volumes: Lazy.any({
-            produce: () => {
-              if (this.container.volumes.length === 0) {
-                return undefined;
-              }
-              return this.container.volumes.map((volume) => {
-                if (EmptyDirVolume.isEmptyDirVolume(volume)) {
-                  return {
-                    name: volume.name,
-                    emptyDir: {
-                      medium: volume.medium,
-                      sizeLimit: volume.sizeLimit ? volume.sizeLimit.toMebibytes().toString() + 'Mi' : undefined,
-                    },
-                  };
-                }
-                if (HostPathVolume.isHostPathVolume(volume)) {
-                  return {
-                    name: volume.name,
-                    hostPath: {
-                      path: volume.path,
-                    },
-                  };
-                }
-                if (SecretPathVolume.isSecretPathVolume(volume)) {
-                  return {
-                    name: volume.name,
-                    secret: {
-                      optional: volume.optional,
-                      secretName: volume.secretName,
-                    },
-                  };
-                }
+          volumes: this.container._mapVolumes((volume) => {
+            if (EmptyDirVolume.isEmptyDirVolume(volume)) {
+              return {
+                name: volume.name,
+                emptyDir: {
+                  medium: volume.medium,
+                  sizeLimit: volume.sizeLimit ? volume.sizeLimit.toMebibytes().toString() + 'Mi' : undefined,
+                },
+              };
+            }
+            if (HostPathVolume.isHostPathVolume(volume)) {
+              return {
+                name: volume.name,
+                hostPath: {
+                  path: volume.path,
+                },
+              };
+            }
+            if (SecretPathVolume.isSecretPathVolume(volume)) {
+              return {
+                name: volume.name,
+                secret: {
+                  optional: volume.optional,
+                  secretName: volume.secretName,
+                },
+              };
+            }
 
-                throw new ValidationError(lit`UnknownVolumeType`, 'unknown volume type', this);
-              });
-            },
+            throw new ValidationError(lit`UnknownVolumeType`, 'unknown volume type', this);
           }),
         },
       },

--- a/packages/aws-cdk-lib/aws-batch/lib/job-definition-base.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/job-definition-base.ts
@@ -1,7 +1,9 @@
 import type { Construct } from 'constructs';
 import type { CfnJobDefinitionProps } from './batch.generated';
 import type { Duration, IResource } from '../../core';
-import { Lazy, Resource } from '../../core';
+import { Resource } from '../../core';
+import type { IArrayBox, IReadableBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import type { IJobDefinitionRef, JobDefinitionReference } from '../../interfaces/generated/aws-batch-interfaces.generated';
 
 /**
@@ -252,7 +254,6 @@ export abstract class JobDefinitionBase extends Resource implements IJobDefiniti
 
   public readonly parameters?: { [key:string]: any };
   public readonly retryAttempts?: number;
-  public readonly retryStrategies: RetryStrategy[];
   public readonly schedulingPriority?: number;
   public readonly timeout?: Duration;
   /**
@@ -262,11 +263,7 @@ export abstract class JobDefinitionBase extends Resource implements IJobDefiniti
    */
   public readonly skipDeregisterOnUpdate?: boolean;
 
-  public get jobDefinitionRef(): JobDefinitionReference {
-    return {
-      jobDefinitionArn: this.jobDefinitionArn,
-    };
-  }
+  private readonly _retryStrategies: IArrayBox<RetryStrategy>;
 
   constructor(scope: Construct, id: string, props?: JobDefinitionProps) {
     super(scope, id, {
@@ -275,14 +272,31 @@ export abstract class JobDefinitionBase extends Resource implements IJobDefiniti
 
     this.parameters = props?.parameters;
     this.retryAttempts = props?.retryAttempts;
-    this.retryStrategies = props?.retryStrategies ?? [];
+    this._retryStrategies = Box.fromArray(props?.retryStrategies ?? []);
     this.schedulingPriority = props?.schedulingPriority;
     this.timeout = props?.timeout;
     this.skipDeregisterOnUpdate = props?.skipDeregisterOnUpdate;
   }
 
+  public get jobDefinitionRef(): JobDefinitionReference {
+    return {
+      jobDefinitionArn: this.jobDefinitionArn,
+    };
+  }
+
+  public get retryStrategies(): RetryStrategy[] {
+    return this._retryStrategies.getMutable();
+  }
+
+  /**
+   * @internal
+   */
+  public _mapRetryStrategies<B>(fn: (strategy: RetryStrategy) => B): IReadableBox<Array<B>> {
+    return this._retryStrategies.map(fn);
+  }
+
   addRetryStrategy(strategy: RetryStrategy): void {
-    this.retryStrategies.push(strategy);
+    this._retryStrategies.push(strategy);
   }
 }
 
@@ -294,19 +308,10 @@ export function baseJobDefinitionProperties(baseJobDefinition: JobDefinitionBase
     parameters: baseJobDefinition.parameters,
     retryStrategy: {
       attempts: baseJobDefinition.retryAttempts,
-      evaluateOnExit: Lazy.any({
-        produce: () => {
-          if (baseJobDefinition.retryStrategies.length === 0) {
-            return undefined;
-          }
-          return baseJobDefinition.retryStrategies.map((strategy) => {
-            return {
-              action: strategy.action,
-              ...strategy.on,
-            };
-          });
-        },
-      }),
+      evaluateOnExit: baseJobDefinition._mapRetryStrategies((strategy) => ({
+        action: strategy.action,
+        ...strategy.on,
+      })),
     },
     schedulingPriority: baseJobDefinition.schedulingPriority,
     timeout: {

--- a/packages/aws-cdk-lib/aws-batch/lib/linux-parameters.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/linux-parameters.ts
@@ -1,6 +1,9 @@
 import { Construct } from 'constructs';
 import type { CfnJobDefinition } from './batch.generated';
 import * as cdk from '../../core';
+import type { IArrayBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
+import { noBoxStackTraces } from '../../core/lib/no-box-stack-traces';
 import { lit } from '../../core/lib/private/literal-string';
 
 /**
@@ -51,6 +54,7 @@ export interface LinuxParametersProps {
 /**
  * Linux-specific options that are applied to the container.
  */
+@noBoxStackTraces
 export class LinuxParameters extends Construct {
   /**
    * Whether the init process is enabled
@@ -75,18 +79,35 @@ export class LinuxParameters extends Construct {
   /**
    * Device mounts
    */
-  protected readonly devices = new Array<Device>();
+  private readonly _devices: IArrayBox<Device>;
+
+  /**
+   * @deprecated - use addDevices instead
+   */
+  protected get devices(): Device[] {
+    return this._devices.getMutable();
+  }
 
   /**
    * TmpFs mounts
    */
-  protected readonly tmpfs = new Array<Tmpfs>();
+  private readonly _tmpfs: IArrayBox<Tmpfs>;
+
+  /**
+   * @deprecated - use addTmpfs instead
+   */
+  protected get tmpfs(): Tmpfs[] {
+    return this._tmpfs.getMutable();
+  }
 
   /**
    * Constructs a new instance of the LinuxParameters class.
    */
   constructor(scope: Construct, id: string, props: LinuxParametersProps = {}) {
     super(scope, id);
+
+    this._devices = Box.fromArray();
+    this._tmpfs = Box.fromArray();
 
     this.validateProps(props);
 
@@ -110,7 +131,7 @@ export class LinuxParameters extends Construct {
    * Adds one or more host devices to a container.
    */
   public addDevices(...device: Device[]) {
-    this.devices.push(...device);
+    this._devices.push(...device);
   }
 
   /**
@@ -119,7 +140,7 @@ export class LinuxParameters extends Construct {
    * Only works with EC2 launch type.
    */
   public addTmpfs(...tmpfs: Tmpfs[]) {
-    this.tmpfs.push(...tmpfs);
+    this._tmpfs.push(...tmpfs);
   }
 
   /**
@@ -132,8 +153,8 @@ export class LinuxParameters extends Construct {
       sharedMemorySize: this.sharedMemorySize?.toMebibytes(),
       maxSwap: this.maxSwap?.toMebibytes(),
       swappiness: this.swappiness,
-      devices: cdk.Lazy.any({ produce: () => this.devices.map(renderDevice) }, { omitEmptyArray: true }),
-      tmpfs: cdk.Lazy.any({ produce: () => this.tmpfs.map(renderTmpfs) }, { omitEmptyArray: true }),
+      devices: this._devices.map(renderDevice),
+      tmpfs: this._tmpfs.map(renderTmpfs),
     };
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -370,9 +370,9 @@ export class Distribution extends Resource implements IDistribution {
 
   private readonly httpVersion: HttpVersion;
   private readonly defaultBehavior: CacheBehavior;
-  private readonly additionalBehaviors: IArrayBox<CacheBehavior> = Box.fromArray([]);
+  private readonly additionalBehaviors: IArrayBox<CacheBehavior> = Box.fromArray();
   private readonly boundOrigins: IArrayBox<BoundOrigin> = Box.fromArray([], { omitEmpty: false });
-  private readonly originGroups: IArrayBox<CfnDistribution.OriginGroupProperty> = Box.fromArray([]);
+  private readonly originGroups: IArrayBox<CfnDistribution.OriginGroupProperty> = Box.fromArray();
 
   private readonly errorResponses: ErrorResponse[];
   private readonly certificate?: ICertificateRef;

--- a/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-base.ts
+++ b/packages/aws-cdk-lib/aws-cloudwatch/lib/alarm-base.ts
@@ -47,11 +47,11 @@ export abstract class AlarmBase extends Resource implements IAlarm {
   public abstract readonly alarmName: string;
 
   /** @internal */
-  protected readonly _alarmActionArns: IArrayBox<string> = Box.fromArray([]);
+  protected readonly _alarmActionArns: IArrayBox<string> = Box.fromArray();
   /** @internal */
-  protected readonly _insufficientDataActionArns: IArrayBox<string> = Box.fromArray([]);
+  protected readonly _insufficientDataActionArns: IArrayBox<string> = Box.fromArray();
   /** @internal */
-  protected readonly _okActionArns: IArrayBox<string> = Box.fromArray([]);
+  protected readonly _okActionArns: IArrayBox<string> = Box.fromArray();
 
   protected get alarmActionArns(): string[] | undefined {
     return this._alarmActionArns.length > 0 ? [...this._alarmActionArns] : undefined;

--- a/packages/aws-cdk-lib/aws-codebuild/lib/project.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project.ts
@@ -1133,14 +1133,14 @@ export class Project extends ProjectBase {
       throw new ValidationError(lit`ProjectSSourceNosource`, "If the Project's source is NoSource, you need to provide a concrete buildSpec", this);
     }
 
-    this._secondarySources = Box.fromArray<CfnProject.SourceProperty>([]);
-    this._secondarySourceVersions = Box.fromArray<CfnProject.ProjectSourceVersionProperty>([]);
-    this._fileSystemLocations = Box.fromArray<CfnProject.ProjectFileSystemLocationProperty>([]);
+    this._secondarySources = Box.fromArray();
+    this._secondarySourceVersions = Box.fromArray();
+    this._fileSystemLocations = Box.fromArray();
     for (const secondarySource of props.secondarySources || []) {
       this.addSecondarySource(secondarySource);
     }
 
-    this._secondaryArtifacts = Box.fromArray<CfnProject.ArtifactsProperty>([]);
+    this._secondaryArtifacts = Box.fromArray();
     for (const secondaryArtifact of props.secondaryArtifacts || []) {
       this.addSecondaryArtifact(secondaryArtifact);
     }

--- a/packages/aws-cdk-lib/aws-codecommit/lib/repository.ts
+++ b/packages/aws-cdk-lib/aws-codecommit/lib/repository.ts
@@ -630,7 +630,7 @@ export class Repository extends RepositoryBase {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    this._triggers = Box.fromArray([]);
+    this._triggers = Box.fromArray();
 
     this.resource = new CfnRepository(this, 'Resource', {
       repositoryName: props.repositoryName,

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/ecs/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/ecs/deployment-group.ts
@@ -8,7 +8,10 @@ import type * as elbv2 from '../../../aws-elasticloadbalancingv2';
 import * as iam from '../../../aws-iam';
 import * as cdk from '../../../core';
 import { ValidationError } from '../../../core';
+import type { IArrayBox } from '../../../core/lib/helpers-internal';
+import { Box } from '../../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
+import { noBoxStackTraces } from '../../../core/lib/no-box-stack-traces';
 import { lit } from '../../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
 import { CODEDEPLOY_REMOVE_ALARMS_FROM_DEPLOYMENT_GROUP } from '../../../cx-api';
@@ -200,6 +203,7 @@ export interface EcsDeploymentGroupProps {
  * @resource AWS::CodeDeploy::DeploymentGroup
  */
 @propertyInjectable
+@noBoxStackTraces
 export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeploymentGroup {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-codedeploy.EcsDeploymentGroup';
@@ -228,7 +232,7 @@ export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeplo
    */
   public readonly role: iam.IRole;
 
-  private readonly alarms: IAlarmRef[];
+  private readonly alarms: IArrayBox<IAlarmRef>;
 
   constructor(scope: Construct, id: string, props: EcsDeploymentGroupProps) {
     super(scope, id, {
@@ -241,7 +245,7 @@ export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeplo
     this.role = this._role;
 
     this._application = props.application || new EcsApplication(this, 'Application');
-    this.alarms = props.alarms || [];
+    this.alarms = Box.fromArray(props.alarms || [], { omitEmpty: false });
 
     this.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSCodeDeployRoleForECS'));
     this._deploymentConfig = this._bindDeploymentConfig(props.deploymentConfig || EcsDeploymentConfig.ALL_AT_ONCE);
@@ -277,15 +281,13 @@ export class EcsDeploymentGroup extends DeploymentGroupBase implements IEcsDeplo
         produce: () => this.renderBlueGreenDeploymentConfiguration(props.blueGreenDeploymentConfig),
       }),
       loadBalancerInfo: cdk.Lazy.any({ produce: () => this.renderLoadBalancerInfo(props.blueGreenDeploymentConfig) }),
-      alarmConfiguration: cdk.Lazy.any({
-        produce: () => renderAlarmConfiguration({
-          alarms: this.alarms,
-          ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
-          removeAlarms: removeAlarmsFromDeploymentGroup,
-          ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
-        }),
-      }),
-      autoRollbackConfiguration: cdk.Lazy.any({ produce: () => renderAutoRollbackConfiguration(this, this.alarms, props.autoRollback) }),
+      alarmConfiguration: this.alarms.derive(alarms => renderAlarmConfiguration({
+        alarms: [...alarms],
+        ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
+        removeAlarms: removeAlarmsFromDeploymentGroup,
+        ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
+      })),
+      autoRollbackConfiguration: this.alarms.derive(alarms => renderAutoRollbackConfiguration(this, [...alarms], props.autoRollback)),
     });
 
     this._setNameAndArn(resource, this.application);

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/lambda/deployment-group.ts
@@ -6,7 +6,7 @@ import { LambdaDeploymentConfig } from './deployment-config';
 import * as iam from '../../../aws-iam';
 import type * as lambda from '../../../aws-lambda';
 import * as cdk from '../../../core';
-import type { IBox } from '../../../core/lib/helpers-internal';
+import type { IArrayBox, IBox } from '../../../core/lib/helpers-internal';
 import { Box } from '../../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
 import { noBoxStackTraces } from '../../../core/lib/no-box-stack-traces';
@@ -168,7 +168,7 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
    */
   public readonly role: iam.IRole;
 
-  private readonly alarms: IAlarmRef[];
+  private readonly alarms: IArrayBox<IAlarmRef>;
   private readonly _preHook: IBox<lambda.IFunction | undefined>;
   private readonly _postHook: IBox<lambda.IFunction | undefined>;
   private readonly _deploymentConfig: IDeploymentConfigRef;
@@ -188,7 +188,7 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
     this.role = this._role;
 
     this.application = props.application || new LambdaApplication(this, 'Application');
-    this.alarms = props.alarms || [];
+    this.alarms = Box.fromArray(props.alarms || [], { omitEmpty: false });
 
     this.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSCodeDeployRoleForLambdaLimited'));
     this._deploymentConfig = this._bindDeploymentConfig(props.deploymentConfig || LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES);
@@ -204,15 +204,13 @@ export class LambdaDeploymentGroup extends DeploymentGroupBase implements ILambd
         deploymentType: 'BLUE_GREEN',
         deploymentOption: 'WITH_TRAFFIC_CONTROL',
       },
-      alarmConfiguration: cdk.Lazy.any({
-        produce: () => renderAlarmConfiguration({
-          alarms: this.alarms,
-          ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
-          removeAlarms: removeAlarmsFromDeploymentGroup,
-          ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
-        }),
-      }),
-      autoRollbackConfiguration: cdk.Lazy.any({ produce: () => renderAutoRollbackConfiguration(this, this.alarms, props.autoRollback) }),
+      alarmConfiguration: this.alarms.derive(alarms => renderAlarmConfiguration({
+        alarms: [...alarms],
+        ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
+        removeAlarms: removeAlarmsFromDeploymentGroup,
+        ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
+      })),
+      autoRollbackConfiguration: this.alarms.derive(alarms => renderAutoRollbackConfiguration(this, [...alarms], props.autoRollback)),
     });
 
     this._setNameAndArn(resource, this.application);

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
@@ -297,7 +297,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
   private readonly _autoScalingGroups: IArrayBox<autoscaling.IAutoScalingGroup>;
   private readonly installAgent: boolean;
   private readonly codeDeployBucket: s3.IBucket;
-  private readonly alarms: IAlarmRef[];
+  private readonly alarms: IArrayBox<IAlarmRef>;
   private readonly loadBalancers?: LoadBalancer[];
 
   constructor(scope: Construct, id: string, props: ServerDeploymentGroupProps = {}) {
@@ -329,7 +329,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
       this.addCodeDeployAgentInstallUserData(asg);
     }
 
-    this.alarms = props.alarms || [];
+    this.alarms = Box.fromArray(props.alarms || [], { omitEmpty: false });
 
     const removeAlarmsFromDeploymentGroup = cdk.FeatureFlags.of(this).isEnabled(CODEDEPLOY_REMOVE_ALARMS_FROM_DEPLOYMENT_GROUP);
 
@@ -348,15 +348,13 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
         },
       ec2TagSet: this.ec2TagSet(props.ec2InstanceTags),
       onPremisesTagSet: this.onPremiseTagSet(props.onPremiseInstanceTags),
-      alarmConfiguration: cdk.Lazy.any({
-        produce: () => renderAlarmConfiguration({
-          alarms: this.alarms,
-          ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
-          removeAlarms: removeAlarmsFromDeploymentGroup,
-          ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
-        }),
-      }),
-      autoRollbackConfiguration: cdk.Lazy.any({ produce: () => renderAutoRollbackConfiguration(this, this.alarms, props.autoRollback) }),
+      alarmConfiguration: this.alarms.derive(alarms => renderAlarmConfiguration({
+        alarms: [...alarms],
+        ignorePollAlarmFailure: props.ignorePollAlarmsFailure,
+        removeAlarms: removeAlarmsFromDeploymentGroup,
+        ignoreAlarmConfiguration: props.ignoreAlarmConfiguration,
+      })),
+      autoRollbackConfiguration: this.alarms.derive(alarms => renderAutoRollbackConfiguration(this, [...alarms], props.autoRollback)),
       terminationHookEnabled: props.terminationHook,
     });
 

--- a/packages/aws-cdk-lib/aws-codepipeline/lib/pipeline.ts
+++ b/packages/aws-cdk-lib/aws-codepipeline/lib/pipeline.ts
@@ -42,8 +42,10 @@ import {
   Token,
   ValidationError,
 } from '../../core';
-import { memoizedGetter } from '../../core/lib/helpers-internal';
+import type { IArrayBox } from '../../core/lib/helpers-internal';
+import { Box, memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
+import { noBoxStackTraces } from '../../core/lib/no-box-stack-traces';
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import * as cxapi from '../../cx-api';
@@ -542,6 +544,7 @@ abstract class PipelineBase extends Resource implements IPipeline {
  *
  * // ... add more stages
  */
+@noBoxStackTraces
 @propertyInjectable
 export class Pipeline extends PipelineBase {
   /** Uniquely identifies this class. */
@@ -576,7 +579,7 @@ export class Pipeline extends PipelineBase {
    */
   public readonly artifactBucket: s3.IBucket;
 
-  private readonly _stages = new Array<Stage>();
+  private readonly _stages: IArrayBox<Stage> = Box.fromArray([], { omitEmpty: false });
   private readonly crossRegionBucketsPassed: boolean;
   private readonly _crossRegionSupport: { [region: string]: CrossRegionSupport } = {};
   private readonly _crossAccountSupport: { [account: string]: Stack } = {};
@@ -586,8 +589,8 @@ export class Pipeline extends PipelineBase {
   private readonly codePipeline: CfnPipeline;
   private readonly pipelineType: PipelineType;
   private readonly usePipelineRoleForActions: boolean;
-  private readonly variables = new Array<Variable>();
-  private readonly triggers = new Array<Trigger>();
+  private readonly variables: IArrayBox<Variable> = Box.fromArray();
+  private readonly triggers: IArrayBox<Trigger> = Box.fromArray();
 
   /**
    * ARN of this pipeline
@@ -702,13 +705,13 @@ export class Pipeline extends PipelineBase {
     this.codePipeline = new CfnPipeline(this, 'Resource', {
       artifactStore: Lazy.any({ produce: () => this.renderArtifactStoreProperty() }),
       artifactStores: Lazy.any({ produce: () => this.renderArtifactStoresProperty() }),
-      stages: Lazy.any({ produce: () => this.renderStages() }),
+      stages: this._stages.map(stage => stage.render()),
       disableInboundStageTransitions: Lazy.any({ produce: () => this.renderDisabledTransitions() }, { omitEmptyArray: true }),
       roleArn: this.role.roleArn,
       restartExecutionOnUpdate: props && props.restartExecutionOnUpdate,
       pipelineType: props.pipelineType ?? (isDefaultV2 ? PipelineType.V2 : undefined),
-      variables: Lazy.any({ produce: () => this.renderVariables() }, { omitEmptyArray: true }),
-      triggers: Lazy.any({ produce: () => this.renderTriggers() }, { omitEmptyArray: true }),
+      variables: this.variables.map(variable => variable._render()),
+      triggers: this.triggers.map(trigger => trigger._render()),
       executionMode: props.executionMode,
       name: this.physicalName,
     });
@@ -824,7 +827,7 @@ export class Pipeline extends PipelineBase {
    * to the pipeline.
    */
   public get stages(): IStage[] {
-    return this._stages.slice();
+    return [...this._stages];
   }
 
   /**
@@ -837,7 +840,7 @@ export class Pipeline extends PipelineBase {
         return stage;
       }
     }
-    throw new ValidationError(lit`PipelineDoesNotContainStage`, `Pipeline does not contain a stage named '${stageName}'. Available stages: ${this._stages.map(s => s.stageName).join(', ')}`, this);
+    throw new ValidationError(lit`PipelineDoesNotContainStage`, `Pipeline does not contain a stage named '${stageName}'. Available stages: ${[...this._stages].map(s => s.stageName).join(', ')}`, this);
   }
 
   /**
@@ -1319,7 +1322,7 @@ export class Pipeline extends PipelineBase {
     const producers: Record<string, PipelineLocation> = {};
     const firstConsumers: Record<string, PipelineLocation> = {};
 
-    for (const [stageIndex, stage] of enumerate(this._stages)) {
+    for (const [stageIndex, stage] of enumerate([...this._stages])) {
       // For every output artifact, get the producer
       for (const action of stage.actionDescriptors) {
         const actionLoc = new PipelineLocation(stageIndex, stage, action);
@@ -1428,25 +1431,13 @@ export class Pipeline extends PipelineBase {
     return this._stages.some(stage => stage.actionDescriptors.some(action => action.region !== undefined));
   }
 
-  private renderStages(): CfnPipeline.StageDeclarationProperty[] {
-    return this._stages.map(stage => stage.render());
-  }
-
   private renderDisabledTransitions(): CfnPipeline.StageTransitionProperty[] {
-    return this._stages
+    return [...this._stages]
       .filter(stage => !stage.transitionToEnabled)
       .map(stage => ({
         reason: stage.transitionDisabledReason,
         stageName: stage.stageName,
       }));
-  }
-
-  private renderVariables(): CfnPipeline.VariableDeclarationProperty[] {
-    return this.variables.map(variable => variable._render());
-  }
-
-  private renderTriggers(): CfnPipeline.PipelineTriggerDeclarationProperty[] {
-    return this.triggers.map(trigger => trigger._render());
   }
 
   private requireRegion(): string {

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -750,13 +750,13 @@ export class TableV2 extends TableBaseV2 {
   private readonly maxReadRequestUnits?: number;
   private readonly maxWriteRequestUnits?: number;
 
-  private readonly replicaTables: IMapBox<string, ReplicaTableProps> = Box.fromMap(new Map());
+  private readonly replicaTables: IMapBox<string, ReplicaTableProps> = Box.fromMap();
   private readonly replicaKeys: { [region: string]: IKey } = {};
   private readonly replicaTableArns: string[] = [];
   private readonly replicaStreamArns: string[] = [];
 
-  private readonly globalSecondaryIndexes: IMapBox<string, CfnGlobalTable.GlobalSecondaryIndexProperty> = Box.fromMap(new Map());
-  private readonly localSecondaryIndexes: IMapBox<string, CfnGlobalTable.LocalSecondaryIndexProperty> = Box.fromMap(new Map());
+  private readonly globalSecondaryIndexes: IMapBox<string, CfnGlobalTable.GlobalSecondaryIndexProperty> = Box.fromMap();
+  private readonly localSecondaryIndexes: IMapBox<string, CfnGlobalTable.LocalSecondaryIndexProperty> = Box.fromMap();
   private readonly globalSecondaryIndexReadCapacitys = new Map<string, Capacity>();
   private readonly globalSecondaryIndexMaxReadUnits = new Map<string, number>();
   private readonly globalTableSettingsReplicationMode?: GlobalTableSettingsReplicationMode;

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
@@ -1309,8 +1309,8 @@ export class Table extends TableBase {
       physicalName: props.tableName,
     });
 
-    this._globalSecondaryIndexes = Box.fromArray([]);
-    this._localSecondaryIndexes = Box.fromArray([]);
+    this._globalSecondaryIndexes = Box.fromArray();
+    this._localSecondaryIndexes = Box.fromArray();
     this._hasIndexBox = Box.combine(
       { gsi: this._globalSecondaryIndexes, lsi: this._localSecondaryIndexes },
       ({ gsi, lsi }) => gsi.length + lsi.length > 0,

--- a/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/security-group.ts
@@ -546,8 +546,8 @@ export class SecurityGroup extends SecurityGroupBase {
       !!props.disableInlineRules :
       !!this.node.tryGetContext(SECURITY_GROUP_DISABLE_INLINE_RULES_CONTEXT_KEY);
 
-    this.directIngressRules = Box.fromArray([]);
-    this.directEgressRules = Box.fromArray([]);
+    this.directIngressRules = Box.fromArray();
+    this.directEgressRules = Box.fromArray();
 
     this.securityGroup = new CfnSecurityGroup(this, 'Resource', {
       groupName: this.physicalName,

--- a/packages/aws-cdk-lib/aws-ecr/lib/repository.ts
+++ b/packages/aws-cdk-lib/aws-ecr/lib/repository.ts
@@ -11,7 +11,6 @@ import type { IResource } from '../../core';
 import {
   Annotations,
   ArnFormat,
-  Lazy,
   RemovalPolicy,
   Resource,
   Stack,
@@ -25,7 +24,7 @@ import {
   ValidationError,
   UnscopedValidationError,
 } from '../../core';
-import type { IBox } from '../../core/lib/helpers-internal';
+import type { IArrayBox, IBox } from '../../core/lib/helpers-internal';
 import { Box, memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { noBoxStackTraces } from '../../core/lib/no-box-stack-traces';
@@ -817,7 +816,7 @@ export class Repository extends RepositoryBase {
     }
   }
 
-  private readonly lifecycleRules = new Array<LifecycleRule>();
+  private readonly lifecycleRules: IArrayBox<LifecycleRule> = Box.fromArray([], { omitEmpty: false });
   private readonly registryId?: string;
   private readonly _policyDocument: IBox<iam.PolicyDocument | undefined>;
   private readonly _resource: CfnRepository;
@@ -852,7 +851,7 @@ export class Repository extends RepositoryBase {
       repositoryName: this.physicalName,
       // It says "Text", but they actually mean "Object".
       repositoryPolicyText: this._policyDocument,
-      lifecyclePolicy: Lazy.any({ produce: () => this.renderLifecyclePolicy() }),
+      lifecyclePolicy: this.lifecycleRules.derive(rules => this.renderLifecyclePolicy(rules)),
       imageScanningConfiguration: props.imageScanOnPush !== undefined ? { scanOnPush: props.imageScanOnPush } : undefined,
       imageTagMutability: props.imageTagMutability,
       imageTagMutabilityExclusionFilters: props.imageTagMutabilityExclusionFilters?.map(
@@ -937,7 +936,7 @@ export class Repository extends RepositoryBase {
       throw new ValidationError(lit`LifecycleRuleMustContainExactlyOneAgeOrCountProperty`, `Life cycle rule must contain exactly one of 'maxImageAge' and 'maxImageCount', got: ${JSON.stringify(rule)}`, this);
     }
 
-    if (rule.tagStatus === TagStatus.ANY && this.lifecycleRules.filter(r => r.tagStatus === TagStatus.ANY).length > 0) {
+    if (rule.tagStatus === TagStatus.ANY && this.lifecycleRules.some(r => r.tagStatus === TagStatus.ANY)) {
       throw new ValidationError(lit`LifecycleCanOnlyHaveOneAnyTagStatusRule`, 'Life cycle can only have one TagStatus.Any rule', this);
     }
 
@@ -979,15 +978,15 @@ export class Repository extends RepositoryBase {
   /**
    * Render the life cycle policy object
    */
-  private renderLifecyclePolicy(): CfnRepository.LifecyclePolicyProperty | undefined {
+  private renderLifecyclePolicy(rules: readonly LifecycleRule[]): CfnRepository.LifecyclePolicyProperty | undefined {
     const stack = Stack.of(this);
     let lifecyclePolicyText: any;
 
-    if (this.lifecycleRules.length === 0 && !this.registryId) { return undefined; }
+    if (rules.length === 0 && !this.registryId) { return undefined; }
 
-    if (this.lifecycleRules.length > 0) {
+    if (rules.length > 0) {
       lifecyclePolicyText = JSON.stringify(stack.resolve({
-        rules: this.orderedLifecycleRules().map(renderLifecycleRule),
+        rules: this.orderedLifecycleRules(rules).map(renderLifecycleRule),
       }));
     }
 
@@ -1002,12 +1001,12 @@ export class Repository extends RepositoryBase {
    *
    * Also applies validation of the 'any' rule.
    */
-  private orderedLifecycleRules(): LifecycleRule[] {
-    if (this.lifecycleRules.length === 0) { return []; }
+  private orderedLifecycleRules(rules: readonly LifecycleRule[]): LifecycleRule[] {
+    if (rules.length === 0) { return []; }
 
-    const prioritizedRules = this.lifecycleRules.filter(r => r.rulePriority !== undefined && r.tagStatus !== TagStatus.ANY);
-    const autoPrioritizedRules = this.lifecycleRules.filter(r => r.rulePriority === undefined && r.tagStatus !== TagStatus.ANY);
-    const anyRules = this.lifecycleRules.filter(r => r.tagStatus === TagStatus.ANY);
+    const prioritizedRules = rules.filter(r => r.rulePriority !== undefined && r.tagStatus !== TagStatus.ANY);
+    const autoPrioritizedRules = rules.filter(r => r.rulePriority === undefined && r.tagStatus !== TagStatus.ANY);
+    const anyRules = rules.filter(r => r.tagStatus === TagStatus.ANY);
     if (anyRules.length > 0 && anyRules[0].rulePriority !== undefined && autoPrioritizedRules.length > 0) {
       // Supporting this is too complex for very little value. We just prohibit it.
       throw new ValidationError(lit`CannotCombinePrioritizedAnyRuleWithUnprioritizedRules`, "Cannot combine prioritized TagStatus.Any rule with unprioritized rules. Remove rulePriority from the 'Any' rule.", this);

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
@@ -763,7 +763,14 @@ export abstract class BaseService extends Resource
    * A list of Elastic Load Balancing load balancer objects, containing the load balancer name, the container
    * name (as it appears in a container definition), and the container port to access from the load balancer.
    */
-  protected networkConfiguration?: CfnService.NetworkConfigurationProperty;
+  private readonly _networkConfigurationBox: IBox<CfnService.NetworkConfigurationProperty | undefined> = Box.fromValue(undefined);
+
+  protected get networkConfiguration(): CfnService.NetworkConfigurationProperty | undefined {
+    return this._networkConfigurationBox.getMutable();
+  }
+  protected set networkConfiguration(value: CfnService.NetworkConfigurationProperty | undefined) {
+    this._networkConfigurationBox.set(value);
+  }
 
   /**
    * The deployment alarms property - this will be rendered directly and lazily as the CfnService.alarms
@@ -782,13 +789,12 @@ export abstract class BaseService extends Resource
    * The details of the service discovery registries to assign to this service.
    * For more information, see Service Discovery.
    */
-  private _serviceRegistries: IArrayBox<CfnService.ServiceRegistryProperty> = Box.fromArray([]);
+  private _serviceRegistries: IArrayBox<CfnService.ServiceRegistryProperty> = Box.fromArray();
 
   /**
    * The service connect configuration for this service.
-   * @internal
    */
-  protected _serviceConnectConfig?: CfnService.ServiceConnectConfigurationProperty;
+  private readonly _serviceConnectConfig: IBox<CfnService.ServiceConnectConfigurationProperty | undefined> = Box.fromValue(undefined);
 
   /**
    * Whether this service is using the ECS deployment controller.
@@ -878,8 +884,8 @@ export abstract class BaseService extends Resource
     }
 
     this.taskDefinition = taskDefinition;
-    this._volumes = Box.fromArray([]);
-    this._lifecycleHooks = Box.fromArray([]);
+    this._volumes = Box.fromArray();
+    this._lifecycleHooks = Box.fromArray();
 
     // launchType will set to undefined if using external DeploymentController or capacityProviderStrategies
     const launchType = props.deploymentController?.type === DeploymentControllerType.EXTERNAL ||
@@ -932,9 +938,9 @@ export abstract class BaseService extends Resource
       capacityProviderStrategy: props.capacityProviderStrategies,
       healthCheckGracePeriodSeconds: this.evaluateHealthGracePeriod(props.healthCheckGracePeriod),
       /* role: never specified, supplanted by Service Linked Role */
-      networkConfiguration: Lazy.any({ produce: () => this.networkConfiguration }, { omitEmptyArray: true }),
+      networkConfiguration: this._networkConfigurationBox,
       serviceRegistries: this._serviceRegistries,
-      serviceConnectConfiguration: Lazy.any({ produce: () => this._serviceConnectConfig }, { omitEmptyArray: true }),
+      serviceConnectConfiguration: this._serviceConnectConfig,
       volumeConfigurations: this._volumes.derive(_ => this.renderVolumes()),
       ...additionalProps,
     });
@@ -1198,7 +1204,7 @@ export abstract class BaseService extends Resource
    * Enable Service Connect on this service.
    */
   public enableServiceConnect(config?: ServiceConnectProps) {
-    if (this._serviceConnectConfig) {
+    if (this._serviceConnectConfig.get() !== undefined) {
       throw new ValidationError(lit`ServiceConnectConfigurationCannot`, 'Service connect configuration cannot be specified more than once.', this);
     }
 
@@ -1261,7 +1267,7 @@ export abstract class BaseService extends Resource
       logConfig = cfg.logDriver.bind(this, this.taskDefinition.defaultContainer);
     }
 
-    this._serviceConnectConfig = {
+    this._serviceConnectConfig.set({
       enabled: true,
       logConfiguration: logConfig,
       namespace: namespace,
@@ -1270,7 +1276,7 @@ export abstract class BaseService extends Resource
         format: cfg.accessLogConfiguration.format,
         includeQueryParameters: cfg.accessLogConfiguration.includeQueryParameters ? 'ENABLED' : 'DISABLED',
       } : undefined,
-    };
+    });
   }
 
   /**
@@ -1784,7 +1790,7 @@ export abstract class BaseService extends Resource
       awsvpcConfiguration: {
         assignPublicIp: assignPublicIp ? 'ENABLED' : 'DISABLED',
         subnets: vpc.selectSubnets(vpcSubnets).subnetIds,
-        securityGroups: Lazy.list({ produce: () => [securityGroup!.securityGroupId] }),
+        securityGroups: [securityGroup!.securityGroupId],
       },
     };
   }

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
@@ -4,6 +4,8 @@ import * as ec2 from '../../../aws-ec2';
 import * as iam from '../../../aws-iam';
 import type { IResource } from '../../../core';
 import { Lazy, Names, PhysicalName, Resource, UnscopedValidationError, ValidationError } from '../../../core';
+import type { IArrayBox } from '../../../core/lib/helpers-internal';
+import { Box } from '../../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../../core/lib/metadata-resource';
 import { lit } from '../../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../../core/lib/prop-injectable';
@@ -435,12 +437,19 @@ export class TaskDefinition extends TaskDefinitionBase {
   /**
    * The container definitions.
    */
-  protected readonly containers = new Array<ContainerDefinition>();
+  private readonly _containers: IArrayBox<ContainerDefinition> = Box.fromArray();
+
+  /**
+   * The container definitions.
+   */
+  protected get containers(): ContainerDefinition[] {
+    return this._containers.getMutable();
+  }
 
   /**
    * All volumes
    */
-  private readonly volumes: Volume[] = [];
+  private readonly volumes: IArrayBox<Volume> = Box.fromArray();
 
   /**
    * Placement constraints for task instances
@@ -569,7 +578,7 @@ export class TaskDefinition extends TaskDefinitionBase {
 
     let taskDefProps: CfnTaskDefinitionProps = {
       containerDefinitions: Lazy.any({ produce: () => this.renderContainers() }, { omitEmptyArray: true }),
-      volumes: Lazy.any({ produce: () => this.renderVolumes() }, { omitEmptyArray: true }),
+      volumes: this.volumes.derive(vs => vs.map(renderVolume)),
       executionRoleArn: Lazy.string({ produce: () => this.executionRole && this.executionRole.roleArn }),
       family: this.family,
       taskRoleArn: this.taskRole.roleArn,
@@ -628,33 +637,6 @@ export class TaskDefinition extends TaskDefinitionBase {
    */
   public get inferenceAccelerators(): InferenceAccelerator[] {
     return this._inferenceAccelerators;
-  }
-
-  private renderVolumes(): CfnTaskDefinition.VolumeProperty[] {
-    return this.volumes.map(renderVolume);
-
-    function renderVolume(spec: Volume): CfnTaskDefinition.VolumeProperty {
-      return {
-        host: spec.host,
-        name: spec.name,
-        configuredAtLaunch: spec.configuredAtLaunch,
-        dockerVolumeConfiguration: spec.dockerVolumeConfiguration && {
-          autoprovision: spec.dockerVolumeConfiguration.autoprovision,
-          driver: spec.dockerVolumeConfiguration.driver,
-          driverOpts: spec.dockerVolumeConfiguration.driverOpts,
-          labels: spec.dockerVolumeConfiguration.labels,
-          scope: spec.dockerVolumeConfiguration.scope,
-        },
-        efsVolumeConfiguration: spec.efsVolumeConfiguration && {
-          filesystemId: spec.efsVolumeConfiguration.fileSystemId,
-          authorizationConfig: spec.efsVolumeConfiguration.authorizationConfig,
-          rootDirectory: spec.efsVolumeConfiguration.rootDirectory,
-          transitEncryption: spec.efsVolumeConfiguration.transitEncryption,
-          transitEncryptionPort: spec.efsVolumeConfiguration.transitEncryptionPort,
-
-        },
-      };
-    }
   }
 
   private renderInferenceAccelerators(): CfnTaskDefinition.InferenceAcceleratorProperty[] {
@@ -739,7 +721,7 @@ export class TaskDefinition extends TaskDefinitionBase {
   @MethodMetadata()
   public addFirelensLogRouter(id: string, props: FirelensLogRouterDefinitionOptions) {
     // only one firelens log router is allowed in each task.
-    if (this.containers.find(x => x instanceof FirelensLogRouter)) {
+    if (this._containers.find(x => x instanceof FirelensLogRouter)) {
       throw new ValidationError(lit`FirelensRouterAlreadyAdded`, 'Firelens log router is already added in this task.', this);
     }
 
@@ -759,7 +741,7 @@ export class TaskDefinition extends TaskDefinitionBase {
       }
     }
 
-    this.containers.push(container);
+    this._containers.push(container);
     if (this.defaultContainer === undefined && container.essential) {
       this.defaultContainer = container;
     }
@@ -895,7 +877,7 @@ export class TaskDefinition extends TaskDefinitionBase {
 
     // Validate that there are no named port mapping conflicts for Service Connect.
     const portMappingNames = new Map<string, string>(); // Map from port mapping name to most recent container it appears in.
-    this.containers.forEach(container => {
+    for (const container of this.containers) {
       for (const pm of container.portMappings) {
         if (pm.name) {
           if (portMappingNames.has(pm.name)) {
@@ -904,9 +886,9 @@ export class TaskDefinition extends TaskDefinitionBase {
           portMappingNames.set(pm.name, container.containerName);
         }
       }
-    });
+    }
     // Validate if multiple volumes configured with configuredAtLaunch.
-    const runtimeVolumes = this.volumes.filter(vol => vol.configuredAtLaunch);
+    const runtimeVolumes = this.volumes.get().filter(vol => vol.configuredAtLaunch);
     if (runtimeVolumes.length > 1) {
       const volumeNames = runtimeVolumes.map(vol => vol.name).join(',');
       ret.push(`More than one volume is configured at launch: [${volumeNames}]`);
@@ -915,7 +897,7 @@ export class TaskDefinition extends TaskDefinitionBase {
     // Validate that volume with configuredAtLaunch set to true is mounted by at least one container.
     for (const volume of this.volumes) {
       if (volume.configuredAtLaunch) {
-        const isVolumeMounted = this.containers.some(container => {
+        const isVolumeMounted = this._containers.some(container => {
           return container.mountPoints.some(mp => mp.sourceVolume === volume.name);
         });
 
@@ -936,12 +918,12 @@ export class TaskDefinition extends TaskDefinitionBase {
   public findPortMappingByName(name: string): PortMapping | undefined {
     let portMapping;
 
-    this.containers.forEach(container => {
+    for (const container of this.containers) {
       const pm = container.findPortMappingByName(name);
       if (pm) {
         portMapping = pm;
       }
-    });
+    }
 
     return portMapping;
   }
@@ -951,7 +933,7 @@ export class TaskDefinition extends TaskDefinitionBase {
    */
   @MethodMetadata()
   public findContainer(containerName: string): ContainerDefinition | undefined {
-    return this.containers.find(c => c.containerName === containerName);
+    return this._containers.find(c => c.containerName === containerName);
   }
 
   private get passRoleStatement() {
@@ -973,12 +955,12 @@ export class TaskDefinition extends TaskDefinitionBase {
     return (networkMode === NetworkMode.NAT) ? undefined : networkMode;
   }
 
+  // Called via Lazy.any (not derive) because it has side effects (creates FirelensLogRouter).
+  // Lazy caches; derive re-runs on every resolve() which would duplicate constructs.
   private renderContainers() {
-    // add firelens log router container if any application container is using firelens log driver,
-    // also check if already created log router container
     for (const container of this.containers) {
       if (container.logDriverConfig && container.logDriverConfig.logDriver === 'awsfirelens'
-        && !this.containers.find(x => x instanceof FirelensLogRouter)) {
+        && !this._containers.find(x => x instanceof FirelensLogRouter)) {
         this.addFirelensLogRouter('log-router', {
           image: obtainDefaultFluentBitECRImage(this, container.logDriverConfig),
           firelensConfig: {
@@ -992,7 +974,7 @@ export class TaskDefinition extends TaskDefinitionBase {
       }
     }
 
-    return this.containers.map(x => x.renderContainerDefinition());
+    return this._containers.get().map(x => x.renderContainerDefinition());
   }
 
   private checkFargateWindowsBasedTasksSize(cpu: string, memory: string, runtimePlatform: RuntimePlatform) {
@@ -1012,6 +994,28 @@ export class TaskDefinition extends TaskDefinitionBase {
       throw new ValidationError(lit`OperatingSystemFamily`, `If operatingSystemFamily is ${runtimePlatform.operatingSystemFamily!._operatingSystemFamily}, then cpu must be in 1024 (1 vCPU), 2048 (2 vCPU), or 4096 (4 vCPU). Provided value was: ${cpu}`, this);
     }
   }
+}
+
+function renderVolume(spec: Volume): CfnTaskDefinition.VolumeProperty {
+  return {
+    host: spec.host,
+    name: spec.name,
+    configuredAtLaunch: spec.configuredAtLaunch,
+    dockerVolumeConfiguration: spec.dockerVolumeConfiguration && {
+      autoprovision: spec.dockerVolumeConfiguration.autoprovision,
+      driver: spec.dockerVolumeConfiguration.driver,
+      driverOpts: spec.dockerVolumeConfiguration.driverOpts,
+      labels: spec.dockerVolumeConfiguration.labels,
+      scope: spec.dockerVolumeConfiguration.scope,
+    },
+    efsVolumeConfiguration: spec.efsVolumeConfiguration && {
+      filesystemId: spec.efsVolumeConfiguration.fileSystemId,
+      authorizationConfig: spec.efsVolumeConfiguration.authorizationConfig,
+      rootDirectory: spec.efsVolumeConfiguration.rootDirectory,
+      transitEncryption: spec.efsVolumeConfiguration.transitEncryption,
+      transitEncryptionPort: spec.efsVolumeConfiguration.transitEncryptionPort,
+    },
+  };
 }
 
 /**

--- a/packages/aws-cdk-lib/aws-ecs/lib/container-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/container-definition.ts
@@ -601,12 +601,12 @@ export class ContainerDefinition extends Construct {
     this.linuxParameters = props.linuxParameters;
     this.containerName = props.containerName ?? this.node.id;
 
-    this._mountPoints = Box.fromArray([]);
-    this._portMappings = Box.fromArray([]);
-    this._volumesFrom = Box.fromArray([]);
-    this._ulimits = Box.fromArray([]);
-    this._containerDependencies = Box.fromArray([]);
-    this._links = Box.fromArray([]);
+    this._mountPoints = Box.fromArray();
+    this._portMappings = Box.fromArray();
+    this._volumesFrom = Box.fromArray();
+    this._ulimits = Box.fromArray();
+    this._containerDependencies = Box.fromArray();
+    this._links = Box.fromArray();
 
     this.imageConfig = props.image.bind(this, this);
     this.imageName = this.imageConfig.imageName;

--- a/packages/aws-cdk-lib/aws-ecs/lib/ec2/ec2-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/ec2/ec2-service.ts
@@ -214,8 +214,8 @@ export class Ec2Service extends BaseService implements IEc2Service {
       }
     }
 
-    const constraints = Box.fromArray<CfnService.PlacementConstraintProperty>([], { omitEmpty: false });
-    const strategies = Box.fromArray<CfnService.PlacementStrategyProperty>([], { omitEmpty: false });
+    const constraints = Box.fromArray([], { omitEmpty: false });
+    const strategies = Box.fromArray([], { omitEmpty: false });
 
     super(scope, id, {
       ...props,

--- a/packages/aws-cdk-lib/aws-ecs/lib/linux-parameters.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/linux-parameters.ts
@@ -105,10 +105,10 @@ export class LinuxParameters extends Construct {
 
     this.validateProps(props);
 
-    this.capAdd = Box.fromArray([]);
-    this.capDrop = Box.fromArray([]);
-    this.devices = Box.fromArray([]);
-    this.tmpfs = Box.fromArray([]);
+    this.capAdd = Box.fromArray();
+    this.capDrop = Box.fromArray();
+    this.devices = Box.fromArray();
+    this.tmpfs = Box.fromArray();
 
     this.sharedMemorySize = props.sharedMemorySize;
     this.initProcessEnabled = props.initProcessEnabled;

--- a/packages/aws-cdk-lib/aws-elasticloadbalancing/lib/load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancing/lib/load-balancer.ts
@@ -285,7 +285,7 @@ export class LoadBalancer extends Resource implements ILoadBalancer, IConnectabl
     this.connections = new Connections({ securityGroups: [this.securityGroup] });
     // Depending on whether the ELB has public or internal IPs, pick the right backend subnets
     this._listeners = Box.fromArray([], { omitEmpty: false });
-    this._instanceIds = Box.fromArray([]);
+    this._instanceIds = Box.fromArray();
 
     const selectedSubnets: SelectedSubnets = loadBalancerSubnets(props);
 

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
@@ -298,7 +298,7 @@ export class ApplicationListener extends BaseListener implements IApplicationLis
       sslPolicy = SslPolicy.TLS13_12_PQ;
     }
 
-    const certificateArns = Box.fromArray<string>([]);
+    const certificateArns: IArrayBox<string> = Box.fromArray();
 
     super(scope, id, {
       loadBalancerArn: props.loadBalancer.loadBalancerArn,

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
@@ -237,7 +237,7 @@ export class NetworkListener extends BaseListener implements INetworkListener {
       sslPolicy = SslPolicy.TLS13_12_PQ;
     }
 
-    const certificateArns = Box.fromArray<string>([]);
+    const certificateArns: IArrayBox<string> = Box.fromArray();
 
     super(scope, id, {
       loadBalancerArn: props.loadBalancer.loadBalancerArn,

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-load-balancer.ts
@@ -320,7 +320,7 @@ export abstract class BaseLoadBalancer extends Resource {
   /**
    * Attributes set on this load balancer
    */
-  private readonly attributes: IMapBox<string, string | undefined> = Box.fromMap(new Map());
+  private readonly attributes: IMapBox<string, string | undefined> = Box.fromMap();
 
   constructor(scope: Construct, id: string, baseProps: BaseLoadBalancerProps, additionalProps: any) {
     super(scope, id, {

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
@@ -391,7 +391,7 @@ export abstract class TargetGroupBase extends Construct implements ITargetGroup 
       );
     }
 
-    this._targetsJson = Box.fromArray([]);
+    this._targetsJson = Box.fromArray();
 
     this._healthCheck = Box.fromValue<HealthCheck>(baseProps.healthCheck || {});
     this.vpc = baseProps.vpc;

--- a/packages/aws-cdk-lib/aws-elasticsearch/lib/elasticsearch-access-policy.ts
+++ b/packages/aws-cdk-lib/aws-elasticsearch/lib/elasticsearch-access-policy.ts
@@ -1,6 +1,7 @@
 import type { Construct } from 'constructs';
 import * as iam from '../../aws-iam';
-import * as cdk from '../../core';
+import type { IArrayBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import * as cr from '../../custom-resources';
 
 /**
@@ -27,9 +28,10 @@ export interface ElasticsearchAccessPolicyProps {
  * Creates LogGroup resource policies.
  */
 export class ElasticsearchAccessPolicy extends cr.AwsCustomResource {
-  private accessPolicyStatements: iam.PolicyStatement[] = [];
+  private readonly accessPolicyStatements: IArrayBox<iam.PolicyStatement>;
 
   constructor(scope: Construct, id: string, props: ElasticsearchAccessPolicyProps) {
+    const accessPolicyStatements: IArrayBox<iam.PolicyStatement> = Box.fromArray([], { omitEmpty: false });
     super(scope, id, {
       resourceType: 'Custom::ElasticsearchAccessPolicy',
       installLatestAwsSdk: false,
@@ -38,13 +40,13 @@ export class ElasticsearchAccessPolicy extends cr.AwsCustomResource {
         service: 'ES',
         parameters: {
           DomainName: props.domainName,
-          AccessPolicies: cdk.Lazy.string({
-            produce: () => JSON.stringify(
+          AccessPolicies: accessPolicyStatements.derive(statements =>
+            JSON.stringify(
               new iam.PolicyDocument({
-                statements: this.accessPolicyStatements,
+                statements: [...statements],
               }).toJSON(),
             ),
-          }),
+          ),
         },
         // this is needed to limit the response body, otherwise it exceeds the CFN 4k limit
         outputPaths: ['DomainConfig.ElasticsearchClusterConfig.AccessPolicies'],
@@ -52,6 +54,7 @@ export class ElasticsearchAccessPolicy extends cr.AwsCustomResource {
       },
       policy: cr.AwsCustomResourcePolicy.fromSdkCalls({ resources: [props.domainArn] }),
     });
+    this.accessPolicyStatements = accessPolicyStatements;
 
     this.addAccessPolicies(...props.accessPolicies);
   }

--- a/packages/aws-cdk-lib/aws-events/lib/rule.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/rule.ts
@@ -132,7 +132,7 @@ export class Rule extends Resource implements IRule {
     };
   }
 
-  private readonly targets: IArrayBox<CfnRule.TargetProperty> = Box.fromArray([]);
+  private readonly targets: IArrayBox<CfnRule.TargetProperty> = Box.fromArray();
   private readonly eventPattern: IBox<EventPattern>;
   private readonly scheduleExpression?: string;
   private readonly description?: string;

--- a/packages/aws-cdk-lib/aws-iam/lib/managed-policy.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/managed-policy.ts
@@ -270,9 +270,9 @@ export class ManagedPolicy extends Resource implements IManagedPolicy, IGrantabl
 
   public readonly grantPrincipal: IPrincipal;
 
-  private readonly roles: IArrayBox<IRoleRef> = Box.fromArray<IRoleRef>([]);
-  private readonly users: IArrayBox<IUserRef> = Box.fromArray<IUserRef>([]);
-  private readonly groups: IArrayBox<IGroupRef> = Box.fromArray<IGroupRef>([]);
+  private readonly roles: IArrayBox<IRoleRef> = Box.fromArray();
+  private readonly users: IArrayBox<IUserRef> = Box.fromArray();
+  private readonly groups: IArrayBox<IGroupRef> = Box.fromArray();
   private readonly _precreatedPolicy?: IManagedPolicy;
 
   constructor(scope: Construct, id: string, props: ManagedPolicyProps = {}) {

--- a/packages/aws-cdk-lib/aws-iam/lib/policy.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/policy.ts
@@ -143,9 +143,9 @@ export class Policy extends Resource implements IPolicy, IGrantable {
   public readonly policyRef: PolicyReference;
 
   private readonly _policyName: string;
-  private readonly roles: IArrayBox<IRole> = Box.fromArray<IRole>([]);
-  private readonly users: IArrayBox<IUser> = Box.fromArray<IUser>([]);
-  private readonly groups: IArrayBox<IGroup> = Box.fromArray<IGroup>([]);
+  private readonly roles: IArrayBox<IRole> = Box.fromArray();
+  private readonly users: IArrayBox<IUser> = Box.fromArray();
+  private readonly groups: IArrayBox<IGroup> = Box.fromArray();
   private readonly force: boolean;
   private referenceTaken = false;
 

--- a/packages/aws-cdk-lib/aws-iam/lib/user.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/user.ts
@@ -289,7 +289,7 @@ export class User extends Resource implements IIdentity, IUser {
 
   public readonly policyFragment: PrincipalPolicyFragment;
 
-  private readonly groups: IArrayBox<any> = Box.fromArray<any>([]);
+  private readonly groups: IArrayBox<any> = Box.fromArray();
   private readonly _managedPolicies: IArrayBox<IManagedPolicy>;
   private readonly attachedPolicies = new AttachedPolicies();
   private defaultPolicy?: Policy;

--- a/packages/aws-cdk-lib/aws-lambda/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function.ts
@@ -941,7 +941,7 @@ export class Function extends FunctionBase {
   protected readonly canCreatePermissions = true;
 
   /** @internal */
-  public readonly _layers: IArrayBox<ILayerVersion> = Box.fromArray([]);
+  public readonly _layers: IArrayBox<ILayerVersion> = Box.fromArray();
 
   /** @internal */
   public _logRetention?: logs.LogRetention;
@@ -972,7 +972,7 @@ export class Function extends FunctionBase {
   /**
    * Environment variables for this function
    */
-  private readonly environment: IMapBox<string, EnvironmentConfig> = Box.fromMap(new Map());
+  private readonly environment: IMapBox<string, EnvironmentConfig> = Box.fromMap();
 
   private readonly currentVersionOptions?: VersionOptions;
   private _currentVersion?: Version;

--- a/packages/aws-cdk-lib/aws-opensearchservice/lib/opensearch-access-policy.ts
+++ b/packages/aws-cdk-lib/aws-opensearchservice/lib/opensearch-access-policy.ts
@@ -42,7 +42,7 @@ export class OpenSearchAccessPolicy extends cr.AwsCustomResource {
   private readonly accessPolicyStatements: IArrayBox<iam.PolicyStatement>;
 
   constructor(scope: Construct, id: string, props: OpenSearchAccessPolicyProps) {
-    const accessPolicyStatements = Box.fromArray<iam.PolicyStatement>([]);
+    const accessPolicyStatements: IArrayBox<iam.PolicyStatement> = Box.fromArray();
     super(scope, id, {
       resourceType: 'Custom::OpenSearchAccessPolicy',
       installLatestAwsSdk: false,

--- a/packages/aws-cdk-lib/aws-rds/lib/parameter-group.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/parameter-group.ts
@@ -2,8 +2,10 @@ import type { Construct } from 'constructs';
 import type { IEngine } from './engine';
 import { CfnDBClusterParameterGroup, CfnDBParameterGroup } from './rds.generated';
 import type { IResource } from '../../core';
-import { Lazy, RemovalPolicy, Resource } from '../../core';
+import { RemovalPolicy, Resource } from '../../core';
 import { ValidationError } from '../../core/lib/errors';
+import type { IMapBox, IReadableBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
@@ -181,7 +183,8 @@ export class ParameterGroup extends Resource implements IParameterGroup {
     return parameterGroup;
   }
 
-  private readonly parameters: { [key: string]: string };
+  private readonly parameters: IMapBox<string, string>;
+  private readonly parametersObject: IReadableBox<{ [key: string]: string }>;
   private readonly family: string;
   private readonly removalPolicy?: RemovalPolicy;
   private readonly description?: string;
@@ -202,7 +205,8 @@ export class ParameterGroup extends Resource implements IParameterGroup {
     this.family = family;
     this.description = props.description;
     this.name = props.name;
-    this.parameters = props.parameters ?? {};
+    this.parameters = Box.fromMap(new Map(Object.entries(props.parameters ?? {})));
+    this.parametersObject = this.parameters.derive(m => Object.fromEntries(m));
     this.removalPolicy = props.removalPolicy;
   }
 
@@ -228,7 +232,7 @@ export class ParameterGroup extends Resource implements IParameterGroup {
    */
   @MethodMetadata()
   public addParameter(key: string, value: string): boolean {
-    this.parameters[key] = value;
+    this.parameters.put(key, value);
     return true;
   }
 
@@ -243,7 +247,7 @@ export class ParameterGroup extends Resource implements IParameterGroup {
         description: this.description || `Parameter group for ${this.family}`,
         family: this.family,
         dbParameterGroupName: this.name,
-        parameters: Lazy.any({ produce: () => this.parameters }),
+        parameters: this.parametersObject,
       });
     }
 
@@ -265,7 +269,7 @@ export class ParameterGroup extends Resource implements IParameterGroup {
         description: this.description || `Cluster parameter group for ${this.family}`,
         family: this.family,
         dbClusterParameterGroupName: this.name,
-        parameters: Lazy.any({ produce: () => this.parameters }),
+        parameters: this.parametersObject,
       });
     }
 

--- a/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
@@ -231,7 +231,7 @@ export class HostedZone extends Resource implements IHostedZone {
   /**
    * VPCs to which this hosted zone will be added
    */
-  private readonly _vpcs: IArrayBox<CfnHostedZone.VPCProperty> = Box.fromArray([]);
+  private readonly _vpcs: IArrayBox<CfnHostedZone.VPCProperty> = Box.fromArray();
 
   protected get vpcs(): CfnHostedZone.VPCProperty[] {
     return [...this._vpcs.get()];

--- a/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/bucket.ts
@@ -2355,12 +2355,12 @@ export class Bucket extends BucketBase {
   }
   private readonly accessControl: IBox<BucketAccessControl | undefined>;
   private readonly ownershipControls: IBox<CfnBucket.OwnershipControlsProperty | undefined>;
-  private readonly lifecycleRules: IArrayBox<LifecycleRule> = Box.fromArray([]);
+  private readonly lifecycleRules: IArrayBox<LifecycleRule> = Box.fromArray();
   private readonly transitionDefaultMinimumObjectSize?: TransitionDefaultMinimumObjectSize;
   private readonly eventBridgeEnabled?: boolean;
-  private readonly metrics: IArrayBox<BucketMetrics> = Box.fromArray([]);
-  private readonly cors: IArrayBox<CorsRule> = Box.fromArray([]);
-  private readonly inventories: IArrayBox<Inventory> = Box.fromArray([]);
+  private readonly metrics: IArrayBox<BucketMetrics> = Box.fromArray();
+  private readonly cors: IArrayBox<CorsRule> = Box.fromArray();
+  private readonly inventories: IArrayBox<Inventory> = Box.fromArray();
   private readonly _resource: CfnBucket;
   private readonly reflection: BucketReflection;
 

--- a/packages/aws-cdk-lib/aws-s3/lib/notifications-resource/notifications-resource.ts
+++ b/packages/aws-cdk-lib/aws-s3/lib/notifications-resource/notifications-resource.ts
@@ -49,9 +49,9 @@ interface NotificationsProps {
 @noBoxStackTraces
 export class BucketNotifications extends Construct {
   private readonly eventBridgeEnabled: IBox<boolean> = Box.fromValue(false);
-  private readonly lambdaNotifications: IArrayBox<LambdaFunctionConfiguration> = Box.fromArray([]);
-  private readonly queueNotifications: IArrayBox<QueueConfiguration> = Box.fromArray([]);
-  private readonly topicNotifications: IArrayBox<TopicConfiguration> = Box.fromArray([]);
+  private readonly lambdaNotifications: IArrayBox<LambdaFunctionConfiguration> = Box.fromArray();
+  private readonly queueNotifications: IArrayBox<QueueConfiguration> = Box.fromArray();
+  private readonly topicNotifications: IArrayBox<TopicConfiguration> = Box.fromArray();
   private resource?: cdk.CfnResource;
   private readonly bucket: IBucket;
   private readonly handlerRole?: iam.IRole;

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
@@ -679,7 +679,7 @@ export class Secret extends SecretBase {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    this._replicaRegions = Box.fromArray([]);
+    this._replicaRegions = Box.fromArray();
 
     if (props.generateSecretString &&
         (props.generateSecretString.secretStringTemplate || props.generateSecretString.generateStringKey) &&

--- a/packages/aws-cdk-lib/aws-ses/lib/receipt-rule.ts
+++ b/packages/aws-cdk-lib/aws-ses/lib/receipt-rule.ts
@@ -3,8 +3,11 @@ import type { IReceiptRuleAction } from './receipt-rule-action';
 import { CfnReceiptRule } from './ses.generated';
 import * as iam from '../../aws-iam';
 import type { IResource } from '../../core';
-import { Aws, Lazy, Resource } from '../../core';
+import { Aws, Resource } from '../../core';
+import type { IArrayBox } from '../../core/lib/helpers-internal';
+import { Box } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
+import { noBoxStackTraces } from '../../core/lib/no-box-stack-traces';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import { DropSpamSingletonFunction } from '../../custom-resource-handlers/dist/aws-ses/drop-spam-provider.generated';
 import type { IReceiptRuleSetRef, IReceiptRuleRef, ReceiptRuleReference } from '../../interfaces/generated/aws-ses-interfaces.generated';
@@ -106,6 +109,7 @@ export interface ReceiptRuleProps extends ReceiptRuleOptions {
  * A new receipt rule.
  */
 @propertyInjectable
+@noBoxStackTraces
 export class ReceiptRule extends Resource implements IReceiptRule {
   /**
    * Uniquely identifies this class.
@@ -126,7 +130,7 @@ export class ReceiptRule extends Resource implements IReceiptRule {
   }
 
   public readonly receiptRuleName: string;
-  private readonly actions = new Array<CfnReceiptRule.ActionProperty>();
+  private readonly actions: IArrayBox<CfnReceiptRule.ActionProperty> = Box.fromArray();
 
   public get receiptRuleRef(): ReceiptRuleReference {
     return {
@@ -144,7 +148,7 @@ export class ReceiptRule extends Resource implements IReceiptRule {
     const resource = new CfnReceiptRule(this, 'Resource', {
       after: props.after?.receiptRuleRef.receiptRuleId,
       rule: {
-        actions: Lazy.any({ produce: () => this.renderActions() }),
+        actions: this.actions,
         enabled: props.enabled ?? true,
         name: this.physicalName,
         recipients: props.recipients,
@@ -167,14 +171,6 @@ export class ReceiptRule extends Resource implements IReceiptRule {
   @MethodMetadata()
   public addAction(action: IReceiptRuleAction) {
     this.actions.push(action.bind(this));
-  }
-
-  private renderActions() {
-    if (this.actions.length === 0) {
-      return undefined;
-    }
-
-    return this.actions;
   }
 }
 

--- a/packages/aws-cdk-lib/aws-sns/lib/topic.ts
+++ b/packages/aws-cdk-lib/aws-sns/lib/topic.ts
@@ -315,7 +315,7 @@ export class Topic extends TopicBase {
 
   private readonly _resource: CfnTopic;
 
-  private readonly loggingConfigs: IArrayBox<LoggingConfig> = Box.fromArray<LoggingConfig>([]);
+  private readonly loggingConfigs: IArrayBox<LoggingConfig> = Box.fromArray();
 
   constructor(scope: Construct, id: string, props: TopicProps = {}) {
     super(scope, id, {

--- a/packages/aws-cdk-lib/aws-synthetics/lib/group.ts
+++ b/packages/aws-cdk-lib/aws-synthetics/lib/group.ts
@@ -138,7 +138,7 @@ export class Group extends cdk.Resource implements IGroup {
   }
 
   private readonly _resource: CfnGroup;
-  private readonly _canaries: ISetBox<ICanary> = Box.fromSet(new Set());
+  private readonly _canaries: ISetBox<ICanary> = Box.fromSet();
 
   constructor(scope: Construct, id: string, props: GroupProps = {}) {
     super(scope, id, {

--- a/packages/aws-cdk-lib/core/lib/custom-resource-provider/cross-region-export-providers/export-reader-provider.ts
+++ b/packages/aws-cdk-lib/core/lib/custom-resource-provider/cross-region-export-providers/export-reader-provider.ts
@@ -1,10 +1,11 @@
 import { Construct } from 'constructs';
-import type { ExportReaderCRProps, CrossRegionExports } from './types';
+import type { ExportReaderCRProps } from './types';
 import { SSM_EXPORT_PATH_PREFIX } from './types';
 import { CfnResource } from '../../cfn-resource';
 import { CustomResource } from '../../custom-resource';
 import { CrossRegionSsmReaderProvider } from '../../dist/core/cross-region-ssm-reader-provider.generated';
-import { Lazy } from '../../lazy';
+import type { IMapBox } from '../../helpers-internal';
+import { Box } from '../../helpers-internal';
 import type { Intrinsic } from '../../private/intrinsic';
 import { Stack } from '../../stack';
 
@@ -28,7 +29,7 @@ export class ExportReader extends Construct {
       : new ExportReader(stack, uniqueId);
   }
 
-  private readonly importParameters: CrossRegionExports = {};
+  private readonly importParameters: IMapBox<string, string> = Box.fromMap();
   private readonly customResource: CustomResource;
   constructor(scope: Construct, id: string, _props: ExportReaderProps = {}) {
     super(scope, id);
@@ -54,7 +55,7 @@ export class ExportReader extends Construct {
     const properties: ExportReaderCRProps = {
       region: stack.region,
       prefix: stack.stackName,
-      imports: Lazy.any({ produce: () => this.importParameters }),
+      imports: this.importParameters.derive(m => Object.fromEntries(m)),
     };
     this.customResource = new CustomResource(this, 'Resource', {
       resourceType: resourceType,
@@ -85,7 +86,7 @@ export class ExportReader extends Construct {
    * @param exports map of unique name associated with the export to SSM Dynamic reference
    */
   public importValue(name: string, value: Intrinsic): Intrinsic {
-    this.importParameters[name] = value.toString();
+    this.importParameters.put(name, value.toString());
     return this.customResource.getAtt(name);
   }
 }

--- a/packages/aws-cdk-lib/core/lib/custom-resource-provider/cross-region-export-providers/export-writer-provider.ts
+++ b/packages/aws-cdk-lib/core/lib/custom-resource-provider/cross-region-export-providers/export-writer-provider.ts
@@ -1,11 +1,12 @@
 import { Construct } from 'constructs';
 import { ExportReader } from './export-reader-provider';
-import type { CrossRegionExports, ExportWriterCRProps } from './types';
+import type { ExportWriterCRProps } from './types';
 import { SSM_EXPORT_PATH_PREFIX } from './types';
 import { CfnDynamicReference, CfnDynamicReferenceService } from '../../cfn-dynamic-reference';
 import { CustomResource } from '../../custom-resource';
 import { CrossRegionSsmWriterProvider } from '../../dist/core/cross-region-ssm-writer-provider.generated';
-import { Lazy } from '../../lazy';
+import type { IMapBox, ISetBox } from '../../helpers-internal';
+import { Box } from '../../helpers-internal';
 import type { Intrinsic } from '../../private/intrinsic';
 import { makeUniqueId } from '../../private/uniqueid';
 import type { Reference } from '../../reference';
@@ -38,12 +39,12 @@ class CRProvider extends CrossRegionSsmWriterProvider {
     return provider;
   }
 
-  private readonly resourceArns = new Set<string>();
+  private readonly resourceArns: ISetBox<string> = Box.fromSet();
   constructor(scope: Construct, id: string, props?: CustomResourceProviderOptions) {
     super(scope, id, props);
     this.addToRolePolicy({
       Effect: 'Allow',
-      Resource: Lazy.list({ produce: () => Array.from(this.resourceArns) }),
+      Resource: this.resourceArns.derive(Array.from),
       Action: [
         'ssm:DeleteParameters',
         'ssm:ListTagsForResource',
@@ -91,7 +92,7 @@ export class ExportWriter extends Construct {
         region: props.region,
       });
   }
-  private readonly _references: CrossRegionExports = {};
+  private readonly _references: IMapBox<string, any> = Box.fromMap();
   private readonly provider: CRProvider;
   constructor(scope: Construct, id: string, props: ExportWriterProps) {
     super(scope, id);
@@ -105,7 +106,7 @@ export class ExportWriter extends Construct {
 
     const properties: ExportWriterCRProps = {
       region: region,
-      exports: Lazy.any({ produce: () => this._references }),
+      exports: this._references.derive(m => Object.fromEntries(m)),
     };
     new CustomResource(this, 'Resource', {
       resourceType: resourceType,
@@ -133,7 +134,7 @@ export class ExportWriter extends Construct {
 
     const ref = new CfnDynamicReference(CfnDynamicReferenceService.SSM, parameterName);
 
-    this._references[parameterName] = stack.resolve(reference.toString());
+    this._references.put(parameterName, stack.resolve(reference.toString()));
     return this.addToExportReader(parameterName, ref, importStack);
   }
 

--- a/packages/aws-cdk-lib/core/lib/custom-resource-provider/custom-resource-provider-base.ts
+++ b/packages/aws-cdk-lib/core/lib/custom-resource-provider/custom-resource-provider-base.ts
@@ -10,8 +10,8 @@ import { CfnResource } from '../cfn-resource';
 import { Duration } from '../duration';
 import { ValidationError } from '../errors';
 import { FileSystem } from '../fs';
-import { PolicySynthesizer, getPrecreatedRoleConfig } from '../helpers-internal';
-import { Lazy } from '../lazy';
+import type { IArrayBox } from '../helpers-internal';
+import { Box, PolicySynthesizer, getPrecreatedRoleConfig } from '../helpers-internal';
 import { lit } from '../private/literal-string';
 import { Size } from '../size';
 import { Stack } from '../stack';
@@ -52,7 +52,7 @@ export abstract class CustomResourceProviderBase extends Construct {
   }
 
   private _codeHash?: string;
-  private policyStatements?: any[];
+  private readonly policyStatements: IArrayBox<any> = Box.fromArray();
   private role?: CfnResource;
   private handler?: CfnResource;
 
@@ -96,7 +96,7 @@ export abstract class CustomResourceProviderBase extends Construct {
             missing: !config.precreatedRoleName,
             roleName: config.precreatedRoleName ?? id+'Role',
             managedPolicies: [{ managedPolicyArn: managedPolicyArn }],
-            policyStatements: this.policyStatements ?? [],
+            policyStatements: [...this.policyStatements.get()],
             assumeRolePolicy: assumeRolePolicyDoc as any,
           });
           return [];
@@ -120,7 +120,13 @@ export abstract class CustomResourceProviderBase extends Construct {
           ManagedPolicyArns: [
             { 'Fn::Sub': managedPolicyArn },
           ],
-          Policies: Lazy.any({ produce: () => this.renderPolicies() }),
+          Policies: this.policyStatements.derive(stmts => stmts.length === 0 ? undefined : [{
+            PolicyName: 'Inline',
+            PolicyDocument: {
+              Version: '2012-10-17',
+              Statement: stmts,
+            },
+          }]),
         },
       });
     }
@@ -179,26 +185,7 @@ export abstract class CustomResourceProviderBase extends Construct {
    * });
    */
   public addToRolePolicy(statement: any): void {
-    if (!this.policyStatements) {
-      this.policyStatements = [];
-    }
     this.policyStatements.push(statement);
-  }
-
-  private renderPolicies() {
-    if (!this.policyStatements) {
-      return undefined;
-    }
-
-    const policies = [{
-      PolicyName: 'Inline',
-      PolicyDocument: {
-        Version: '2012-10-17',
-        Statement: this.policyStatements,
-      },
-    }];
-
-    return policies;
   }
 
   private renderEnvironmentVariables(env?: { [key: string]: string }) {

--- a/packages/aws-cdk-lib/core/lib/helpers-internal/box.ts
+++ b/packages/aws-cdk-lib/core/lib/helpers-internal/box.ts
@@ -392,7 +392,7 @@ export class Box {
    *   array is empty. Set to `false` to resolve to an empty array instead.
    * @returns a new `ArrayBox<A>`.
    */
-  public static fromArray<A>(as: Array<A>, options?: { omitEmpty?: boolean }): IArrayBox<A> {
+  public static fromArray<A>(as: Array<A> = [], options?: { omitEmpty?: boolean }): IArrayBox<A> {
     return new ArrayState(as, options?.omitEmpty ?? true);
   }
 
@@ -402,7 +402,7 @@ export class Box {
    * @param map the initial map contents.
    * @returns a new `MapBox<K, V>`.
    */
-  public static fromMap<K, V>(map: Map<K, V>): IMapBox<K, V> {
+  public static fromMap<K, V>(map: Map<K, V> = new Map()): IMapBox<K, V> {
     return new MapState(map);
   }
 
@@ -412,7 +412,7 @@ export class Box {
    * @param set the initial set contents.
    * @returns a new `SetBox<A>`.
    */
-  public static fromSet<A>(set: Set<A>): ISetBox<A> {
+  public static fromSet<A>(set: Set<A> = new Set()): ISetBox<A> {
     return new SetState(set);
   }
 


### PR DESCRIPTION
Migrate ~50 L2 constructs across multiple service modules from using `Lazy.any()`/`Lazy.list()` with mutable arrays to using `Box.fromArray()`, `Box.fromMap()`, and `Box.fromSet()`. This replaces the pattern of capturing a closure over a mutable array with the Box API, which provides better stack trace attribution for mutations made in user code.

Key changes:
- Add default parameter values to `Box.fromArray()`, `Box.fromMap()`, and `Box.fromSet()` factory methods
- Replace `Lazy` + mutable array/map patterns with `IArrayBox`/`IMapBox` and their `derive()` method for transformations
- Convert public mutable array properties to getters backed by private box fields where needed (e.g., `volumes`, `containers`)
- Simplify render methods by using box derivations instead of `Lazy.any({ produce: () => ... })` callbacks

Affected services: apigateway, applicationautoscaling, appmesh, autoscaling, backup, batch, cloudfront, cloudwatch, codebuild, codecommit, codedeploy, codepipeline, dynamodb, ec2, ecr, ecs, elasticloadbalancing, elasticloadbalancingv2, elasticsearch, events, iam, lambda, opensearchservice, rds, route53, s3, secretsmanager, ses, sns, synthetics, core (custom-resource-provider)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
