### PR TITLE
ci(integ-test-delpoyment): rebase PR branch onto main before running integration tests

### DIFF
--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -40,6 +40,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase onto main
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git pull origin main --rebase
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The `integration-test-deployment.yml` workflow checks out the PR head SHA directly, which may be behind `main`. This means integration tests can run against a stale base, potentially missing conflicts or regressions introduced by recent merges to main.

### Description of changes

Added a "Rebase onto main" step after the checkout that runs `git pull origin main --rebase`. This ensures the PR branch includes the latest main changes before the build and integration tests execute.

The step includes `git config --global` for user identity since the CodeBuild runner environment doesn't have a default committer configured, which git requires during rebase.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Tested on a fork (Abogical/aws-cdk) using PR #21 with the `pr/needs-integration-tests-deployment` label. Confirmed the rebase step completes successfully and the workflow proceeds to subsequent steps.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*