### PR TITLE
chore(bundling): check if docker image is cached before building

### DIFF
--- a/packages/aws-cdk-lib/core/lib/bundling.ts
+++ b/packages/aws-cdk-lib/core/lib/bundling.ts
@@ -353,21 +353,26 @@ export class DockerImage extends BundlingDockerImage {
     const tagHash = crypto.createHash('sha256').update(input).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    const dockerArgs: string[] = [
-      'build', '-t', tag,
-      ...(options.file ? ['-f', join(path, options.file)] : []),
-      ...(options.platform ? ['--platform', options.platform] : []),
-      ...(options.network ? ['--network', options.network] : []),
-      ...(options.targetStage ? ['--target', options.targetStage] : []),
-      ...(options.cacheFrom ? [...options.cacheFrom.map(cacheFrom => ['--cache-from', this.cacheOptionToFlag(cacheFrom)]).flat()] : []),
-      ...(options.cacheTo ? ['--cache-to', this.cacheOptionToFlag(options.cacheTo)] : []),
-      ...(options.cacheDisabled ? ['--no-cache'] : []),
-      ...flatten(Object.entries(buildArgs).map(([k, v]) => ['--build-arg', `${k}=${v}`])),
-      ...flatten(Object.entries(options.buildContexts || {}).map(([k, v]) => ['--build-context', `${k}=${v}`])),
-      path,
-    ];
+    // Skip the build if the image already exists in the local Docker daemon.
+    // The tag is deterministic (content-addressed from path + all options),
+    // so an existing image with this tag is guaranteed to be up-to-date.
+    if (!this.isImageCached(tag)) {
+      const dockerArgs: string[] = [
+        'build', '-t', tag,
+        ...(options.file ? ['-f', join(path, options.file)] : []),
+        ...(options.platform ? ['--platform', options.platform] : []),
+        ...(options.network ? ['--network', options.network] : []),
+        ...(options.targetStage ? ['--target', options.targetStage] : []),
+        ...(options.cacheFrom ? [...options.cacheFrom.map(cacheFrom => ['--cache-from', this.cacheOptionToFlag(cacheFrom)]).flat()] : []),
+        ...(options.cacheTo ? ['--cache-to', this.cacheOptionToFlag(options.cacheTo)] : []),
+        ...(options.cacheDisabled ? ['--no-cache'] : []),
+        ...flatten(Object.entries(buildArgs).map(([k, v]) => ['--build-arg', `${k}=${v}`])),
+        ...flatten(Object.entries(options.buildContexts || {}).map(([k, v]) => ['--build-context', `${k}=${v}`])),
+        path,
+      ];
 
-    dockerExec(dockerArgs);
+      dockerExec(dockerArgs);
+    }
 
     // Fingerprints the directory containing the Dockerfile we're building and
     // differentiates the fingerprint based on build arguments. We do this so
@@ -385,6 +390,14 @@ export class DockerImage extends BundlingDockerImage {
    */
   public static override fromRegistry(image: string) {
     return new DockerImage(image);
+  }
+
+  private static isImageCached(tag: string): boolean {
+    const prog = process.env.CDK_DOCKER ?? 'docker';
+    const proc = spawnSync(prog, ['image', 'inspect', tag], {
+      stdio: 'ignore',
+    });
+    return proc.status === 0;
   }
 
   private static cacheOptionToFlag(option: DockerCacheOption): string {

--- a/packages/aws-cdk-lib/core/test/bundling.test.ts
+++ b/packages/aws-cdk-lib/core/test/bundling.test.ts
@@ -55,6 +55,15 @@ describe('bundling', () => {
       output: ['stdout', 'stderr'],
       signal: null,
     });
+    // image inspect returns non-zero (image not cached)
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
+      signal: null,
+    });
 
     const imageHash = '123456abcdef';
     const fingerprintStub = sinon.stub(FileSystem, 'fingerprint');
@@ -76,15 +85,50 @@ describe('bundling', () => {
     const tag = `cdk-${tagHash}`;
 
     expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+      'image', 'inspect', tag,
+    ], { stdio: 'ignore' })).toEqual(true);
+
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--build-arg', 'TEST_ARG=cdk-test',
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
+  });
+
+  test('fromBuild skips docker build when image is already cached', () => {
+    const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
+      status: 0,
+      stderr: Buffer.from('stderr'),
+      stdout: Buffer.from('stdout'),
+      pid: 123,
+      output: ['stdout', 'stderr'],
+      signal: null,
+    });
+
+    const imageHash = '123456abcdef';
+    sinon.stub(FileSystem, 'fingerprint').callsFake(() => imageHash);
+
+    const image = DockerImage.fromBuild('docker-path', {
+      buildArgs: { TEST_ARG: 'cdk-test' },
+    });
+
+    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
+      path: 'docker-path',
+      buildArgs: { TEST_ARG: 'cdk-test' },
+    })).digest('hex');
+    const tag = `cdk-${tagHash}`;
+
+    // Only the image inspect call should have been made — no build
+    expect(spawnSyncStub.calledOnce).toEqual(true);
+    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+      'image', 'inspect', tag,
+    ], { stdio: 'ignore' })).toEqual(true);
+    expect(image.image).toEqual(tag);
   });
 
   test('bundling with image from asset with cache disabled', () => {
@@ -94,6 +138,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -112,13 +164,13 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--no-cache',
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -131,6 +183,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -148,13 +208,13 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--platform', platform,
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -167,6 +227,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -191,7 +259,7 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--cache-from', 'type=s3,region=us-west-2,bucket=my-bucket,name=foo',
       '--cache-from', 'type=gha,url=https://example.com,token=abc123,scope=gh-ref-image2',
@@ -199,7 +267,7 @@ describe('bundling', () => {
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -212,6 +280,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -229,13 +305,13 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--target', targetStage,
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -248,6 +324,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -265,13 +349,13 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--network', network,
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -313,12 +397,20 @@ describe('bundling', () => {
   });
 
   test('BundlerDockerImage json is the bundler image if building an image', () => {
-    sinon.stub(child_process, 'spawnSync').returns({
+    const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
     const imageHash = '123456abcdef';
@@ -345,24 +437,40 @@ describe('bundling', () => {
       output: ['stdout', 'stderr'],
       signal: null,
     });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
+      signal: null,
+    });
 
     const imagePath = path.join(__dirname, 'fs', 'fixtures', 'test1');
     DockerImage.fromAsset(imagePath, {
       file: 'my-dockerfile',
     });
 
-    expect(spawnSyncStub.calledOnce).toEqual(true);
+    expect(spawnSyncStub.calledTwice).toEqual(true);
     const expected = path.join(imagePath, 'my-dockerfile');
-    expect(new RegExp(`-f ${expected}`).test(spawnSyncStub.firstCall.args[1]?.join(' ') ?? '')).toEqual(true);
+    expect(new RegExp(`-f ${expected}`).test(spawnSyncStub.secondCall.args[1]?.join(' ') ?? '')).toEqual(true);
   });
 
   test('fromAsset', () => {
-    sinon.stub(child_process, 'spawnSync').returns({
+    const spawnSyncStub = sinon.stub(child_process, 'spawnSync').returns({
       status: 0,
       stderr: Buffer.from('stderr'),
       stdout: Buffer.from('sha256:1234567890abcdef'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -758,6 +866,14 @@ describe('bundling', () => {
       output: ['stdout', 'stderr'],
       signal: null,
     });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
+      signal: null,
+    });
 
     const imageHash = '123456abcdef';
     const fingerprintStub = sinon.stub(FileSystem, 'fingerprint');
@@ -780,14 +896,14 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--build-context', 'mycontext=/path/to/context',
       '--build-context', 'alpine=docker-image://alpine:latest',
       'docker-path',
     ])).toEqual(true);
 
-    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.thirdCall.calledWith(dockerCmd, [
       'run', '--rm',
       tag,
     ])).toEqual(true);
@@ -800,6 +916,14 @@ describe('bundling', () => {
       stdout: Buffer.from('stdout'),
       pid: 123,
       output: ['stdout', 'stderr'],
+      signal: null,
+    });
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      stderr: Buffer.from(''),
+      stdout: Buffer.from(''),
+      pid: 123,
+      output: ['', ''],
       signal: null,
     });
 
@@ -828,7 +952,7 @@ describe('bundling', () => {
     })).digest('hex');
     const tag = `cdk-${tagHash}`;
 
-    expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
+    expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
       '--build-arg', 'TEST_ARG=cdk-test',
       '--build-context', 'mycontext=/path/to/context',


### PR DESCRIPTION
### Reason for this change

<!--What is the bug or use case behind this change?-->
Whenever we load a docker image while bundling, the docker image gets cached in the local docker daemon for easy access in the future. Currently we discover the image was cached by running while we are attempting to build it. 

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->
Skip `docker build` if we detect that the image we want to use is already cached. Check whether the image is in the cache using `docker image inspect <tag>`. 

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->
N/A

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Updated existing unit tests, added unit test to verify `docker build` is skipped if image is cached. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
