### PR TITLE
fix(logs): use account root ARN principals

### DIFF
--- a/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
+++ b/packages/aws-cdk-lib/aws-logs/lib/log-group.ts
@@ -290,8 +290,7 @@ abstract class LogGroupBase extends Resource implements ILogGroup {
    * Adds a statement to the resource policy associated with this log group.
    * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
    *
-   * Any ARN Principals inside of the statement will be converted into AWS Account ID strings
-   * because CloudWatch Logs Resource Policies do not accept ARN principals.
+   * Any ARN Principals inside of the statement will be converted into account root ARN principals.
    *
    * @param statement The policy statement to add
    */
@@ -300,23 +299,20 @@ abstract class LogGroupBase extends Resource implements ILogGroup {
       this.policy = new ResourcePolicy(this, 'Policy');
     }
     this.policy.document.addStatements(statement.copy({
-      principals: statement.principals.map(p => this.convertArnPrincipalToAccountId(p)),
+      principals: statement.principals.map(p => this.convertArnPrincipalToAccountRootArn(p)),
     }));
     return { statementAdded: true, policyDependable: this.policy };
   }
 
-  private convertArnPrincipalToAccountId(principal: iam.IPrincipal) {
+  private convertArnPrincipalToAccountRootArn(principal: iam.IPrincipal) {
     if (principal.principalAccount) {
-      // we use ArnPrincipal here because the constructor inserts the argument
-      // into the template without mutating it, which means that there is no
-      // ARN created by this call.
-      return new iam.ArnPrincipal(principal.principalAccount);
+      return new iam.AccountPrincipal(principal.principalAccount);
     }
 
     if (principal instanceof iam.ArnPrincipal && principal.arn !== '*') {
       const parsedArn = Arn.split(principal.arn, ArnFormat.SLASH_RESOURCE_NAME);
       if (parsedArn.account) {
-        return new iam.ArnPrincipal(parsedArn.account);
+        return new iam.AccountPrincipal(parsedArn.account);
       }
     }
 

--- a/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
+++ b/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
@@ -471,7 +471,7 @@ describe('log group', () => {
     });
   });
 
-  test('when added to log groups, IAM users are converted into account IDs in the resource policy', () => {
+  test('when added to log groups, IAM users are converted into account root ARNs in the resource policy', () => {
     // GIVEN
     const stack = new Stack();
     const lg = new LogGroup(stack, 'LogGroup');
@@ -485,7 +485,16 @@ describe('log group', () => {
 
     // THEN
     Template.fromStack(stack).hasResourceProperties('AWS::Logs::ResourcePolicy', {
-      PolicyDocument: '{"Statement":[{"Action":"logs:PutLogEvents","Effect":"Allow","Principal":{"AWS":"123456789012"},"Resource":"*"}],"Version":"2012-10-17"}',
+      PolicyDocument: {
+        'Fn::Join': [
+          '',
+          [
+            '{"Statement":[{"Action":"logs:PutLogEvents","Effect":"Allow","Principal":{"AWS":"arn:',
+            { Ref: 'AWS::Partition' },
+            ':iam::123456789012:root"},"Resource":"*"}],"Version":"2012-10-17"}',
+          ],
+        ],
+      },
       PolicyName: 'LogGroupPolicy643B329C',
     });
   });
@@ -516,7 +525,7 @@ describe('log group', () => {
     });
   });
 
-  test('imported values are treated as if they are ARNs and converted to account IDs via CFN pseudo parameters', () => {
+  test('imported values are treated as if they are ARNs and converted to account root ARNs via CFN pseudo parameters', () => {
     // GIVEN
     const stack = new Stack();
     const lg = new LogGroup(stack, 'LogGroup');
@@ -534,14 +543,16 @@ describe('log group', () => {
         'Fn::Join': [
           '',
           [
-            '{\"Statement\":[{\"Action\":\"logs:PutLogEvents\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"',
+            '{\"Statement\":[{\"Action\":\"logs:PutLogEvents\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:',
+            { Ref: 'AWS::Partition' },
+            ':iam::',
             {
               'Fn::Select': [
                 4,
                 { 'Fn::Split': [':', { 'Fn::ImportValue': 'SomeRole' }] },
               ],
             },
-            '\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}',
+            ':root\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}',
           ],
         ],
       },


### PR DESCRIPTION
### Issue

Closes #37797.

### Reason for this change

`LogGroup.addToResourcePolicy()` converted IAM ARN principals to bare AWS account IDs before synthesizing the CloudWatch Logs resource policy. CloudFormation accepts that form, but stores the principal canonically as `arn:${AWS::Partition}:iam::<account>:root`, which causes drift detection to report a persistent false positive.

### Description of changes

This changes the conversion to use `iam.AccountPrincipal`, so ARN principals are reduced to canonical account root ARN principals instead of bare account IDs. The existing log group tests now assert the synthesized policy document uses the account root ARN form, including the tokenized imported-role-ARN case.

### Description of how you validated changes

- `yarn --cwd packages/aws-cdk-lib test aws-logs/test/loggroup.test.ts --runInBand --coverage=false`
- `yarn --cwd packages/aws-cdk-lib test aws-logs/test/policy.test.ts --runInBand --coverage=false`
