### PR TITLE
fix(stepfunctions): `Choice.afterwards()` excludes the otherwise branch from end states by default

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/states/choice.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/states/choice.ts
@@ -83,7 +83,10 @@ export class Choice extends State {
    * Use this to combine all possible choice paths back.
    */
   public afterwards(options: AfterwardsOptions = {}): Chain {
-    const endStates = State.filterNextables(State.findReachableEndStates(this, { includeErrorHandlers: options.includeErrorHandlers }));
+    const endStates = State.filterNextables(State.findReachableEndStates(this, {
+      includeErrorHandlers: options.includeErrorHandlers,
+      includeDefaultChoiceTransitions: options.includeOtherwise ?? false,
+    }));
     if (options.includeOtherwise && this.defaultChoice) {
       throw new UnscopedValidationError(lit`ChoiceStateAlreadyHasOtherwise`, `'includeOtherwise' set but Choice state ${this.stateId} already has an 'otherwise' transition`);
     }

--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/states/state.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/states/state.ts
@@ -632,7 +632,7 @@ export abstract class State extends Construct implements IChainable {
   private outgoingTransitions(options: FindStateOptions): State[] {
     const ret = new Array<State>();
     if (this._next) { ret.push(this._next); }
-    if (this.defaultChoice) { ret.push(this.defaultChoice); }
+    if (this.defaultChoice && options.includeDefaultChoiceTransitions !== false) { ret.push(this.defaultChoice); }
     for (const c of this.choices) {
       ret.push(c.next);
     }
@@ -655,6 +655,18 @@ export interface FindStateOptions {
    * @default false
    */
   readonly includeErrorHandlers?: boolean;
+
+  /**
+   * Whether or not to follow the default/otherwise transition of a Choice state
+   *
+   * When false, the default (otherwise) branch is excluded from the traversal.
+   * `Choice.afterwards()` passes this as false (matching the `includeOtherwise` option)
+   * so that the otherwise state is not treated as a reachable end state unless
+   * the caller explicitly requested it.
+   *
+   * @default true
+   */
+  readonly includeDefaultChoiceTransitions?: boolean;
 }
 
 /**

--- a/packages/aws-cdk-lib/aws-stepfunctions/test/states-language.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/test/states-language.test.ts
@@ -310,6 +310,47 @@ describe('States Language', () => {
     });
   }),
 
+  test('afterwards() excludes the otherwise state from end states by default (poll-loop pattern)', () => {
+    // GIVEN — a polling loop where the otherwise branch loops back through already-chained states
+    const stack = new cdk.Stack();
+
+    const waitToRepeat = new stepfunctions.Wait(stack, 'WaitToRepeat', {
+      time: stepfunctions.WaitTime.duration(cdk.Duration.seconds(60)),
+    });
+    const checkStatus = new stepfunctions.Pass(stack, 'CheckStatus');
+    const isComplete = new stepfunctions.Choice(stack, 'IsComplete')
+      .when(stepfunctions.Condition.stringEquals('$.status', 'FAILED'), new stepfunctions.Fail(stack, 'Failed'))
+      .when(stepfunctions.Condition.stringEquals('$.status', 'COMPLETED'), new stepfunctions.Pass(stack, 'Completed'))
+      .otherwise(waitToRepeat);
+
+    // WHEN — chaining a next step after the choice; previously threw "StateAlreadyHasNextState"
+    // because afterwards() included waitToRepeat in end states, which already had checkStatus as next
+    waitToRepeat
+      .next(checkStatus)
+      .next(isComplete.afterwards())
+      .next(new stepfunctions.Pass(stack, 'DoOtherThing'));
+
+    // THEN — DoOtherThing is reachable only from Completed, not via the otherwise loop
+    expect(render(waitToRepeat)).toStrictEqual({
+      StartAt: 'WaitToRepeat',
+      States: {
+        WaitToRepeat: { Type: 'Wait', Seconds: 60, Next: 'CheckStatus' },
+        CheckStatus: { Type: 'Pass', Next: 'IsComplete' },
+        IsComplete: {
+          Type: 'Choice',
+          Choices: [
+            { Variable: '$.status', StringEquals: 'FAILED', Next: 'Failed' },
+            { Variable: '$.status', StringEquals: 'COMPLETED', Next: 'Completed' },
+          ],
+          Default: 'WaitToRepeat',
+        },
+        Failed: { Type: 'Fail' },
+        Completed: { Type: 'Pass', Next: 'DoOtherThing' },
+        DoOtherThing: { Type: 'Pass', End: true },
+      },
+    });
+  }),
+
   test('Can include OTHERWISE transition for Choice in afterwards()', () => {
     // GIVEN
     const stack = new cdk.Stack();


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37649.

Credit to @taesungh for the clear diagnosis and reproduction steps, to @pahud for tracing the root cause to `outgoingTransitions()` unconditionally including `defaultChoice` regardless of `includeOtherwise`, and to @vishwakt for the design analysis on the feature-flag question.

### Reason for this change

`AfterwardsOptions.includeOtherwise` is documented with `@default false`, meaning `Choice.afterwards()` should exclude the otherwise state from its returned end states by default. In practice the option was ignored. `afterwards()` called `State.findReachableEndStates()` without forwarding any flag about the default transition, and `State.outgoingTransitions()` always added `defaultChoice` to the traversal. The result: calling `afterwards().next(Y)` traversed into the otherwise branch, found states reachable from there, and called `.next(Y)` on them too. In the poll-loop pattern (where `otherwise()` points to a state already chained earlier), this threw `StateAlreadyHasNextState` instead of working correctly.

### Description of changes

- `FindStateOptions` gains `readonly includeDefaultChoiceTransitions?: boolean`. Default is `true` (i.e. `undefined !== false`), so `bindToGraph`, `findReachableStates`, and all external callers are unaffected. Only `Choice.afterwards()` passes this as `false`.
- `State.outgoingTransitions()` gates the `defaultChoice` push on `options.includeDefaultChoiceTransitions !== false`.
- `Choice.afterwards()` passes `includeDefaultChoiceTransitions: options.includeOtherwise ?? false`, excluding the otherwise branch by default and including it only when the caller explicitly opts in.

**On feature flags:** The old traversal contradicted the documented `@default false` for `includeOtherwise`. No code relying on that traversal had a documented guarantee to stand on. The AGENTS.md feature-flag criteria technically apply here (behavior change for previously-synthesizable code), so I'm happy to add a `BugFix` flag (`aws-stepfunctions:respectAfterwardsIncludeOtherwise`) if the team prefers.

**Out of scope:** The related case where `choice.afterwards({ includeOtherwise: true })` throws when `otherwise()` was already called (noted by @taesungh in the issue thread) is a separate problem and not addressed here.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

New unit test `'afterwards() excludes the otherwise state from end states by default (poll-loop pattern)'` in `states-language.test.ts`. It builds the exact poll-loop definition from the issue and asserts: (1) synth does not throw `StateAlreadyHasNextState`, and (2) the synthesized template shows `Default: 'WaitToRepeat'` still rendering correctly and `DoOtherThing` chained only through the `Completed` branch. The existing `'Can include OTHERWISE transition for Choice in afterwards()'` test still passes, confirming `includeOtherwise: true` is unaffected. All 28 stepfunctions unit tests pass.

No integration test was added: this fix touches traversal logic only, with no new CloudFormation resource types, properties, or custom resources. An exemption comment will be added if the linter flags it.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*