### PR TITLE
fix(python-alpha): python function build args not being respected

### DIFF
--- a/packages/@aws-cdk/aws-lambda-python-alpha/lib/Dockerfile
+++ b/packages/@aws-cdk/aws-lambda-python-alpha/lib/Dockerfile
@@ -24,6 +24,9 @@ ENV POETRY_CACHE_DIR=/tmp/poetry-cache
 ENV UV_CACHE_DIR=/tmp/uv-cache
 
 RUN \
+    export PIP_INDEX_URL=${PIP_INDEX_URL} && \
+    export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL} && \
+    export HTTPS_PROXY=${HTTPS_PROXY} && \
 # create a new virtualenv for python to use
 # so that it isn't using root
     python -m venv /usr/app/venv && \
@@ -46,7 +49,7 @@ RUN \
 # Ensure no temporary files remain in the caches
     rm -rf /tmp/pip-cache/* /tmp/poetry-cache/* /tmp/uv-cache/*
 
-# Setting a non-root user to run default command, 
+# Setting a non-root user to run default command,
 # This will be overridden later when the Docker container is running, using either the local OS user or props.user.
 USER nobody
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #26920

### Reason for this change

Current the build args that exist for `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL` and `HTTPS_PROXY` are passed as build args, but the args are never exported to the environment or used directly for all the pip install commands when building the image.  In environments where pypi may be locked down it will not work. Similarly, users are expecting all pip related installs to follow what they pass for args to be used in all steps of the build and the [docs](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html) point to this exact use case with PIP_INDEX_URL as an example of what build args is used for 
<img width="885" height="314" alt="image" src="https://github.com/user-attachments/assets/7c01b9d4-58c3-4e39-b470-0f9543192251" />


### Description of changes

export the args so the pip install actually leverage the passed in values.

### Describe any new or updated permissions being added

N/a


### Description of how you validated changes

Manual validation using a work project. Could not think of way to have this correctly checked for in the absence of a private mirror that the current test cases are not trying.

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
