### PR TITLE
Security: Fix 3 findings in GitHub Actions workflows

### DIFF
--- a/.github/SECURITY_ADVISORY.md
+++ b/.github/SECURITY_ADVISORY.md
@@ -1,0 +1,24 @@
+# Security Advisory
+
+Sentinel detected 3 security findings in your GitHub Actions workflows that require manual review.
+
+## dangerous-triggers
+
+### integration-test-deployment.yml (line 40)
+
+**Severity:** critical
+**Issue:** pull_request_target + checkout of PR head — fork code runs with base repo secrets
+**Fix:** Use pull_request trigger instead, or don't checkout PR head code
+
+### request-cli-integ-test.yml (line 25)
+
+**Severity:** critical
+**Issue:** pull_request_target + checkout of PR head — fork code runs with base repo secrets
+**Fix:** Use pull_request trigger instead, or don't checkout PR head code
+
+### request-cli-integ-test.yml (line 25)
+
+**Severity:** critical
+**Issue:** pull_request_target + checkout of PR head — fork code runs with base repo secrets
+**Fix:** Use pull_request trigger instead, or don't checkout PR head code
+


### PR DESCRIPTION
## Security: 3 findings across 1 rule

### Requires manual review

**dangerous-triggers** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/dangerous-triggers)
- `integration-test-deployment.yml` line 40: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code
- `request-cli-integ-test.yml` line 25: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code
- `request-cli-integ-test.yml` line 25: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code

### How this was detected

This finding was identified by deterministic pattern matching — no AI or machine learning was used in the detection. Sentinel uses static analysis rules that match known-vulnerable YAML patterns against a database of documented exploit vectors. Every finding maps to a specific, reproducible pattern. [Source code](https://github.com/jpr5/sentinel) is open for inspection.

---
<sub>&#x1f6e1;&#xfe0f; This PR was generated by [Sentinel](https://sentinel.copilotkit.dev), an open-source security scanner. [Why this PR?](https://medium.com/@jordanritter/security-hardening-github-workflows-at-scale-d291a33774e1) · Free, no tracking</sub>

[&#x2705; Add Sentinel to this repo](https://sentinel-bot.copilotkit.dev/adopt?repo=aws%2Faws-cdk&token=1444353b-832c-46b4-b83e-2ff80e1bb2d4) · [&#x1f6ab; Opt out of future PRs](https://sentinel-bot.copilotkit.dev/opt-out?repo=aws%2Faws-cdk&token=86db2894-74fd-4e0d-b7ff-83f575f0efdb)
