### PR TITLE
ci(integ-test-deployment): set aws region for the creds to us-east-1

### DIFF
--- a/tools/@aws-cdk/integration-test-deployment/lib/integration-test-runner.ts
+++ b/tools/@aws-cdk/integration-test-deployment/lib/integration-test-runner.ts
@@ -40,7 +40,7 @@ export const deployIntegTests = async (props: {
         AWS_ACCESS_KEY_ID: allocation.allocation.credentials.accessKeyId,
         AWS_SECRET_ACCESS_KEY: allocation.allocation.credentials.secretAccessKey,
         AWS_SESSION_TOKEN: allocation.allocation.credentials.sessionToken,
-        AWS_REGION: allocation.allocation.environment.region,
+        AWS_REGION: 'us-east-1',
         AWS_ACCOUNT_ID: allocation.allocation.environment.account,
         TARGET_BRANCH_COMMIT: process.env.TARGET_BRANCH_COMMIT,
         SOURCE_BRANCH_COMMIT: process.env.SOURCE_BRANCH_COMMIT,


### PR DESCRIPTION
### Reason for this change

The underlying service will return a "global" region in the future, indicating that the allocation is not restricted to a region. This breaks the role assume operation as it requires a valid AWS region, even if that region is not used.

### Description of changes

Set the region as 'us-east-1' for role assumption.

### Describe any new or updated permissions being added

No permissions added.


### Description of how you validated changes

Tested in local fork: https://github.com/Abogical/aws-cdk/actions/runs/26176909248/job/77021864205

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
