### PR TITLE
fix(logs): emit account root ARN in resource policy to prevent CloudFormation drift

### DIFF
--- a/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
@@ -290,8 +290,10 @@ abstract class LogGroupBase extends Resource implements ILogGroup {
    * Adds a statement to the resource policy associated with this log group.
    * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
    *
-   * Any ARN Principals inside of the statement will be converted into AWS Account ID strings
-   * because CloudWatch Logs Resource Policies do not accept ARN principals.
+   * Any ARN Principals inside of the statement will be converted into account root ARN format
+   * (`arn:{partition}:iam::{accountId}:root`) because CloudWatch Logs Resource Policies do not
+   * accept specific ARN principals. Using the root ARN format avoids CloudFormation drift
+   * detection false positives caused by CloudFormation normalizing bare account IDs server-side.
    *
    * @param statement The policy statement to add
    */
@@ -307,16 +309,13 @@ abstract class LogGroupBase extends Resource implements ILogGroup {
 
   private convertArnPrincipalToAccountId(principal: iam.IPrincipal) {
     if (principal.principalAccount) {
-      // we use ArnPrincipal here because the constructor inserts the argument
-      // into the template without mutating it, which means that there is no
-      // ARN created by this call.
-      return new iam.ArnPrincipal(principal.principalAccount);
+      return new iam.AccountPrincipal(principal.principalAccount);
     }
 
     if (principal instanceof iam.ArnPrincipal && principal.arn !== '*') {
       const parsedArn = Arn.split(principal.arn, ArnFormat.SLASH_RESOURCE_NAME);
       if (parsedArn.account) {
-        return new iam.ArnPrincipal(parsedArn.account);
+        return new iam.AccountPrincipal(parsedArn.account);
       }
     }
 

--- a/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
+++ b/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
@@ -471,7 +471,7 @@ describe('log group', () => {
     });
   });
 
-  test('when added to log groups, IAM users are converted into account IDs in the resource policy', () => {
+  test('when added to log groups, IAM principals are converted into account root ARN format in the resource policy', () => {
     // GIVEN
     const stack = new Stack();
     const lg = new LogGroup(stack, 'LogGroup');
@@ -483,11 +483,41 @@ describe('log group', () => {
       principals: [new iam.ArnPrincipal('arn:aws:iam::123456789012:user/user-name')],
     }));
 
-    // THEN
+    // THEN — principal emits the canonical root ARN so CloudFormation drift detection
+    // sees no difference between the template and the deployed resource.
     Template.fromStack(stack).hasResourceProperties('AWS::Logs::ResourcePolicy', {
-      PolicyDocument: '{"Statement":[{"Action":"logs:PutLogEvents","Effect":"Allow","Principal":{"AWS":"123456789012"},"Resource":"*"}],"Version":"2012-10-17"}',
+      PolicyDocument: {
+        'Fn::Join': [
+          '',
+          [
+            '{\"Statement\":[{\"Action\":\"logs:PutLogEvents\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:',
+            { Ref: 'AWS::Partition' },
+            ':iam::123456789012:root\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}',
+          ],
+        ],
+      },
       PolicyName: 'LogGroupPolicy643B329C',
     });
+  });
+
+  test('cross-account grantRead emits root ARN principal, not bare account ID, to prevent CloudFormation drift', () => {
+    // Regression test for https://github.com/aws/aws-cdk/issues/37797.
+    // CloudFormation normalizes "123456789012" to "arn:aws:iam::123456789012:root" after
+    // deployment; emitting the bare account ID causes persistent drift false positives.
+    const stack = new Stack();
+    const lg = new LogGroup(stack, 'LogGroup');
+    const crossAccountRole = iam.Role.fromRoleArn(stack, 'CrossAccountRole', 'arn:aws:iam::999888777666:role/Reader');
+
+    lg.grantRead(crossAccountRole);
+
+    // The PolicyDocument serializes as a Fn::Join when the principal contains tokens.
+    // Stringify the whole resource policy to check the principal format.
+    const resources = Template.fromStack(stack).findResources('AWS::Logs::ResourcePolicy');
+    const policyDocJson = JSON.stringify(Object.values(resources)[0].Properties.PolicyDocument);
+
+    // Must emit root ARN format, not bare account ID, to match what CloudFormation stores.
+    expect(policyDocJson).toContain(':iam::999888777666:root');
+    expect(policyDocJson).not.toContain('"999888777666"');
   });
 
   test('log groups accept the AnyPrincipal policy', () => {
@@ -516,7 +546,7 @@ describe('log group', () => {
     });
   });
 
-  test('imported values are treated as if they are ARNs and converted to account IDs via CFN pseudo parameters', () => {
+  test('imported values are treated as if they are ARNs and converted to account root ARN format via CFN pseudo parameters', () => {
     // GIVEN
     const stack = new Stack();
     const lg = new LogGroup(stack, 'LogGroup');
@@ -528,20 +558,23 @@ describe('log group', () => {
       principals: [iam.Role.fromRoleArn(stack, 'Role', Fn.importValue('SomeRole'))],
     }));
 
-    // THEN
+    // THEN — principal emits canonical root ARN using CFN intrinsics so drift detection
+    // sees no difference between the template and the deployed resource.
     Template.fromStack(stack).hasResourceProperties('AWS::Logs::ResourcePolicy', {
       PolicyDocument: {
         'Fn::Join': [
           '',
           [
-            '{\"Statement\":[{\"Action\":\"logs:PutLogEvents\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"',
+            '{\"Statement\":[{\"Action\":\"logs:PutLogEvents\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:',
+            { Ref: 'AWS::Partition' },
+            ':iam::',
             {
               'Fn::Select': [
                 4,
                 { 'Fn::Split': [':', { 'Fn::ImportValue': 'SomeRole' }] },
               ],
             },
-            '\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}',
+            ':root\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}',
           ],
         ],
       },


### PR DESCRIPTION
Closes #37797.

### Reason for this change

`grantRead()` and `addToResourcePolicy()` convert ARN principals to account-level principals before writing them into the `LogGroup` resource policy. CloudWatch Logs resource policies don't accept specific IAM ARNs, only account-level ones. The conversion was building `new iam.ArnPrincipal(accountId)` with the bare account ID string.

CloudFormation accepts this format at deploy time but normalizes it to `arn:aws:iam::ACCOUNT:root` server-side. Every subsequent drift check then sees a literal mismatch between the template and the deployed resource, even though nothing changed. For any stack with a cross-account `grantRead()`, drift detection was permanently noisy.

### Description of changes

`AccountPrincipal` already produces the canonical form CloudFormation stores. Replacing `new iam.ArnPrincipal(accountId)` with `new iam.AccountPrincipal(accountId)` in both branches of `convertArnPrincipalToAccountId()` is the complete fix. The solution was already in the codebase, just not wired up in this path.

Token account IDs work correctly too. When the account comes from an imported role ARN (via `Fn::ImportValue`), `AccountPrincipal` wraps it through `StackDependentToken`, and CDK's join-fusion optimization produces the right `Fn::Join` at synthesis time.

### Description of how you validated changes

Updated the existing principal-conversion test to assert the root ARN format (`Fn::Join` with `{Ref: AWS::Partition}`) instead of a bare account ID string. Added a regression test that calls `grantRead()` with an imported cross-account role and confirms the emitted policy contains `:iam::ACCOUNT:root`, not the bare account number. All 39 `aws-logs` unit tests pass.

This fix is purely in `convertArnPrincipalToAccountId()`, with no new CloudFormation resource types and no new CFN properties, so I'll request an integ test exemption via comment after the linter runs.

### Why this does not use a feature flag

CONTRIBUTING names two conditions that make a template change unsafe to apply automatically: resource replacement leading to service disruption, or breaking assumptions users have taken on the old setup. Neither one applies here.

**No replacement.** Looking `AWS::Logs::ResourcePolicy` up in `@aws-cdk/aws-service-spec`: `primaryIdentifier` is `["PolicyName"]`, `PolicyName` carries `causesReplacement: yes`, and `PolicyDocument` has no `causesReplacement` set, so updates to it apply in place. This change rewrites `PolicyDocument` and leaves `PolicyName` untouched, which the unchanged `PolicyName: 'LogGroupPolicy643B329C'` assertion in the existing test still covers.

**No assumption to break.** The deployed policy already holds the root ARN. That is the observation in #37797: across several production stacks the reporters see `{"AWS": "arn:aws:iam::ACCOUNT:root"}` on the deployed resource while their template says `{"AWS": "ACCOUNT"}`, and that gap is what makes drift fire on every evaluation cycle. So the template is moving to the value the live resource already stores. Anyone who reads the deployed resource policy today sees the root ARN and sees the same string after this lands.

A flag would also cut against the people who reported the bug. BugFix flags default to off for existing apps, and existing apps are the drifting population in #37797. Shipping behind a default-off flag means every team currently filing false-positive drift tickets keeps filing them until someone finds the flag and sets it. `features.ts` also notes that a BugFix flag "will never be removed", so the off branch, the one CloudFormation rewrites on every deploy anyway, would stay in the codebase for good.

That is the reasoning rather than a verdict. If you would rather have the opt-in regardless, say so and I will add the flag.

### Upgrade diff

Any stack that reaches `addToResourcePolicy` with a principal carrying a resolvable account sees one `PolicyDocument` change in `cdk diff`. That covers `grantRead()` and direct `addToResourcePolicy(ArnPrincipal)`, both same-account and cross-account:

```diff
- "Principal": { "AWS": "123456789012" }
+ "Principal": { "AWS": { "Fn::Join": ["", ["arn:", { "Ref": "AWS::Partition" }, ":iam::123456789012:root"]] } }
```

The first deploy after upgrading is a one-time in-place update that writes back the value already stored. Granted permissions do not change, since a bare account ID is shorthand for the account root, which is the same string `AccountPrincipal` builds. Drift stops reporting once that deploy completes. Rendering through `Ref: AWS::Partition` instead of a hardcoded `aws` keeps the principal correct in the China and GovCloud partitions.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
