### PR TITLE
feat(apigatewayv2): expose disableExecuteApiEndpoint for WebSocketApi

### DIFF
--- a/packages/aws-cdk-lib/aws-apigatewayv2/lib/websocket/api.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/lib/websocket/api.ts
@@ -118,6 +118,16 @@ export interface WebSocketApiProps {
    * @default false
    */
   readonly disableSchemaValidation?: boolean;
+
+  /**
+   * Specifies whether clients can invoke your API using the default endpoint.
+   * By default, clients can invoke your API with the default
+   * `wss://{api_id}.execute-api.{region}.amazonaws.com` endpoint. Set this to
+   * true if you would like clients to use your custom domain name.
+   *
+   * @default false execute-api endpoint enabled.
+   */
+  readonly disableExecuteApiEndpoint?: boolean;
 }
 
 /**
@@ -167,7 +177,12 @@ export class WebSocketApi extends ApiBase implements IWebSocketApi {
 
   public readonly isWebsocketApi = true;
   public readonly apiId: string;
-  public readonly apiEndpoint: string;
+  private readonly _apiEndpoint: string;
+
+  /**
+   * Specifies whether clients can invoke this WebSocket API by using the default execute-api endpoint.
+   */
+  public readonly disableExecuteApiEndpoint?: boolean;
 
   /**
    * A human friendly name for this WebSocket API. Note that this is different from `webSocketApiId`.
@@ -180,6 +195,7 @@ export class WebSocketApi extends ApiBase implements IWebSocketApi {
     addConstructMetadata(this, props);
 
     this.webSocketApiName = props?.apiName ?? id;
+    this.disableExecuteApiEndpoint = props?.disableExecuteApiEndpoint;
 
     const resource = new CfnApi(this, 'Resource', {
       name: this.webSocketApiName,
@@ -189,9 +205,10 @@ export class WebSocketApi extends ApiBase implements IWebSocketApi {
       routeSelectionExpression: props?.routeSelectionExpression ?? '$request.body.action',
       ipAddressType: props?.ipAddressType,
       disableSchemaValidation: props?.disableSchemaValidation,
+      disableExecuteApiEndpoint: this.disableExecuteApiEndpoint,
     });
     this.apiId = resource.ref;
-    this.apiEndpoint = resource.attrApiEndpoint;
+    this._apiEndpoint = resource.attrApiEndpoint;
 
     if (props?.connectRouteOptions) {
       this.addRoute('$connect', props.connectRouteOptions);
@@ -202,6 +219,16 @@ export class WebSocketApi extends ApiBase implements IWebSocketApi {
     if (props?.defaultRouteOptions) {
       this.addRoute('$default', props.defaultRouteOptions);
     }
+  }
+
+  /**
+   * Get the default endpoint for this API.
+   */
+  public get apiEndpoint(): string {
+    if (this.disableExecuteApiEndpoint) {
+      throw new ValidationError(lit`ApiEndpointAccessibleDisableExecuteWebSocket`, 'apiEndpoint is not accessible when disableExecuteApiEndpoint is set to true.', this);
+    }
+    return this._apiEndpoint;
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-apigatewayv2/test/websocket/api.test.ts
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/test/websocket/api.test.ts
@@ -151,6 +151,31 @@ describe('WebSocketApi', () => {
     expect(() => api.apiEndpoint).toThrow(/apiEndpoint is not configured/);
   });
 
+  test('disableExecuteApiEndpoint is enabled', () => {
+    const stack = new Stack();
+
+    new WebSocketApi(stack, 'api', {
+      disableExecuteApiEndpoint: true,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGatewayV2::Api', {
+      Name: 'api',
+      ProtocolType: 'WEBSOCKET',
+      DisableExecuteApiEndpoint: true,
+    });
+  });
+
+  test('throws when accessing apiEndpoint and disableExecuteApiEndpoint is true', () => {
+    const stack = new Stack();
+    const api = new WebSocketApi(stack, 'api', {
+      disableExecuteApiEndpoint: true,
+    });
+
+    expect(() => api.apiEndpoint).toThrow(
+      /apiEndpoint is not accessible when disableExecuteApiEndpoint is set to true./,
+    );
+  });
+
   test('get arnForExecuteApi', () => {
     const stack = new Stack();
     const api = new WebSocketApi(stack, 'api');


### PR DESCRIPTION
### Issue
Closes #35516.

### Reason for this change
`HttpApi` already exposes `disableExecuteApiEndpoint`, and `CfnApi` supports `DisableExecuteApiEndpoint` for API Gateway v2 APIs. `WebSocketApi` currently does not expose or pass through the property, which prevents users from disabling the default execute-api endpoint without dropping down to lower-level constructs.

### Description of changes
- Adds `disableExecuteApiEndpoint` to `WebSocketApiProps`.
- Passes the value through to the underlying `AWS::ApiGatewayV2::Api`.
- Mirrors `HttpApi` behavior by throwing when `apiEndpoint` is accessed while the default endpoint is disabled.
- Adds focused WebSocket API tests for synthesis and `apiEndpoint` access.

### Description of how you validated changes
- Attempted to run `jest test/websocket/api.test.ts --runInBand` using the existing local AWS CDK toolchain. The test runner could not start in the fresh worktree because generated `core/dist` artifacts were missing (`../dist/core/cfn-utils-provider.generated`).
- Verified the implementation against the existing `HttpApi` pattern and checked the synthesized property expectations in the focused test changes.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
- [x] My change is relevant to the issue above
- [x] I tried to run relevant tests and documented the local environment blocker
