### PR TITLE
fix(autoscaling): `StepScalingPolicy` emits spurious cooldown deprecation warning

### DIFF
--- a/packages/aws-cdk-lib/aws-autoscaling/lib/step-scaling-policy.ts
+++ b/packages/aws-cdk-lib/aws-autoscaling/lib/step-scaling-policy.ts
@@ -150,7 +150,7 @@ export class StepScalingPolicy extends Construct {
 
       this.lowerAction = new StepScalingAction(this, 'LowerPolicy', {
         adjustmentType,
-        cooldown: props.cooldown,
+        ...(props.cooldown !== undefined ? { cooldown: props.cooldown } : {}),
         estimatedInstanceWarmup: props.estimatedInstanceWarmup,
         metricAggregationType: props.metricAggregationType ?? aggregationTypeFromMetric(props.metric),
         minAdjustmentMagnitude: props.minAdjustmentMagnitude,
@@ -182,7 +182,7 @@ export class StepScalingPolicy extends Construct {
 
       this.upperAction = new StepScalingAction(this, 'UpperPolicy', {
         adjustmentType,
-        cooldown: props.cooldown,
+        ...(props.cooldown !== undefined ? { cooldown: props.cooldown } : {}),
         estimatedInstanceWarmup: props.estimatedInstanceWarmup,
         metricAggregationType: props.metricAggregationType ?? aggregationTypeFromMetric(props.metric),
         minAdjustmentMagnitude: props.minAdjustmentMagnitude,

--- a/packages/aws-cdk-lib/aws-autoscaling/test/scaling.test.ts
+++ b/packages/aws-cdk-lib/aws-autoscaling/test/scaling.test.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { Template } from '../../assertions';
+import { Annotations, Match, Template } from '../../assertions';
 import * as cloudwatch from '../../aws-cloudwatch';
 import * as ec2 from '../../aws-ec2';
 import * as elbv2 from '../../aws-elasticloadbalancingv2';
@@ -213,6 +213,43 @@ describe('scaling', () => {
     expect(() => Template.fromStack(stack).hasResourceProperties('AWS::AutoScaling::ScalingPolicy', {
       CoolDown: undefined,
     })).toThrow(/Template has 1 resources with type AWS::AutoScaling::ScalingPolicy, but none match as expected/);
+  });
+
+  test('scaleOnMetric without cooldown does not emit cooldown deprecation warning', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const fixture = new ASGFixture(stack, 'Fixture');
+
+    // WHEN - cooldown is not set
+    fixture.asg.scaleOnMetric('Metric', {
+      metric: new cloudwatch.Metric({ namespace: 'Test', metricName: 'Metric' }),
+      scalingSteps: [
+        { upper: 0, change: -1 },
+        { lower: 100, change: +1 },
+      ],
+    });
+
+    // THEN - no cooldown warning should be emitted for either the lower or upper policy
+    Annotations.fromStack(stack).hasNoWarning('*', Match.stringLikeRegexp('@aws-cdk/aws-autoscaling:cooldownOnStepScaling'));
+  });
+
+  test('scaleOnMetric with cooldown emits cooldown deprecation warning', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const fixture = new ASGFixture(stack, 'Fixture');
+
+    // WHEN - cooldown is explicitly set (deprecated on StepScaling)
+    fixture.asg.scaleOnMetric('Metric', {
+      metric: new cloudwatch.Metric({ namespace: 'Test', metricName: 'Metric' }),
+      scalingSteps: [
+        { upper: 0, change: -1 },
+        { lower: 100, change: +1 },
+      ],
+      cooldown: cdk.Duration.seconds(60),
+    });
+
+    // THEN - the deprecation warning fires because cooldown is explicitly set
+    Annotations.fromStack(stack).hasWarning('*', Match.stringLikeRegexp('@aws-cdk/aws-autoscaling:cooldownOnStepScaling'));
   });
 
   test('step scaling', () => {


### PR DESCRIPTION
### Issue #37833

Fixes #37833

### Reason for this change

Every `StepScalingPolicy` (and every call to `AutoScalingGroup.scaleOnMetric`) prints two JSII deprecation warnings for `StepScalingActionProps#cooldown` during synthesis, even when the user never set that property. In a stack with many step-scaled groups, this floods build output and buries legitimate deprecation signals.

The root cause: `StepScalingPolicy` unconditionally writes `cooldown: props.cooldown` into the props passed to `StepScalingAction`, so the key is always present even when the value is `undefined`. JSII's generated deprecation checker uses a key-existence test (`'cooldown' in p`) rather than a value test, so the warning fires whenever the key appears, regardless of its value.

### Description of changes

In `packages/aws-cdk-lib/aws-autoscaling/lib/step-scaling-policy.ts`, replaced `cooldown: props.cooldown` with a conditional spread in both the `lowerAction` and `upperAction` constructor calls:

```ts
...(props.cooldown !== undefined ? { cooldown: props.cooldown } : {})
```

When `cooldown` is not set, the key is absent from the props object. The JSII key-existence check returns false and no warning fires. When the user explicitly passes `cooldown`, it is still forwarded and the deprecation warning fires correctly.

No CloudFormation output changes. `StepScalingAction` already discards the `cooldown` value and does not pass it to `CfnScalingPolicy`.

### Description of how you validated changes

Added two tests to `packages/aws-cdk-lib/aws-autoscaling/test/scaling.test.ts`:

1. `scaleOnMetric without cooldown does not emit cooldown deprecation warning` — verifies no `@aws-cdk/aws-autoscaling:cooldownOnStepScaling` CDK annotation is added to the stack.
2. `scaleOnMetric with cooldown emits cooldown deprecation warning` — verifies the annotation is present when `cooldown` is explicitly set, confirming the intentional deprecation path is preserved.

One caveat: JSII's key-existence check (`'cooldown' in p`) only runs in compiled output, not in the ts-jest environment. The tests above cover the related CDK annotation behavior (`StepScalingAction`'s `if (props.cooldown)` guard). The fix can be verified end-to-end by running `cdk synth` on the reproduction case in the issue and confirming the warnings no longer appear.

All 20 tests in `scaling.test.ts` pass.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*