### PR TITLE
docs(ec2): clarify default network ACL rule 100

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -1463,6 +1463,13 @@ export class Vpc extends VpcBase {
   public readonly vpcCidrBlock: string;
 
   /**
+   * The ID of the default network ACL created by AWS for this VPC.
+   *
+   * The default network ACL contains AWS-managed entries, including rule 100
+   * that allows all IPv4 ingress and egress traffic. CloudFormation cannot
+   * remove or replace those default entries. To use a deny-by-default network
+   * ACL, create a `NetworkAcl` and associate it with selected subnets instead.
+   *
    * @attribute
    */
   public readonly vpcDefaultNetworkAcl: string;
@@ -2277,6 +2284,9 @@ export class Subnet extends Resource implements ISubnet {
    *
    * Upon creation, this is the default ACL which allows all traffic, except
    * explicit DENY entries that you add.
+   *
+   * The AWS-managed default network ACL includes rule 100, which allows all
+   * IPv4 ingress and egress traffic. CloudFormation cannot delete this rule.
    *
    * You can replace it with a custom ACL which denies all traffic except
    * the explicit ALLOW entries that you add by creating a `NetworkAcl`


### PR DESCRIPTION
### Issue
Closes #13220.

### Reason for this change
AWS creates a default network ACL for every VPC and includes AWS-managed allow-all rule 100 entries. CDK exposes the default ACL ID but CloudFormation cannot remove or replace those default entries, so users need a custom NetworkAcl associated with selected subnets when they want deny-by-default behavior.

### Description of changes
- Documents the AWS-managed default network ACL behavior on `Vpc.vpcDefaultNetworkAcl`.
- Clarifies on `Subnet.networkAcl` that the default ACL includes rule 100 and CloudFormation cannot delete it.
- Points users to custom `NetworkAcl` association as the workaround.

### Validation
- `git diff --check`
- No runtime tests run; documentation-only change.