### PR TITLE
fix(ecs): support digest references in TagParameterContainerImage via imageDigest option

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/images/tag-parameter-container-image.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/images/tag-parameter-container-image.ts
@@ -55,7 +55,7 @@ export class TagParameterContainerImage extends ContainerImage {
   }
 
   /**
-   * Returns the name of the CloudFormation Parameter that represents the tag of the image
+   * Returns the name of the CloudFormation Parameter that represents the tag or digest of the image
    * in the ECR repository.
    */
   public get tagParameterName(): string {
@@ -71,7 +71,7 @@ export class TagParameterContainerImage extends ContainerImage {
   }
 
   /**
-   * Returns the value of the CloudFormation Parameter that represents the tag of the image
+   * Returns the value of the CloudFormation Parameter that represents the tag or digest of the image
    * in the ECR repository.
    */
   public get tagParameterValue(): string {

--- a/packages/aws-cdk-lib/aws-ecs/lib/images/tag-parameter-container-image.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/images/tag-parameter-container-image.ts
@@ -7,9 +7,26 @@ import type { ContainerImageConfig } from '../container-image';
 import { ContainerImage } from '../container-image';
 
 /**
+ * Properties for `TagParameterContainerImage`.
+ */
+export interface TagParameterContainerImageProps {
+  /**
+   * Whether the CloudFormation Parameter holds an image digest (`sha256:...`) rather than a tag.
+   *
+   * When `true`, the separator between the repository URI and the parameter value is `@`
+   * instead of `:`, producing `ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPO@sha256:...`.
+   *
+   * Use this when your pipeline passes a digest rather than a mutable tag.
+   *
+   * @default false
+   */
+  readonly imageDigest?: boolean;
+}
+
+/**
  * A special type of `ContainerImage` that uses an ECR repository for the image,
- * but a CloudFormation Parameter for the tag of the image in that repository.
- * This allows providing this tag through the Parameter at deploy time,
+ * but a CloudFormation Parameter for the tag or digest of the image in that repository.
+ * This allows providing this tag or digest through the Parameter at deploy time,
  * for example in a CodePipeline that pushes a new tag of the image to the repository during a build step,
  * and then provides that new tag through the CloudFormation Parameter in the deploy step.
  *
@@ -17,11 +34,13 @@ import { ContainerImage } from '../container-image';
  */
 export class TagParameterContainerImage extends ContainerImage {
   private readonly repository: ecr.IRepository;
+  private readonly imageDigest: boolean;
   private imageTagParameter?: cdk.CfnParameter;
 
-  public constructor(repository: ecr.IRepository) {
+  public constructor(repository: ecr.IRepository, props: TagParameterContainerImageProps = {}) {
     super();
     this.repository = repository;
+    this.imageDigest = props.imageDigest ?? false;
   }
 
   public bind(scope: Construct, containerDefinition: ContainerDefinition): ContainerImageConfig {
@@ -29,7 +48,9 @@ export class TagParameterContainerImage extends ContainerImage {
     const imageTagParameter = new cdk.CfnParameter(scope, 'ImageTagParam');
     this.imageTagParameter = imageTagParameter;
     return {
-      imageName: this.repository.repositoryUriForTag(imageTagParameter.valueAsString),
+      imageName: this.imageDigest
+        ? this.repository.repositoryUriForDigest(imageTagParameter.valueAsString)
+        : this.repository.repositoryUriForTag(imageTagParameter.valueAsString),
     };
   }
 

--- a/packages/aws-cdk-lib/aws-ecs/test/images/tag-parameter-container-image.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/images/tag-parameter-container-image.test.ts
@@ -33,6 +33,68 @@ describe('tag parameter container image', () => {
       }).toThrow(/TagParameterContainerImage must be used in a container definition when using tagParameterValue/);
     });
 
+    test('synthesizes image URI with ":" separator for tag (default)', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const repository = new ecr.Repository(stack, 'Repository');
+      const tagParameterContainerImage = new ecs.TagParameterContainerImage(repository);
+      const taskDefinition = new ecs.FargateTaskDefinition(stack, 'TaskDef');
+
+      // WHEN
+      taskDefinition.addContainer('Container', { image: tagParameterContainerImage });
+
+      // THEN — Image URI must use ":" between repo URI and tag parameter
+      Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: {
+              'Fn::Join': ['', Match.arrayWith([':'])],
+            },
+          }),
+        ]),
+      });
+      Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: Match.not({
+              'Fn::Join': ['', Match.arrayWith(['@'])],
+            }),
+          }),
+        ]),
+      });
+    });
+
+    test('synthesizes image URI with "@" separator when imageDigest is true', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const repository = new ecr.Repository(stack, 'Repository');
+      const tagParameterContainerImage = new ecs.TagParameterContainerImage(repository, { imageDigest: true });
+      const taskDefinition = new ecs.FargateTaskDefinition(stack, 'TaskDef');
+
+      // WHEN
+      taskDefinition.addContainer('Container', { image: tagParameterContainerImage });
+
+      // THEN — Image URI must use "@" between repo URI and digest parameter
+      Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: {
+              'Fn::Join': ['', Match.arrayWith(['@'])],
+            },
+          }),
+        ]),
+      });
+      Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: Match.not({
+              'Fn::Join': ['', Match.arrayWith([':'])],
+            }),
+          }),
+        ]),
+      });
+    });
+
     test('can be used in a cross-account manner', () => {
       // GIVEN
       const app = new cdk.App();


### PR DESCRIPTION
Closes #37718.

Credit to @nguyengg for filing this with a clear diagnosis, and to @pahud for the key insight that `repositoryUriForTagOrDigest()` can't be used here because `CfnParameter.valueAsString` is an unresolved CloudFormation token at synth time — the `startsWith('sha256:')` check always fails.

### Reason for this change

`TagParameterContainerImage.bind()` always calls `repositoryUriForTag()`, which produces a colon separator between the repository URI and the parameter value. When the parameter holds a digest (`sha256:...`), the correct separator is `@`. The naive fix of switching to `repositoryUriForTagOrDigest()` doesn't work because that method resolves the tag/digest at synth time using `startsWith('sha256:')`, but `CfnParameter.valueAsString` is an unresolved token — so it always falls through to the tag path.

### Description of changes

Adds an optional `imageDigest?: boolean` prop to `TagParameterContainerImage` (default: `false`, fully backward-compatible). When `true`, `bind()` calls `repositoryUriForDigest()` instead of `repositoryUriForTag()`, producing the correct `@` separator in the synthesized CloudFormation template. Also updates the JSDoc for `tagParameterName` and `tagParameterValue` to reflect that the parameter may hold a digest as well as a tag.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Two new unit tests in `tag-parameter-container-image.test.ts`:
- Default (`imageDigest: false` / omitted): asserts the synthesized `Image` property uses `:` separator
- `imageDigest: true`: asserts the synthesized `Image` property uses `@` separator

All existing tests continue to pass.

### Checklist

- [x] My code adheres to the CONTRIBUTING guide
- [x] I have tested this locally where applicable
- [x] This PR fixes a bug (non-breaking change that fixes an issue)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license