### PR TITLE
fix(events): serialize EventBusPolicy statements

### DIFF
--- a/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
@@ -649,7 +649,7 @@ export class EventBusPolicy extends Resource {
 
     new CfnEventBusPolicy(this, 'Resource', {
       statementId: props.statementId!,
-      statement: props.statement,
+      statement: props.statement.toJSON(),
       eventBusName: props.eventBus.eventBusName,
     });
   }

--- a/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
@@ -4,7 +4,7 @@ import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
 import * as sqs from '../../aws-sqs';
 import { Aws, CfnResource, Stack, Arn, App, PhysicalName, CfnOutput } from '../../core';
-import { EventBus, IncludeDetail, Level } from '../lib';
+import { EventBus, EventBusPolicy, IncludeDetail, Level } from '../lib';
 
 describe('event bus', () => {
   test('default event bus', () => {
@@ -626,6 +626,48 @@ describe('event bus', () => {
             'BusEA82B648',
             'Arn',
           ],
+        },
+      },
+    });
+  });
+
+  test('EventBusPolicy serializes PolicyStatement props', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const bus = new EventBus(stack, 'Bus');
+
+    // WHEN
+    new EventBusPolicy(stack, 'Policy', {
+      eventBus: bus,
+      statementId: 'MyStatement',
+      statement: new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.AccountPrincipal('111111111111')],
+        actions: ['events:PutEvents'],
+        resources: [bus.eventBusArn],
+      }),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBusPolicy', {
+      StatementId: 'MyStatement',
+      Statement: {
+        Action: 'events:PutEvents',
+        Effect: 'Allow',
+        Principal: {
+          AWS: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::111111111111:root',
+              ],
+            ],
+          },
         },
       },
     });


### PR DESCRIPTION
### Issue
Closes #24031.

### Reason for this change
`EventBusPolicyProps.statement` is typed as `iam.PolicyStatement`, but `EventBusPolicy` passed the `PolicyStatement` instance directly into the underlying `CfnEventBusPolicy`. When that statement includes principals, CloudFormation synthesis can walk the `grantPrincipal` object graph and fail with a circular reference.

`EventBus.addToResourcePolicy()` already avoids this by passing `statement.toJSON()` into `EventBusPolicy`. Direct `EventBusPolicy` usage should do the same thing.

### Description of changes
- Serializes `EventBusPolicyProps.statement` with `toJSON()` before passing it to `CfnEventBusPolicy`.
- Adds a regression test covering direct `EventBusPolicy` usage with an `AccountPrincipal`.

### Description of how you validated changes
- `git diff --check` passes.
- Attempted to run `jest aws-events/test/event-bus.test.ts --runInBand` using the existing local AWS CDK toolchain. The test runner could not start in the fresh worktree because generated `core/dist` artifacts were missing (`../dist/core/cfn-utils-provider.generated`).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
- [x] My change is relevant to the issue above
- [x] I added a regression test
- [x] I tried to run relevant tests and documented the local environment blocker
