### PR TITLE
fix(dynamodb): set top-level SSESpecification for TableV2MultiAccountReplica

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -1506,6 +1506,7 @@ export class TableV2MultiAccountReplica extends TableBaseV2 {
 
     const resource = new CfnGlobalTable(this, 'Resource', {
       tableName: props.replicaSourceTable.tableName,
+      sseSpecification: props.encryption?._renderSseSpecification(),
       replicas: [{
         region: this.stack.region,
         deletionProtectionEnabled: props.deletionProtection,

--- a/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
@@ -4245,6 +4245,10 @@ test('TableV2MultiAccountReplica with custom encryption', () => {
   });
 
   Template.fromStack(replicaStack).hasResourceProperties('AWS::DynamoDB::GlobalTable', {
+    SSESpecification: {
+      SSEEnabled: true,
+      SSEType: 'KMS',
+    },
     Replicas: [
       Match.objectLike({
         SSESpecification: {


### PR DESCRIPTION
## Summary\n- set the top-level SSESpecification on TableV2MultiAccountReplica when customer-managed encryption is configured\n- extend the existing regression test to assert the synthesized AWS::DynamoDB::GlobalTable includes the top-level KMS SSE settings\n\nCloses #37783\n\n## Testing\n- attempted to run the targeted TableV2MultiAccountReplica with custom encryption test locally\n- local execution in this Windows environment was blocked by unrelated generated-asset prerequisites in the monorepo before the test body could run\n