### PR TITLE
fix(core): handle string "false" for boolean context values in validation

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/synthesis.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis.ts
@@ -197,8 +197,8 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
   if (reports.length > 0) {
     const tree = new ConstructTree(root);
     const formatter = new PolicyValidationReportFormatter(tree);
-    const failOnErrors = root.node.tryGetContext(cxapi.FAIL_SYNTH_ON_VALIDATION_ERRORS_CONTEXT) ?? true;
-    const writeLegacyReport = root.node.tryGetContext(cxapi.VALIDATION_REPORT_JSON_CONTEXT) ?? false;
+    const failOnErrors = getBooleanContext(root, cxapi.FAIL_SYNTH_ON_VALIDATION_ERRORS_CONTEXT, true);
+    const writeLegacyReport = getBooleanContext(root, cxapi.VALIDATION_REPORT_JSON_CONTEXT, false);
 
     const reportFile = path.join(assembly.directory, cxapi.VALIDATION_REPORT_FILE);
     const jsonOutput = formatter.formatJson(reports, assembly.version);
@@ -558,4 +558,10 @@ function visit(root: IConstruct, order: 'pre' | 'post', cb: (x: IConstruct) => v
   if (order === 'post') {
     cb(root);
   }
+}
+
+function getBooleanContext(root: IConstruct, key: string, defaultValue: boolean): boolean {
+  const raw = root.node.tryGetContext(key);
+  if (raw === undefined) return defaultValue;
+  return raw !== false && raw !== 'false';
 }

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -682,6 +682,45 @@ Policy Validation Report Summary
     expect(allOutput).not.toContain('Validation Report');
   });
 
+  test('failSynthOnValidationErrors="false" (string) works the same as boolean false', () => {
+    const app = new core.App({
+      policyValidationBeta1: [
+        new FakePlugin('test-plugin', [{
+          description: 'test recommendation',
+          ruleName: 'test-rule',
+          ruleMetadata: {
+            id: 'abcdefg',
+          },
+          violatingResources: [{
+            locations: ['test-location'],
+            resourceLogicalId: 'Fake',
+            templatePath: '/path/to/Default.template.json',
+          }],
+        }]),
+      ],
+      context: {
+        '@aws-cdk/core:failSynthOnValidationErrors': 'false',
+      },
+    });
+    const stack = new core.Stack(app);
+    new core.CfnResource(stack, 'Fake', {
+      type: 'Test::Resource::Fake',
+      properties: {
+        result: 'failure',
+      },
+    });
+    app.synth();
+
+    expect(process.exitCode).toBeUndefined();
+
+    const file = path.join(app.outdir, 'validation-report.json');
+    expect(fs.existsSync(file)).toBe(true);
+
+    const allOutput = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
+    expect(allOutput).not.toContain('Validation failed');
+    expect(allOutput).not.toContain('Validation Report');
+  });
+
   test('Pretty print as default', () => {
     const app = new core.App({
       policyValidationBeta1: [


### PR DESCRIPTION
## Summary

- Context values passed via `--context key=value` on the CLI arrive as strings in `CDK_CONTEXT_JSON`. The previous code used `?? true` which only catches `null`/`undefined`, so the string `"false"` (truthy in JS) caused `failSynthOnValidationErrors` to erroneously trigger — printing the legacy report to stderr and setting `process.exitCode = 1`, killing the synth subprocess before the CLI could read `validation-report.json`.
- Introduced a `getBooleanContext` helper that correctly handles both boolean `false` and string `"false"`, with a configurable default.
- Applied the same fix to `writeLegacyReport` context key for consistency.

Context: https://github.com/aws/aws-cdk-cli/pull/630/changes establishes that context values arriving from the CLI are always strings, so boolean context keys must handle the string `"false"` explicitly.

## Test plan

- [x] Added unit test: `failSynthOnValidationErrors="false" (string) works the same as boolean false`
- [x] Existing test `failSynthOnValidationErrors=false writes JSON but does not print or fail` continues to pass
- [x] Full validation test suite passes (48/48)