### PR TITLE
feat(core): add Token.asStringList(), Token.asAnyList(), and Lazy.anyList()

### DIFF
--- a/packages/aws-cdk-lib/core/lib/lazy.ts
+++ b/packages/aws-cdk-lib/core/lib/lazy.ts
@@ -280,6 +280,35 @@ export class Lazy {
   }
 
   /**
+   * Defer the one-time calculation of a list of arbitrary values to synthesis time
+   *
+   * Use this if you want to render a list to a template whose actual value depends on
+   * some state mutation that may happen after the construct has been created.
+   *
+   * The inner function will only be invoked once, and the resolved value
+   * cannot depend on the Stack the Token is used in.
+   */
+  public static anyList(producer: IStableAnyProducer, options: LazyListValueOptions = {}): any[] {
+    return Token.asAnyList(new LazyAnyList(producer, true, options), options);
+  }
+
+  /**
+   * Defer the calculation of a list of arbitrary values to synthesis time
+   *
+   * Use of this function is not recommended; unless you know you need it for sure, you
+   * probably don't. Use `Lazy.anyList()` instead.
+   *
+   * The inner function may be invoked multiple times during synthesis. You
+   * should only use this method if the returned value depends on variables
+   * that may change during the Aspect application phase of synthesis, or if
+   * the value depends on the Stack the value is being used in. Both of these
+   * cases are rare, and only ever occur for AWS Construct Library authors.
+   */
+  public static uncachedAnyList(producer: IAnyProducer, options: LazyListValueOptions = {}): any[] {
+    return Token.asAnyList(new LazyAnyList(producer, false, options), options);
+  }
+
+  /**
    * Defer the one-time calculation of an arbitrarily typed value to synthesis time
    *
    * Use this if you want to render an object to a template whose actual value depends on
@@ -387,6 +416,20 @@ class LazyAny extends LazyBase<any> {
   public resolve(context: IResolveContext) {
     const resolved = super.resolve(context);
     if (Array.isArray(resolved) && resolved.length === 0 && this.options.omitEmptyArray) {
+      return undefined;
+    }
+    return resolved;
+  }
+}
+
+class LazyAnyList extends LazyBase<any> {
+  constructor(producer: IAnyProducer | IStableAnyProducer, cache: boolean, private readonly options: LazyListValueOptions = {}) {
+    super(producer as ILazyProducer<any>, cache);
+  }
+
+  public resolve(context: IResolveContext) {
+    const resolved = super.resolve(context);
+    if (Array.isArray(resolved) && resolved.length === 0 && this.options.omitEmpty) {
       return undefined;
     }
     return resolved;

--- a/packages/aws-cdk-lib/core/lib/token.ts
+++ b/packages/aws-cdk-lib/core/lib/token.ts
@@ -100,10 +100,30 @@ export class Token {
 
   /**
    * Return a reversible list representation of this token
+   *
+   * @deprecated Use `Token.asStringList()` or `Token.asAnyList()` instead.
    */
   public static asList(value: any, options: EncodingOptions = {}): string[] {
+    return Token.asStringList(value, options);
+  }
+
+  /**
+   * Return a reversible string list representation of this token
+   */
+  public static asStringList(value: any, options: EncodingOptions = {}): string[] {
     if (Array.isArray(value) && value.every(x => typeof x === 'string')) { return value; }
     return TokenMap.instance().registerList(Token.asAny(value), options.displayHint);
+  }
+
+  /**
+   * Return a reversible list representation of this token
+   *
+   * Use this for L1 properties typed as `any[]` or `object[]` where the
+   * produced value is an array of non-string elements.
+   */
+  public static asAnyList(value: any, options: EncodingOptions = {}): any[] {
+    if (Array.isArray(value) && !value.some(Token.isUnresolved)) { return value; }
+    return TokenMap.instance().registerList(Token.asAny(value), options.displayHint) as any;
   }
 
   /**


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

`Token.asList()` only returns `string[]`, which makes it impossible to create list tokens for L1 properties typed as `any[]` or `object[]`. There was no way to defer computation of non-string arrays while still getting proper token encoding.

### Description of changes

Introduces `Token.asStringList()` and `Token.asAnyList()` as explicit, type-safe replacements for `Token.asList()`. `Token.asAnyList()` uses the same list encoding mechanism but is typed as `any[]`, enabling its use with non-string array properties.

Adds `Lazy.anyList()` and `Lazy.uncachedAnyList()` as the deferred-computation counterparts, mirroring the existing `Lazy.list()` / `Lazy.uncachedList()` pattern but for arbitrary element types.

Deprecates `Token.asList()` in favor of the new explicit methods.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

`npx tsc --noEmit` passes. Full `yarn build` (jsii) passes.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
