### PR TITLE
fix(dynamodb): `TableV2MultiAccountReplica` omits top-level SSESpecification for KMS encryption

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -1521,6 +1521,7 @@ export class TableV2MultiAccountReplica extends TableBaseV2 {
         globalTableSettingsReplicationMode: props.globalTableSettingsReplicationMode,
       }],
       globalTableSourceArn: props.replicaSourceTable.tableArn,
+      sseSpecification: props.encryption?._renderSseSpecification(),
     });
     resource.applyRemovalPolicy(props.removalPolicy);
 

--- a/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
@@ -4244,7 +4244,16 @@ test('TableV2MultiAccountReplica with custom encryption', () => {
     encryption: TableEncryptionV2.customerManagedKey(key),
   });
 
-  Template.fromStack(replicaStack).hasResourceProperties('AWS::DynamoDB::GlobalTable', {
+  const template = Template.fromStack(replicaStack);
+
+  // Top-level SSESpecification must be present so DynamoDB does not treat the table
+  // as unencrypted and reject the replica-level KMSMasterKeyId with
+  // "ReplicaSSESpecification and SSEType must be null when SSE is set to default".
+  template.hasResourceProperties('AWS::DynamoDB::GlobalTable', {
+    SSESpecification: { SSEEnabled: true, SSEType: 'KMS' },
+  });
+
+  template.hasResourceProperties('AWS::DynamoDB::GlobalTable', {
     Replicas: [
       Match.objectLike({
         SSESpecification: {
@@ -4254,6 +4263,25 @@ test('TableV2MultiAccountReplica with custom encryption', () => {
         },
       }),
     ],
+  });
+});
+
+test('TableV2MultiAccountReplica with AWS managed key sets top-level SSESpecification', () => {
+  const app = new App();
+  const sourceStack = new Stack(app, 'SourceStack', { env: { account: '111111111111', region: 'us-east-2' } });
+  const replicaStack = new Stack(app, 'ReplicaStack', { env: { account: '222222222222', region: 'us-east-1' } });
+
+  const sourceTable = new TableV2(sourceStack, 'SourceTable', {
+    partitionKey: { name: 'pk', type: AttributeType.STRING },
+  });
+
+  new TableV2MultiAccountReplica(replicaStack, 'ReplicaTable', {
+    replicaSourceTable: sourceTable,
+    encryption: TableEncryptionV2.awsManagedKey(),
+  });
+
+  Template.fromStack(replicaStack).hasResourceProperties('AWS::DynamoDB::GlobalTable', {
+    SSESpecification: { SSEEnabled: true, SSEType: 'KMS' },
   });
 });
 


### PR DESCRIPTION
Fixes #37783

## Problem

`TableV2MultiAccountReplica` creates a `CfnGlobalTable` without a top-level `SSESpecification` when KMS encryption is configured. DynamoDB rejects the replica-level `KMSMasterKeyId` at deploy time with:

> ReplicaSSESpecification and SSEType must be null when SSE is set to default

The per-replica `SSESpecification` (which carries the `KMSMasterKeyId`) is present, but DynamoDB requires the top-level `SSESpecification` before accepting any per-replica KMS key.

## Fix

Add `sseSpecification: props.encryption?._renderSseSpecification()` to the `CfnGlobalTable` constructor in `TableV2MultiAccountReplica`. `TableV2` already makes this same call at line 866. `TableV2MultiAccountReplica` simply missed it.

When `encryption` is `undefined` (the DynamoDB-owned key default), the optional chain resolves to `undefined` and CDK omits the property from the template, so there is no behavior change for users without encryption configured.

## Tests

- Updated the existing `TableV2MultiAccountReplica with custom encryption` test to assert `SSESpecification: { SSEEnabled: true, SSEType: 'KMS' }` at the top level. This assertion fails on unpatched code.
- Added `TableV2MultiAccountReplica with AWS managed key sets top-level SSESpecification` to cover the `awsManagedKey()` path.

Type-checked: `tsc --noEmit` on `packages/aws-cdk-lib` reports zero errors in `aws-dynamodb`.