### PR TITLE
fix(core): serialize List<String> cross-stack refs as joined strings in weak/both mode

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/refs.ts
+++ b/packages/aws-cdk-lib/core/lib/private/refs.ts
@@ -495,8 +495,11 @@ function createGetStackOutput(reference: Reference, options: GetStackOutputOptio
 
   let output = scope.node.tryFindChild(outputId) as CfnOutput;
   if (output == null) {
+    const isStringList = reference.typeHint === ResolutionTypeHint.STRING_LIST;
     output = new CfnOutput(scope, outputId, {
-      value: Token.asString(reference),
+      value: isStringList
+        ? Fn.join(STRING_LIST_REFERENCE_DELIMITER, Token.asList(reference))
+        : Token.asString(reference),
     });
   }
 
@@ -532,9 +535,15 @@ function createGetStackOutput(reference: Reference, options: GetStackOutputOptio
     }
   }
 
-  return Tokenization.reverseCompleteString(
-    Fn.getStackOutput(exportingStack.stackName, output.logicalId, exportingStack.region, roleArn),
-  ) as Intrinsic;
+  const getStackOutputString = Fn.getStackOutput(exportingStack.stackName, output.logicalId, exportingStack.region, roleArn);
+
+  if (reference.typeHint === ResolutionTypeHint.STRING_LIST) {
+    return Tokenization.reverseList(
+      Fn.split(STRING_LIST_REFERENCE_DELIMITER, getStackOutputString),
+    ) as Intrinsic;
+  }
+
+  return Tokenization.reverseCompleteString(getStackOutputString) as Intrinsic;
 }
 
 export function getExportable(stack: Stack, reference: Reference): Intrinsic {

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -1334,6 +1334,75 @@ describe('stack', () => {
     expect(template2.Resources.SomeResource.Properties.Name).not.toHaveProperty('Fn::ImportValue');
   });
 
+  test('same-region weak references with STRING_LIST attribute serialize value with Fn::Join and deserialize with Fn::Split', () => {
+    // Regression test for https://github.com/aws/aws-cdk/issues/37910
+    // PublishOutput path must not emit a raw list as the CFN output value — CloudFormation
+    // requires all Output.Value fields to be strings.
+    const app = new App({ context: { [cxapi.DEFAULT_CROSS_STACK_REFERENCES]: 'weak' } });
+    const stack1 = new Stack(app, 'Stack1', { env: { region: 'us-east-1', account: '111111111111' } });
+    const exportResource = new CfnResource(stack1, 'SomeResourceExport', {
+      type: 'AWS::VPC::Endpoint',
+    });
+    const stack2 = new Stack(app, 'Stack2', { env: { region: 'us-east-1', account: '111111111111' } });
+
+    // WHEN - consume a list-type attribute across stacks
+    new CfnResource(stack2, 'SomeResource', {
+      type: 'AWS::S3::Bucket',
+      properties: { DnsEntries: exportResource.getAtt('DnsEntries', ResolutionTypeHint.STRING_LIST) },
+    });
+
+    const assembly = app.synth();
+    const template1 = assembly.getStackByName(stack1.stackName).template;
+    const template2 = assembly.getStackByName(stack2.stackName).template;
+
+    // THEN - producer output value is a joined string, not a raw list
+    const outputs = Object.values(template1.Outputs ?? {}) as any[];
+    expect(outputs.length).toBeGreaterThan(0);
+    const publishOutput = outputs.find((o: any) => o.Export === undefined);
+    expect(publishOutput).toBeDefined();
+    expect(publishOutput.Value).toHaveProperty('Fn::Join');
+    expect(publishOutput.Value['Fn::Join'][0]).toBe('||');
+
+    // THEN - consumer splits the joined string back into a list
+    const dnsEntries = template2.Resources.SomeResource.Properties.DnsEntries;
+    expect(dnsEntries).toHaveProperty('Fn::Split');
+    expect(dnsEntries['Fn::Split'][0]).toBe('||');
+    expect(dnsEntries['Fn::Split'][1]).toHaveProperty('Fn::GetStackOutput');
+  });
+
+  test('same-region both references with STRING_LIST attribute serialize value with Fn::Join and deserialize with Fn::Split', () => {
+    // Regression test for https://github.com/aws/aws-cdk/issues/37910
+    const app = new App({ context: { [cxapi.DEFAULT_CROSS_STACK_REFERENCES]: 'both' } });
+    const stack1 = new Stack(app, 'Stack1', { env: { region: 'us-east-1', account: '111111111111' } });
+    const exportResource = new CfnResource(stack1, 'SomeResourceExport', {
+      type: 'AWS::VPC::Endpoint',
+    });
+    const stack2 = new Stack(app, 'Stack2', { env: { region: 'us-east-1', account: '111111111111' } });
+
+    // WHEN - consume a list-type attribute across stacks
+    new CfnResource(stack2, 'SomeResource', {
+      type: 'AWS::S3::Bucket',
+      properties: { DnsEntries: exportResource.getAtt('DnsEntries', ResolutionTypeHint.STRING_LIST) },
+    });
+
+    const assembly = app.synth();
+    const template1 = assembly.getStackByName(stack1.stackName).template;
+    const template2 = assembly.getStackByName(stack2.stackName).template;
+
+    // THEN - the PublishOutput (no Export) uses Fn::Join, not a raw list
+    const outputs = Object.values(template1.Outputs ?? {}) as any[];
+    const publishOutput = outputs.find((o: any) => o.Export === undefined);
+    expect(publishOutput).toBeDefined();
+    expect(publishOutput.Value).toHaveProperty('Fn::Join');
+    expect(publishOutput.Value['Fn::Join'][0]).toBe('||');
+
+    // THEN - consumer splits the joined string back into a list
+    const dnsEntries = template2.Resources.SomeResource.Properties.DnsEntries;
+    expect(dnsEntries).toHaveProperty('Fn::Split');
+    expect(dnsEntries['Fn::Split'][0]).toBe('||');
+    expect(dnsEntries['Fn::Split'][1]).toHaveProperty('Fn::GetStackOutput');
+  });
+
   test('invalid cross stack reference strength throws', () => {
     // GIVEN
     const app = new App({ context: { [cxapi.DEFAULT_CROSS_STACK_REFERENCES]: 'invalid' } });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37910.

## Summary

- `createGetStackOutput` (the `PublishOutput` code path used by `defaultCrossStackReferences: "weak"` and `"both"`) was emitting raw list values in CloudFormation `Output.Value` fields for `STRING_LIST` type attributes (e.g. VPC endpoint `DnsEntries`). CloudFormation requires all output values to be strings, causing deployments to fail with *"Every Value member must be a string"*.
- Applied the same `Fn::Join('||', ...)`/`Fn::Split('||', ...)` stringification pattern that `createImportValue` (strong path) and `createNestedStackOutput` (nested stack path) already use correctly.
- Added regression tests for both `weak` and `both` modes.

## Test plan

- [ ] `same-region weak references with STRING_LIST attribute serialize value with Fn::Join and deserialize with Fn::Split`
- [ ] `same-region both references with STRING_LIST attribute serialize value with Fn::Join and deserialize with Fn::Split`