### PR TITLE
fix(cognito): skip domainPrefix validation when value contains embedded token markers

### DIFF
--- a/packages/aws-cdk-lib/aws-cognito/lib/user-pool-domain.ts
+++ b/packages/aws-cdk-lib/aws-cognito/lib/user-pool-domain.ts
@@ -161,7 +161,8 @@ export class UserPoolDomain extends Resource implements IUserPoolDomain {
     }
 
     if (props.cognitoDomain?.domainPrefix &&
-      !Token.isUnresolved(props.cognitoDomain?.domainPrefix) &&
+      !Token.isUnresolved(props.cognitoDomain.domainPrefix) &&
+      !props.cognitoDomain.domainPrefix.includes('${') &&
       !/^[a-z0-9-]+$/.test(props.cognitoDomain.domainPrefix)) {
       throw new ValidationError(lit`DomainPrefixCognitoDomainContain`, 'domainPrefix for cognitoDomain can contain only lowercase alphabets, numbers and hyphens', this);
     }

--- a/packages/aws-cdk-lib/aws-cognito/test/user-pool-domain.test.ts
+++ b/packages/aws-cdk-lib/aws-cognito/test/user-pool-domain.test.ts
@@ -104,6 +104,17 @@ describe('User Pool Domain', () => {
     })).not.toThrow();
   });
 
+  test('does not fail when domainPrefix is a token transformed by native string operations', () => {
+    const stack = new Stack();
+    const pool = new UserPool(stack, 'Pool');
+
+    const parameter = new CfnParameter(stack, 'Parameter');
+
+    expect(() => pool.addDomain('Domain', {
+      cognitoDomain: { domainPrefix: parameter.valueAsString.replace('_', '').toLowerCase() },
+    })).not.toThrow();
+  });
+
   testDeprecated('custom resource is added when cloudFrontDomainName property is used', () => {
     // GIVEN
     const stack = new Stack();


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37514.

Credit to @pahud, who did the full root-cause analysis here. This PR is the implementation.

### Reason for this change

If you derive `cognitoDomain.domainPrefix` from a user pool ID like this:

```ts
cognitoDomain: { domainPrefix: userPool.userPoolId.replace('_', '').toLowerCase() }
```

CDK throws a validation error at synth time even though the value is token-derived.

The problem is case sensitivity. `Token.isUnresolved()` looks for `${Token[` (capital T). After `.toLowerCase()`, that becomes `${token[` (lowercase), which CDK no longer recognizes. The regex then runs on the mangled string and throws.

### Description of changes

Added `!domainPrefix.includes('${')` as a second guard alongside `Token.isUnresolved()`. Any string containing `${` at synth time carries an embedded reference that can't be statically validated, no matter what string operations were applied to it.

Safe to add: `{` is not a valid character in Cognito domain prefixes, so a real prefix will never contain `${`.

- 1 line added in `user-pool-domain.ts`
- 1 regression test added
- Cleaned up a redundant `?.` on the same condition (the outer check already guards against `undefined`)

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added a unit test that mirrors the issue exactly:

```ts
const parameter = new CfnParameter(stack, 'Parameter');
expect(() => pool.addDomain('Domain', {
  cognitoDomain: { domainPrefix: parameter.valueAsString.replace('_', '').toLowerCase() },
})).not.toThrow();
```

Confirmed it fails on the pre-fix code and passes after. All 17 existing tests in `user-pool-domain.test.ts` continue to pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*