### PR TITLE
chore(bedrock-agentcore-alpha): deprecate graduated exports

### DIFF
--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/common/types.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/common/types.ts
@@ -15,6 +15,7 @@
  * Custom claim value type.
  * Shared by Runtime and Gateway custom claim implementations.
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum CustomClaimValueType {
   /** String value type */
@@ -26,6 +27,7 @@ export enum CustomClaimValueType {
 /**
  * Custom claim match operator.
  * Shared by Runtime and Gateway custom claim implementations.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum CustomClaimOperator {
   /** Equals operator - used for STRING type claims */

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/custom-evaluator.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/custom-evaluator.ts
@@ -29,6 +29,7 @@ import {
 
 /**
  * Properties for creating an Evaluator.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface EvaluatorProps {
   /**
@@ -115,6 +116,10 @@ export interface EvaluatorProps {
  * });
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class Evaluator extends EvaluatorBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string =

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/data-source.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/data-source.ts
@@ -41,6 +41,7 @@ import type { IRuntimeEndpoint } from '../runtime/runtime-endpoint-base';
  *   logGroupNames: ['/aws/my-external-agent/logs'],
  *   serviceNames: ['my-external-agent'],
  * });
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class DataSourceConfig {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator-base.ts
@@ -18,6 +18,7 @@ import type { Construct } from 'constructs';
 
 /**
  * Interface for Evaluator resources.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IEvaluator extends IResource, IEvaluatorRef {
   /**
@@ -65,6 +66,7 @@ export interface IEvaluator extends IResource, IEvaluatorRef {
 /**
  * Abstract base class for Evaluator.
  * Contains methods and attributes valid for evaluators either created with CDK or imported.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class EvaluatorBase extends Resource implements IEvaluator {
   public abstract readonly evaluatorArn: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator-config.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator-config.ts
@@ -27,6 +27,7 @@ import {
  *
  * Uses a foundation model to assess agent performance based on
  * custom instructions and a rating scale.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface LlmAsAJudgeOptions {
   /**
@@ -81,6 +82,7 @@ export interface LlmAsAJudgeOptions {
  * Options for configuring a code-based custom evaluator using a Lambda function.
  *
  * Uses a Lambda function to implement custom evaluation logic.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CodeBasedOptions {
   /**
@@ -123,6 +125,7 @@ export interface CodeBasedOptions {
  *   { label: 'Good', definition: 'Adequate response.', value: 3 },
  *   { label: 'Excellent', definition: 'Outstanding response.', value: 5 },
  * ]);
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class EvaluatorRatingScale {
   /**
@@ -189,6 +192,7 @@ export class EvaluatorRatingScale {
  * const codeConfig = agentcore.EvaluatorConfig.codeBased({
  *   lambdaFunction: myEvalFunction,
  * });
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class EvaluatorConfig {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/evaluator.ts
@@ -28,6 +28,7 @@ import type { BuiltinEvaluator, EvaluatorReferenceBindResult } from './types';
  * // Using custom evaluators
  * declare const myCustomEvaluator: agentcore.IEvaluator;
  * const custom = agentcore.EvaluatorReference.custom(myCustomEvaluator);
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class EvaluatorReference {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/online-evaluation-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/online-evaluation-base.ts
@@ -18,6 +18,7 @@ import type { Construct } from 'constructs';
 
 /**
  * Interface for OnlineEvaluationConfig resources.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IOnlineEvaluationConfig extends IResource, iam.IGrantable, IOnlineEvaluationConfigRef {
   /**
@@ -75,6 +76,7 @@ export interface IOnlineEvaluationConfig extends IResource, iam.IGrantable, IOnl
 /**
  * Abstract base class for OnlineEvaluationConfig.
  * Contains methods and attributes valid for configurations either created with CDK or imported.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class OnlineEvaluationBase extends Resource implements IOnlineEvaluationConfig {
   public abstract readonly onlineEvaluationConfigArn: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/online-evaluation.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/online-evaluation.ts
@@ -44,6 +44,7 @@ import {
 
 /**
  * Properties for creating an OnlineEvaluationConfig.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OnlineEvaluationConfigProps extends OnlineEvaluationBaseProps {
   /**
@@ -93,6 +94,10 @@ export interface OnlineEvaluationConfigProps extends OnlineEvaluationBaseProps {
  * });
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class OnlineEvaluationConfig extends OnlineEvaluationBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string =

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/perms.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/perms.ts
@@ -14,6 +14,7 @@
 /**
  * Permissions to describe CloudWatch Log Groups.
  * This is a list operation that does not support resource-level permissions.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const EVALUATION_CLOUDWATCH_LOGS_DESCRIBE_PERMS = [
   'logs:DescribeLogGroups',
@@ -22,6 +23,7 @@ export const EVALUATION_CLOUDWATCH_LOGS_DESCRIBE_PERMS = [
 /**
  * Permissions for the execution role to query CloudWatch Logs.
  * These actions support resource-level permissions scoped to specific log groups.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const EVALUATION_CLOUDWATCH_LOGS_QUERY_PERMS = [
   'logs:GetQueryResults',
@@ -30,6 +32,7 @@ export const EVALUATION_CLOUDWATCH_LOGS_QUERY_PERMS = [
 
 /**
  * Permissions for the execution role to invoke Bedrock models.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const EVALUATION_BEDROCK_MODEL_PERMS = [
   'bedrock:InvokeModel',
@@ -38,6 +41,7 @@ export const EVALUATION_BEDROCK_MODEL_PERMS = [
 
 /**
  * Permissions for the execution role to write evaluation results.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const EVALUATION_CLOUDWATCH_LOGS_WRITE_PERMS = [
   'logs:CreateLogGroup',
@@ -47,6 +51,7 @@ export const EVALUATION_CLOUDWATCH_LOGS_WRITE_PERMS = [
 
 /**
  * Permissions for CloudWatch index policies.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const EVALUATION_CLOUDWATCH_INDEX_POLICY_PERMS = [
   'logs:DescribeIndexPolicies',

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/types.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/types.ts
@@ -19,6 +19,7 @@ import type * as iam from 'aws-cdk-lib/aws-iam';
  *
  * These evaluators assess different aspects of agent performance
  * at various levels (session, trace, or tool call).
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class BuiltinEvaluator {
   /**
@@ -101,6 +102,7 @@ export class BuiltinEvaluator {
 
 /**
  * The execution status of an online evaluation configuration.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ExecutionStatus {
   /**
@@ -128,6 +130,7 @@ export class ExecutionStatus {
 
 /**
  * Filter operators for online evaluation filtering.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class FilterOperator {
   /**
@@ -190,6 +193,7 @@ export class FilterOperator {
  * - `FilterValue.string()` for string comparisons
  * - `FilterValue.number()` for numeric comparisons
  * - `FilterValue.boolean()` for boolean comparisons
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class FilterValue {
   /**
@@ -239,6 +243,7 @@ export class FilterValue {
  *
  * Filters determine which agent traces should be included in the evaluation
  * based on trace properties.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface FilterConfig {
   /**
@@ -264,6 +269,7 @@ export interface FilterConfig {
 
 /**
  * Configuration for CloudWatch Logs data source.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CloudWatchLogsDataSourceConfig {
   /**
@@ -291,6 +297,7 @@ export interface CloudWatchLogsDataSourceConfig {
  * Base properties for creating an OnlineEvaluationConfig.
  * The actual OnlineEvaluationProps is defined in online-evaluation-config.ts
  * to avoid circular dependencies.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OnlineEvaluationBaseProps {
   /**
@@ -362,6 +369,7 @@ export interface OnlineEvaluationBaseProps {
 
 /**
  * The result of binding an EvaluatorReference.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface EvaluatorReferenceBindResult {
   /**
@@ -372,6 +380,7 @@ export interface EvaluatorReferenceBindResult {
 
 /**
  * The result of binding a DataSourceConfig.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface DataSourceConfigBindResult {
   /**
@@ -384,6 +393,7 @@ export interface DataSourceConfigBindResult {
  * The level at which a custom evaluator assesses agent performance.
  *
  * Determines what granularity of data the evaluator operates on.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class EvaluationLevel {
   /**
@@ -418,6 +428,7 @@ export class EvaluationLevel {
  * A categorical rating scale option for custom evaluators.
  *
  * Categorical scales define discrete labels for scoring agent performance.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CategoricalRatingOption {
   /**
@@ -439,6 +450,7 @@ export interface CategoricalRatingOption {
  * A numerical rating scale option for custom evaluators.
  *
  * Numerical scales define labeled numeric values for scoring agent performance.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface NumericalRatingOption {
   /**
@@ -467,6 +479,7 @@ export interface NumericalRatingOption {
  * Inference configuration for a custom LLM-as-a-Judge evaluator.
  *
  * Controls how the foundation model generates evaluation responses.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface EvaluatorInferenceConfig {
   /**
@@ -497,6 +510,7 @@ export interface EvaluatorInferenceConfig {
 
 /**
  * Attributes for importing an existing Evaluator.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface EvaluatorAttributes {
   /**
@@ -519,6 +533,7 @@ export interface EvaluatorAttributes {
 
 /**
  * Attributes for importing an existing OnlineEvaluationConfig.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OnlineEvaluationConfigAttributes {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/evaluation/validation-helpers.ts
@@ -68,6 +68,7 @@ export type ValidationFn<T> = (param: T, scope?: IConstruct) => string[];
  * @param name - The configuration name to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateConfigName(name: string, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -108,6 +109,7 @@ export function validateConfigName(name: string, _scope?: IConstruct): string[] 
  * @param description - The description to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateDescription(description: string | undefined, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -134,6 +136,7 @@ export function validateDescription(description: string | undefined, _scope?: IC
  * @param evaluators - The evaluators array to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateEvaluators(evaluators: IEvaluatorReference[], _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -163,6 +166,7 @@ export function validateEvaluators(evaluators: IEvaluatorReference[], _scope?: I
  * @param percentage - The sampling percentage to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateSamplingPercentage(percentage: number | undefined, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -195,6 +199,7 @@ export function validateSamplingPercentage(percentage: number | undefined, _scop
  * @param filters - The filters array to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateFilters(filters: FilterConfig[] | undefined, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -217,6 +222,7 @@ export function validateFilters(filters: FilterConfig[] | undefined, _scope?: IC
  * @param minutes - The session timeout in minutes to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateSessionTimeout(minutes: number | undefined, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -249,6 +255,7 @@ export function validateSessionTimeout(minutes: number | undefined, _scope?: ICo
  * @param names - The log group names array to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateLogGroupNames(names: string[], _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -270,6 +277,7 @@ export function validateLogGroupNames(names: string[], _scope?: IConstruct): str
  * @param names - The service names array to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateServiceNames(names: string[], _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -292,6 +300,7 @@ export function validateServiceNames(names: string[], _scope?: IConstruct): stri
  * @param name - The evaluator name to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateEvaluatorName(name: string, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -332,6 +341,7 @@ export function validateEvaluatorName(name: string, _scope?: IConstruct): string
  * @param instructions - The instructions to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateInstructions(instructions: string, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -357,6 +367,7 @@ export function validateInstructions(instructions: string, _scope?: IConstruct):
  * @param options - The categorical rating options to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateCategoricalRatingScale(options: CategoricalRatingOption[], _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -383,6 +394,7 @@ export function validateCategoricalRatingScale(options: CategoricalRatingOption[
  * @param options - The numerical rating options to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateNumericalRatingScale(options: NumericalRatingOption[], _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -409,6 +421,7 @@ export function validateNumericalRatingScale(options: NumericalRatingOption[], _
  * @param seconds - The timeout in seconds to validate
  * @param _scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateLambdaTimeout(seconds: number | undefined, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -438,6 +451,7 @@ export function validateLambdaTimeout(seconds: number | undefined, _scope?: ICon
  * @param param - The parameter to validate
  * @param scope - The construct scope for error reporting (optional)
  * @returns The validated parameter
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function throwIfInvalid<T>(validationFn: ValidationFn<T>, param: T, scope?: IConstruct): T {
   const errors = validationFn(param, scope);
@@ -499,11 +513,19 @@ function validateTags(tags: { [key: string]: string } | undefined, keyPattern: R
 }
 
 /** Validates tags for Evaluator resources (Unicode keys allowed per CFN docs) */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export function validateEvaluatorTags(tags?: { [key: string]: string }, scope?: IConstruct): string[] {
   return validateTags(tags, EVALUATOR_TAG_KEY_PATTERN, scope);
 }
 
 /** Validates tags for OnlineEvaluationConfig resources (ASCII keys per CFN pattern) */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export function validateEvaluationTags(tags?: { [key: string]: string }, scope?: IConstruct): string[] {
   return validateTags(tags, ONLINE_EVALUATION_CONFIG_TAG_KEY_PATTERN, scope);
 }

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/gateway-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/gateway-base.ts
@@ -16,6 +16,7 @@ import type { IGatewayProtocolConfig } from './protocol';
  *****************************************************************************/
 /**
  * Exception levels for gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum GatewayExceptionLevel {
   /**
@@ -31,6 +32,7 @@ export enum GatewayExceptionLevel {
  *****************************************************************************/
 /**
  * Interface for Gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IGateway extends IResource, IGatewayRef {
   /**
@@ -229,6 +231,11 @@ export interface IGateway extends IResource, IGatewayRef {
  *                                Base Class
  *****************************************************************************/
 
+/**
+ * Base class for Gateway constructs.
+ *
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export abstract class GatewayBase extends Resource implements IGateway {
   public abstract readonly gatewayArn: string;
   public abstract readonly gatewayId: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/gateway.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/gateway.ts
@@ -32,6 +32,7 @@ import { validateStringField, validateFieldPattern } from './validation-helpers'
 /**
  * The enforcement mode for a policy engine associated with a gateway.
  *
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class PolicyEngineMode {
   /**
@@ -61,6 +62,7 @@ export class PolicyEngineMode {
  * When configured, the policy engine intercepts all agent requests through this
  * gateway and evaluates them against the defined Cedar policies.
  * [disable-awslint:prefer-ref-interface]
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayPolicyEngineConfig {
   /**
@@ -86,6 +88,7 @@ export interface GatewayPolicyEngineConfig {
 
 /**
  * Options for adding a Lambda target to a gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddLambdaTargetOptions {
   /**
@@ -120,6 +123,7 @@ export interface AddLambdaTargetOptions {
 
 /**
  * Options for adding an OpenAPI target to a gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddOpenApiTargetOptions {
   /**
@@ -158,6 +162,7 @@ export interface AddOpenApiTargetOptions {
 
 /**
  * Options for adding a Smithy target to a gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddSmithyTargetOptions {
   /**
@@ -187,6 +192,7 @@ export interface AddSmithyTargetOptions {
 
 /**
  * Options for adding an MCP Server target to a gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddMcpServerTargetOptions {
   /**
@@ -223,6 +229,7 @@ export interface AddMcpServerTargetOptions {
 
 /**
  * Options for adding an API Gateway target to a gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddApiGatewayTargetOptions {
   /**
@@ -273,6 +280,7 @@ export interface AddApiGatewayTargetOptions {
 
 /**
  * Properties for defining a Gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayProps {
   /**
@@ -360,6 +368,7 @@ export interface GatewayProps {
 
 /**
  * Attributes for importing an existing Gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayAttributes {
   /**
@@ -394,6 +403,10 @@ export interface GatewayAttributes {
  * @see https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateGateway.html
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class Gateway extends GatewayBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.Gateway';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/inbound-auth/authorizer.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/inbound-auth/authorizer.ts
@@ -9,6 +9,7 @@ import type { GatewayCustomClaim } from './custom-claim';
 
 /**
  * Gateway authorizer type
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum GatewayAuthorizerType {
   /** Custom JWT authorizer type */
@@ -21,6 +22,7 @@ export enum GatewayAuthorizerType {
 
 /**
  * Abstract interface for gateway authorizer configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IGatewayAuthorizerConfig {
   /**
@@ -40,6 +42,7 @@ export interface IGatewayAuthorizerConfig {
  *****************************************************************************/
 /**
  * Custom JWT authorizer configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CustomJwtConfiguration {
   /**
@@ -79,6 +82,7 @@ export interface CustomJwtConfiguration {
 
 /**
  * Custom JWT authorizer configuration implementation
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class CustomJwtAuthorizer implements IGatewayAuthorizerConfig {
   public readonly authorizerType = GatewayAuthorizerType.CUSTOM_JWT;
@@ -121,6 +125,7 @@ export class CustomJwtAuthorizer implements IGatewayAuthorizerConfig {
 /**
  * AWS IAM authorizer configuration implementation
  *
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class IamAuthorizer implements IGatewayAuthorizerConfig {
   public readonly authorizerType = GatewayAuthorizerType.AWS_IAM;
@@ -141,6 +146,7 @@ export class IamAuthorizer implements IGatewayAuthorizerConfig {
 
 /**
  * No authorization configuration implementation
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class NoAuthAuthorizer implements IGatewayAuthorizerConfig {
   public readonly authorizerType = GatewayAuthorizerType.NONE;
@@ -157,6 +163,11 @@ export class NoAuthAuthorizer implements IGatewayAuthorizerConfig {
  *                               Factory
  *****************************************************************************/
 
+/**
+ * Properties for configuring a Cognito authorizer.
+ *
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export interface CognitoAuthorizerProps {
   /**
    * The Cognito User Pool to use for authentication
@@ -186,6 +197,7 @@ export interface CognitoAuthorizerProps {
 }
 /**
  * Factory class for creating Gateway Authorizers
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class GatewayAuthorizer {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/inbound-auth/custom-claim.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/inbound-auth/custom-claim.ts
@@ -21,6 +21,7 @@ import { CustomClaimOperator, CustomClaimValueType } from '../../common/types';
  * Represents a custom claim validation configuration for Gateway JWT authorizers.
  * Custom claims allow you to validate additional fields in JWT tokens beyond
  * the standard audience, client, and scope validations.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class GatewayCustomClaim {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/interceptor.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/interceptor.ts
@@ -8,6 +8,7 @@ import type { IGateway } from './gateway-base';
 
 /**
  * The interception point where the interceptor will be invoked
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum InterceptionPoint {
   /**
@@ -29,6 +30,7 @@ export enum InterceptionPoint {
 
 /**
  * Options for configuring an interceptor
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface InterceptorOptions {
   /**
@@ -48,6 +50,7 @@ export interface InterceptorOptions {
  * Represents an interceptor that can be bound to a Gateway
  *
  * Interceptors allow custom code execution at specific points in the gateway request/response flow.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IInterceptor {
   /**
@@ -72,6 +75,7 @@ export interface IInterceptor {
 
 /**
  * Configuration returned from binding an interceptor to a Gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface InterceptorBindConfig {
   /**
@@ -91,6 +95,7 @@ export interface InterceptorBindConfig {
  * - REQUEST interceptors execute before calling the target
  * - RESPONSE interceptors execute after the target responds
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-interceptors.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class LambdaInterceptor implements IInterceptor {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/api-key.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/api-key.ts
@@ -10,6 +10,7 @@ import { GATEWAY_API_KEY_PERMS, GATEWAY_WORKLOAD_IDENTITY_PERMS, GATEWAY_SECRETS
  *****************************************************************************/
 /**
  * API Key additional configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiKeyAdditionalConfiguration {
 
@@ -35,6 +36,7 @@ export interface ApiKeyAdditionalConfiguration {
 /**
  * API Key credential location type
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum ApiKeyCredentialLocationType {
   HEADER = 'HEADER',
@@ -43,6 +45,7 @@ export enum ApiKeyCredentialLocationType {
 
 /**
  * API Key location within the request
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ApiKeyCredentialLocation {
   /**
@@ -99,6 +102,7 @@ export class ApiKeyCredentialLocation {
  * API key credential provider ARNs for gateway outbound auth (Token Vault identity).
  *
  * Pass this to {@link GatewayCredentialProvider.fromApiKeyIdentityArn} or to {@link ApiKeyCredentialProviderConfiguration}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiKeyCredentialProviderProps {
   /**
@@ -128,6 +132,7 @@ export interface ApiKeyCredentialProviderProps {
  * API Key credential provider configuration implementation
  * Can be used with OpenAPI targets
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ApiKeyCredentialProviderConfiguration implements ICredentialProviderConfig {
   public readonly credentialProviderType = CredentialProviderType.API_KEY;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/credential-provider.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/credential-provider.ts
@@ -15,6 +15,7 @@ import type { IGateway } from '../gateway-base';
  *****************************************************************************/
 /**
  * Credential provider types supported by gateway target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum CredentialProviderType {
   /**
@@ -39,6 +40,7 @@ export enum CredentialProviderType {
 
 /**
  * Abstract interface for gateway credential provider configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ICredentialProviderConfig {
   /**
@@ -61,6 +63,7 @@ export interface ICredentialProviderConfig {
 
 /**
  * Optional gateway settings when binding an {@link IApiKeyCredentialProvider} to a target.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface FromApiKeyIdentityOptions {
   /**
@@ -73,6 +76,7 @@ export interface FromApiKeyIdentityOptions {
 
 /**
  * OAuth scopes (and optional custom parameters) when binding an {@link IOAuth2CredentialProvider} to a gateway target.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface FromOauthIdentityOptions {
   /**
@@ -90,6 +94,7 @@ export interface FromOauthIdentityOptions {
 
 /**
  * Factory class for creating different Gateway Credential Providers
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class GatewayCredentialProvider {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/iam-role.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/iam-role.ts
@@ -12,6 +12,7 @@ import type { IGateway } from '../gateway-base';
  * Gateway IAM Role credential provider configuration implementation
  * Can be used with Lambda and Smithy targets
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class GatewayIamRoleCredentialProviderConfig implements ICredentialProviderConfig {
   public readonly credentialProviderType = CredentialProviderType.GATEWAY_IAM_ROLE;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/oauth.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/outbound-auth/oauth.ts
@@ -11,6 +11,7 @@ import { GATEWAY_OAUTH_PERMS, GATEWAY_OAUTH_COMPLETE_AUTH_PERMS, GATEWAY_WORKLOA
 
 /**
  * OAuth configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuthConfiguration {
   /**
@@ -59,6 +60,7 @@ export interface OAuthConfiguration {
  * OAuth credential provider configuration implementation
  * Can be used with OpenAPI targets
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class OAuthCredentialProviderConfiguration implements ICredentialProviderConfig {
   public readonly credentialProviderType = CredentialProviderType.OAUTH;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/perms.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/perms.ts
@@ -6,6 +6,7 @@
 /**
  * Permissions to invoke the gateway
  * Used by agents or other services that need to call the gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_INVOKE_PERMS = ['bedrock-agentcore:InvokeGateway'];
 
@@ -16,6 +17,7 @@ export const GATEWAY_INVOKE_PERMS = ['bedrock-agentcore:InvokeGateway'];
 /**
  * KMS permissions for encryption
  * Required when using KMS keys for encryption
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_KMS_KEY_PERMS = [
   'kms:GenerateDataKey',
@@ -33,12 +35,14 @@ export const GATEWAY_KMS_KEY_PERMS = [
 /**
  * Assume role permission
  * Required for the gateway service to assume the execution role
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_ASSUME_ROLE = ['sts:AssumeRole'];
 
 /**
  * Outbound auth - Workload identity permissions (API key targets)
  * Used to obtain access tokens for workload identity
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_WORKLOAD_IDENTITY_PERMS = [
   'bedrock-agentcore:GetWorkloadAccessToken',
@@ -47,6 +51,7 @@ export const GATEWAY_WORKLOAD_IDENTITY_PERMS = [
 /**
  * Outbound auth - Workload identity permissions (OAuth targets)
  * OAuth flows additionally require JWT-based and user-ID-based token exchange
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_WORKLOAD_IDENTITY_OAUTH_PERMS = [
   'bedrock-agentcore:GetWorkloadAccessToken',
@@ -57,6 +62,7 @@ export const GATEWAY_WORKLOAD_IDENTITY_OAUTH_PERMS = [
 /**
  * Outbound auth - OAuth permissions
  * Used to obtain OAuth tokens and complete token auth for target authentication
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_OAUTH_PERMS = [
   'bedrock-agentcore:GetResourceOauth2Token',
@@ -65,6 +71,7 @@ export const GATEWAY_OAUTH_PERMS = [
 /**
  * Outbound auth - OAuth complete token auth permissions
  * Used to complete the OAuth token authorization flow
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_OAUTH_COMPLETE_AUTH_PERMS = [
   'bedrock-agentcore:CompleteResourceTokenAuth',
@@ -73,6 +80,7 @@ export const GATEWAY_OAUTH_COMPLETE_AUTH_PERMS = [
 /**
  * Outbound auth - API Key permissions
  * Used to retrieve API keys for target authentication
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_API_KEY_PERMS = [
   'bedrock-agentcore:GetResourceApiKey',
@@ -83,6 +91,7 @@ export const GATEWAY_API_KEY_PERMS = [
  * Required for reading credential secrets backing Token Vault providers.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-outbound-auth.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_SECRETS_PERMS = ['secretsmanager:GetSecretValue'];
 
@@ -92,11 +101,13 @@ export const GATEWAY_SECRETS_PERMS = ['secretsmanager:GetSecretValue'];
 
 /**
  * Get permissions for gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_GET_PERMS = ['bedrock-agentcore:GetGatewayTarget', 'bedrock-agentcore:GetGateway'];
 
 /**
  * List permissions for gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_LIST_PERMS = [
   'bedrock-agentcore:ListGateways',
@@ -105,6 +116,7 @@ export const GATEWAY_LIST_PERMS = [
 
 /**
  * Create permissions for gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_CREATE_PERMS = [
   'bedrock-agentcore:CreateGateway',
@@ -113,6 +125,7 @@ export const GATEWAY_CREATE_PERMS = [
 
 /**
  * Update permissions for gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_UPDATE_PERMS = [
   'bedrock-agentcore:UpdateGateway',
@@ -121,6 +134,7 @@ export const GATEWAY_UPDATE_PERMS = [
 
 /**
  * Delete permissions for gateway resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_DELETE_PERMS = [
   'bedrock-agentcore:DeleteGateway',
@@ -129,11 +143,13 @@ export const GATEWAY_DELETE_PERMS = [
 
 /**
  * Combined manage permissions (create, update, delete)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_MANAGE_PERMS = [...new Set([...GATEWAY_CREATE_PERMS, ...GATEWAY_UPDATE_PERMS, ...GATEWAY_DELETE_PERMS])];
 
 /**
  * Synchronization permissions for MCP server targets
  * Used to refresh tool catalogs when MCP server tools change
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const GATEWAY_SYNC_PERMS = ['bedrock-agentcore:SynchronizeGatewayTargets'];

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/protocol.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/protocol.ts
@@ -6,6 +6,7 @@ import type { CfnGateway } from 'aws-cdk-lib/aws-bedrockagentcore';
 /**
  * The type of protocols
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum GatewayProtocolType {
   /**
@@ -20,6 +21,7 @@ export enum GatewayProtocolType {
 
 /**
  * Abstract interface for gateway protocol configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IGatewayProtocolConfig {
   /**
@@ -36,6 +38,7 @@ export interface IGatewayProtocolConfig {
 
 /**
  * Factory class for instantiating Gateway Protocols
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class GatewayProtocol {
   /**
@@ -56,6 +59,7 @@ export abstract class GatewayProtocol {
  * The Model Context Protocol uses string-based version identifiers following the format YYYY-MM-DD,
  * to indicate the last date backwards incompatible changes were made.
  * Versions are available at https://github.com/modelcontextprotocol/modelcontextprotocol/releases
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum MCPProtocolVersion {
   /**
@@ -68,6 +72,7 @@ export enum MCPProtocolVersion {
 
 /**
  * Search types supported by MCP gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum McpGatewaySearchType {
   /**
@@ -82,6 +87,7 @@ export enum McpGatewaySearchType {
  * MCP protocol configuration
  * The configuration for the Model Context Protocol (MCP).
  * This protocol enables communication between Amazon Bedrock Agent and external tools.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface McpConfiguration {
   /**
@@ -111,6 +117,7 @@ export interface McpConfiguration {
 
 /**
  * MCP (Model Context Protocol) configuration implementation
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class McpProtocolConfiguration implements IGatewayProtocolConfig {
   public readonly protocolType: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/api-schema.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/api-schema.ts
@@ -13,6 +13,7 @@ import { TargetSchema } from './base-schema';
  *****************************************************************************/
 /**
  * Represents the concept of an API Schema for a Gateway Target.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class ApiSchema extends TargetSchema {
   /**
@@ -83,6 +84,7 @@ export abstract class ApiSchema extends TargetSchema {
  *
  * The asset is uploaded to an S3 staging bucket, then moved to its final location
  * by CloudFormation during deployment.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class AssetApiSchema extends ApiSchema {
   private asset?: s3_assets.Asset;
@@ -150,6 +152,7 @@ export class AssetApiSchema extends ApiSchema {
  * Class to define an API Schema from an inline string.
  * The schema can be provided directly as a string.
  * Validation is performed at the target configuration level where the schema type is known.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class InlineApiSchema extends ApiSchema {
   constructor(private readonly schema: string) {
@@ -182,6 +185,7 @@ export class InlineApiSchema extends ApiSchema {
 // ------------------------------------------------------
 /**
  * Class to define an API Schema from an S3 object.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class S3ApiSchema extends ApiSchema {
   constructor(private readonly location: Location, public readonly bucketOwnerAccountId?: string) {

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/base-schema.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/base-schema.ts
@@ -5,6 +5,7 @@ import type { Construct } from 'constructs';
  * Base abstract class for all schema types used in Bedrock AgentCore Gateway Targets.
  * This provides a common interface for both API schemas and tool schemas.
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class TargetSchema {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/tool-schema.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/schema/tool-schema.ts
@@ -15,6 +15,7 @@ import { TargetSchema } from './base-schema';
 /**
  * Abstract interface for tool schema configuration
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IToolSchemaConfiguration {
   /**
@@ -30,6 +31,7 @@ export interface IToolSchemaConfiguration {
 
 /**
  * Schema definition types
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum SchemaDefinitionType {
   /** String type */
@@ -48,6 +50,7 @@ export enum SchemaDefinitionType {
 
 /**
  * Schema definition for tool input/output
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface SchemaDefinition {
   /**
@@ -91,6 +94,7 @@ export interface SchemaDefinition {
 
 /**
  * Tool definition for inline payload
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ToolDefinition {
   /**
@@ -121,6 +125,11 @@ export interface ToolDefinition {
 /******************************************************************************
  *                       TOOL SCHEMA CLASS
  *****************************************************************************/
+/**
+ * Defines the schema for tools available to a gateway target.
+ *
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export abstract class ToolSchema extends TargetSchema {
   /**
    * Creates a tool Schema from a local file.
@@ -190,6 +199,7 @@ export abstract class ToolSchema extends TargetSchema {
  *
  * The asset is uploaded to an S3 staging bucket, then moved to its final location
  * by CloudFormation during deployment.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class AssetToolSchema extends ToolSchema {
   private asset?: s3_assets.Asset;
@@ -250,6 +260,7 @@ export class AssetToolSchema extends ToolSchema {
 /**
  * Class to define a Tool Schema from an inline string.
  * The schema can be provided directly as a string in either JSON or YAML format.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class InlineToolSchema extends ToolSchema {
   constructor(private readonly schema: ToolDefinition[]) {
@@ -281,6 +292,7 @@ export class InlineToolSchema extends ToolSchema {
 // ------------------------------------------------------
 /**
  * Class to define a Tool Schema from an S3 object.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class S3ToolSchema extends ToolSchema {
   constructor(private readonly location: Location, public readonly bucketOwnerAccountId?: string) {

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target-base.ts
@@ -10,6 +10,7 @@ import type { ICredentialProviderConfig } from '../outbound-auth/credential-prov
  *****************************************************************************/
 /**
  * Protocol types supported by gateway targets
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum GatewayTargetProtocolType {
   /** Model Context Protocol type */
@@ -18,6 +19,7 @@ export enum GatewayTargetProtocolType {
 
 /**
  * MCP target types
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum McpTargetType {
   /** OpenAPI schema target type */
@@ -41,6 +43,7 @@ export enum McpTargetType {
  *
  * Represents a target that hosts tools for the gateway.
  * Targets can be Lambda functions, OpenAPI schemas, or Smithy models.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IGatewayTarget extends IResource, IGatewayTargetRef {
   /**
@@ -125,6 +128,7 @@ export interface IGatewayTarget extends IResource, IGatewayTargetRef {
  *
  * Extends the base gateway target interface with MCP-specific properties.
  * MCP targets expose tools using the Model Context Protocol.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IMcpGatewayTarget extends IGatewayTarget {
   /**
@@ -141,6 +145,7 @@ export interface IMcpGatewayTarget extends IGatewayTarget {
  *
  * Provides common functionality for all gateway target types including
  * permission management and property definitions.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class GatewayTargetBase extends Resource implements IGatewayTarget {
   public abstract readonly targetArn: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target-configuration.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target-configuration.ts
@@ -19,6 +19,7 @@ import { McpTargetType } from './target-base';
 
 /**
  * Configuration returned by binding a target configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface TargetConfigurationConfig {
   /**
@@ -29,6 +30,7 @@ export interface TargetConfigurationConfig {
 
 /**
  * Base interface for target configurations
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ITargetConfiguration {
   /**
@@ -56,6 +58,7 @@ export interface ITargetConfiguration {
 /**
  * Abstract base class for MCP target configurations
  * Provides common functionality for all MCP target types
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class McpTargetConfiguration implements ITargetConfiguration {
   /**
@@ -94,6 +97,7 @@ export abstract class McpTargetConfiguration implements ITargetConfiguration {
  *
  * This configuration wraps a Lambda function as MCP tools,
  * allowing the gateway to invoke the function to provide tool capabilities.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class LambdaTargetConfiguration extends McpTargetConfiguration {
   /**
@@ -167,6 +171,7 @@ export class LambdaTargetConfiguration extends McpTargetConfiguration {
  *
  * This configuration exposes an OpenAPI/REST API as MCP tools,
  * allowing the gateway to transform API operations into tool calls.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class OpenApiTargetConfiguration extends McpTargetConfiguration {
   /**
@@ -267,6 +272,7 @@ export class OpenApiTargetConfiguration extends McpTargetConfiguration {
  *
  * This configuration exposes a Smithy-modeled API as MCP tools,
  * allowing the gateway to transform Smithy operations into tool calls.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class SmithyTargetConfiguration extends McpTargetConfiguration {
   /**
@@ -328,6 +334,7 @@ export class SmithyTargetConfiguration extends McpTargetConfiguration {
  * functions for AI agents. When you configure an MCP server as a gateway target,
  * the gateway automatically discovers and indexes available tools through
  * synchronization.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class McpServerTargetConfiguration extends McpTargetConfiguration {
   /**
@@ -419,6 +426,7 @@ export class McpServerTargetConfiguration extends McpTargetConfiguration {
 
 /**
  * HTTP methods supported by API Gateway
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum ApiGatewayHttpMethod {
   /** GET method */
@@ -444,6 +452,7 @@ export enum ApiGatewayHttpMethod {
  * Each filter supports two path matching strategies:
  * - **Explicit paths**: Matches a single specific path, such as `/pets/{petId}`
  * - **Wildcard paths**: Matches all paths starting with the specified prefix, such as `/pets/*`
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiGatewayToolFilter {
   /**
@@ -468,6 +477,7 @@ export interface ApiGatewayToolFilter {
  * after filtering. Each override must specify an explicit path and a single HTTP method.
  * The override must match an operation that exists in your API and must correspond to one
  * of the operations resolved by your filters.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiGatewayToolOverride {
   /**
@@ -497,6 +507,7 @@ export interface ApiGatewayToolOverride {
 
 /**
  * Configuration for passing metadata (headers and query parameters) to the API Gateway target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface MetadataConfiguration {
   /**
@@ -542,6 +553,7 @@ export interface MetadataConfiguration {
  * The API Gateway tool configuration defines which operations from your REST API
  * are exposed as tools. It requires a list of tool filters to select operations
  * to expose, and optionally accepts tool overrides to customize tool metadata.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiGatewayToolConfiguration {
   /**
@@ -560,6 +572,7 @@ export interface ApiGatewayToolConfiguration {
 
 /**
  * Properties for creating an API Gateway target configuration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiGatewayTargetConfigurationProps {
   /**
@@ -600,6 +613,7 @@ export interface ApiGatewayTargetConfigurationProps {
  * - API must use a public endpoint type
  * - Methods with both AWS_IAM authorization and API key requirements are not supported
  * - Proxy resources (e.g., `/pets/{proxy+}`) are not supported
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ApiGatewayTargetConfiguration extends McpTargetConfiguration {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/targets/target.ts
@@ -26,6 +26,7 @@ import { validateStringField, validateFieldPattern } from '../validation-helpers
 
 /**
  * Common properties for all Gateway Target types
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetCommonProps {
   /**
@@ -46,6 +47,7 @@ export interface GatewayTargetCommonProps {
 
 /**
  * Properties for creating a Gateway Target resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetProps extends GatewayTargetCommonProps {
   /**
@@ -72,6 +74,7 @@ export interface GatewayTargetProps extends GatewayTargetCommonProps {
 /**
  * Properties for creating a Lambda-based Gateway Target
  * Convenience interface for the most common use case
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetLambdaProps extends GatewayTargetCommonProps {
   /**
@@ -99,6 +102,7 @@ export interface GatewayTargetLambdaProps extends GatewayTargetCommonProps {
 
 /**
  * Properties for creating an OpenAPI-based Gateway Target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetOpenApiProps extends GatewayTargetCommonProps {
   /**
@@ -129,6 +133,7 @@ export interface GatewayTargetOpenApiProps extends GatewayTargetCommonProps {
 
 /**
  * Properties for creating a Smithy-based Gateway Target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetSmithyProps extends GatewayTargetCommonProps {
   /**
@@ -151,6 +156,7 @@ export interface GatewayTargetSmithyProps extends GatewayTargetCommonProps {
 
 /**
  * Properties for creating an MCP Server-based Gateway Target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetMcpServerProps extends GatewayTargetCommonProps {
   /**
@@ -176,6 +182,7 @@ export interface GatewayTargetMcpServerProps extends GatewayTargetCommonProps {
 
 /**
  * Properties for creating an API Gateway-based Gateway Target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetApiGatewayProps extends GatewayTargetCommonProps {
   /**
@@ -219,6 +226,7 @@ export interface GatewayTargetApiGatewayProps extends GatewayTargetCommonProps {
 
 /**
  * Attributes for importing an existing Gateway Target
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayTargetAttributes {
   /**
@@ -275,6 +283,10 @@ export interface GatewayTargetAttributes {
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets.html
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class GatewayTarget extends GatewayTargetBase implements IMcpGatewayTarget {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.GatewayTarget';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/gateway/validation-helpers.ts
@@ -22,6 +22,7 @@ interface StringLengthValidation extends IntervalValidation {
  * @returns true if validation passes
  * @throws Error if validation fails with current length information
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateStringField(params: StringLengthValidation): string[] {
   const errors: string[] = [];
@@ -63,6 +64,7 @@ export function validateStringField(params: StringLengthValidation): string[] {
  * @returns true if validation passes
  * @throws Error if validation fails with detailed message
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateFieldPattern(
   value: string,
@@ -108,6 +110,7 @@ export type ValidationFn<T> = (param: T) => string[];
 /**
  * OpenAPI schema validation parameters
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OpenApiSchemaValidationParams {
   /**
@@ -364,6 +367,7 @@ function validateCallbacksAndWebhooks(schemaObj: any, schemaName: string, errors
  * @param params - The validation parameters
  * @returns Array of validation error messages (empty if valid)
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateOpenApiSchema(params: OpenApiSchemaValidationParams): string[] {
   const errors: string[] = [];

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/api-key-credential-provider.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/api-key-credential-provider.ts
@@ -39,6 +39,7 @@ import {
 
 /**
  * An API key credential provider registered in AgentCore Token Vault.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IApiKeyCredentialProvider extends IResource, iam.IGrantable, IApiKeyCredentialProviderRef {
   /**
@@ -102,6 +103,7 @@ export interface IApiKeyCredentialProvider extends IResource, iam.IGrantable, IA
 
 /**
  * Provider and secret ARNs for wiring a Token Vault API key identity into a gateway target.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayApiKeyIdentityBinding {
   /**
@@ -117,6 +119,7 @@ export interface GatewayApiKeyIdentityBinding {
 
 /**
  * Properties for a new {@link ApiKeyCredentialProvider} (Token Vault resource).
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiKeyCredentialProviderResourceProps {
   /**
@@ -151,6 +154,7 @@ export interface ApiKeyCredentialProviderResourceProps {
 
 /**
  * Attributes for importing an existing API key credential provider.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ApiKeyCredentialProviderAttributes {
   /**
@@ -299,6 +303,10 @@ abstract class ApiKeyCredentialProviderBase extends Resource implements IApiKeyC
  * @resource AWS::BedrockAgentCore::ApiKeyCredentialProvider
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class ApiKeyCredentialProvider extends ApiKeyCredentialProviderBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.ApiKeyCredentialProvider';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/grant-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/grant-helpers.ts
@@ -26,6 +26,7 @@ import type { IConstruct } from 'constructs';
  *   - token-vault/default/apikeycredentialprovider/*  (instance)
  *
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const TOKEN_VAULT_API_KEY_PARENT_RESOURCES = [
   'token-vault/default',
@@ -34,6 +35,7 @@ export const TOKEN_VAULT_API_KEY_PARENT_RESOURCES = [
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const TOKEN_VAULT_OAUTH2_PARENT_RESOURCES = [
   'token-vault/default',
@@ -42,6 +44,7 @@ export const TOKEN_VAULT_OAUTH2_PARENT_RESOURCES = [
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const WORKLOAD_IDENTITY_PARENT_RESOURCES = [
   'workload-identity-directory/default',
@@ -57,6 +60,7 @@ export const WORKLOAD_IDENTITY_PARENT_RESOURCES = [
  * by the gateway/service at runtime.
  *
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const WORKLOAD_IDENTITY_USE_RESOURCES = [
   'workload-identity-directory/default',
@@ -68,6 +72,7 @@ export const WORKLOAD_IDENTITY_USE_RESOURCES = [
  * plus all parent/collection ARNs that the service's authorization model requires.
  *
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function buildIdentityResourceArns(
   scope: IConstruct,
@@ -90,6 +95,7 @@ export function buildIdentityResourceArns(
  * parent/collection ARNs required by the Bedrock AgentCore authorization model.
  *
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function grantReadWithList(
   scope: IConstruct,
@@ -119,6 +125,7 @@ export function grantReadWithList(
  * supplied (e.g. via `fromApiKeyCredentialProviderAttributes`), we scope tightly.
  *
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function grantCredentialSecret(
   scope: IConstruct,

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/oauth2-credential-provider.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/oauth2-credential-provider.ts
@@ -40,6 +40,7 @@ import {
  * Built-in OAuth2 vendors supported by `AWS::BedrockAgentCore::OAuth2CredentialProvider`.
  *
  * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-bedrockagentcore-oauth2credentialprovider.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum OAuth2CredentialProviderVendor {
   /** Google OAuth2. */
@@ -100,6 +101,7 @@ export enum OAuth2CredentialProviderVendor {
 
 /**
  * An OAuth2 credential provider registered in AgentCore Token Vault.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IOAuth2CredentialProvider extends IResource, iam.IGrantable, IOAuth2CredentialProviderRef {
   /**
@@ -174,6 +176,7 @@ export interface IOAuth2CredentialProvider extends IResource, iam.IGrantable, IO
 
 /**
  * Provider ARN, secret ARN, and OAuth scopes for wiring a Token Vault OAuth2 identity into a gateway target.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GatewayOAuth2IdentityBinding {
   /**
@@ -201,6 +204,7 @@ export interface GatewayOAuth2IdentityBinding {
 
 /**
  * Shared properties for OAuth2 credential providers created via {@link OAuth2CredentialProvider} factory methods.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2CredentialProviderBaseProps {
   /**
@@ -220,6 +224,7 @@ export interface OAuth2CredentialProviderBaseProps {
 
 /**
  * OAuth2 client identifier and secret registered with the identity provider (all vendors).
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2ClientCredentials {
   /** OAuth2 client identifier. */
@@ -238,36 +243,42 @@ export interface OAuth2ClientCredentials {
 
 /**
  * Naming, tags, and client credentials shared by every {@link OAuth2CredentialProvider} factory.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2CredentialProviderFactoryBaseProps extends OAuth2CredentialProviderBaseProps, OAuth2ClientCredentials {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingSlack}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface SlackOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingGithub}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GithubOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingGoogle}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface GoogleOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingSalesforce}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface SalesforceOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingMicrosoft}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface MicrosoftOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
   /**
@@ -280,12 +291,14 @@ export interface MicrosoftOAuth2CredentialProviderProps extends OAuth2Credential
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingAtlassian}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AtlassianOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
 
 /**
  * Props for {@link OAuth2CredentialProvider.usingLinkedin}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface LinkedinOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -294,6 +307,7 @@ export interface LinkedinOAuth2CredentialProviderProps extends OAuth2CredentialP
  * Props for {@link OAuth2CredentialProvider.usingFacebook}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-facebook.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface FacebookOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -302,6 +316,7 @@ export interface FacebookOAuth2CredentialProviderProps extends OAuth2CredentialP
  * Props for {@link OAuth2CredentialProvider.usingX}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-x.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface XOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -310,6 +325,7 @@ export interface XOAuth2CredentialProviderProps extends OAuth2CredentialProvider
  * Props for {@link OAuth2CredentialProvider.usingYandex}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-yandex.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface YandexOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -318,6 +334,7 @@ export interface YandexOAuth2CredentialProviderProps extends OAuth2CredentialPro
  * Props for {@link OAuth2CredentialProvider.usingReddit}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-reddit.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RedditOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -326,6 +343,7 @@ export interface RedditOAuth2CredentialProviderProps extends OAuth2CredentialPro
  * Props for {@link OAuth2CredentialProvider.usingZoom}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-zoom.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ZoomOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -334,6 +352,7 @@ export interface ZoomOAuth2CredentialProviderProps extends OAuth2CredentialProvi
  * Props for {@link OAuth2CredentialProvider.usingTwitch}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-twitch.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface TwitchOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -342,6 +361,7 @@ export interface TwitchOAuth2CredentialProviderProps extends OAuth2CredentialPro
  * Props for {@link OAuth2CredentialProvider.usingSpotify}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-spotify.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface SpotifyOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -350,6 +370,7 @@ export interface SpotifyOAuth2CredentialProviderProps extends OAuth2CredentialPr
  * Props for {@link OAuth2CredentialProvider.usingDropbox}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-dropbox.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface DropboxOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -358,6 +379,7 @@ export interface DropboxOAuth2CredentialProviderProps extends OAuth2CredentialPr
  * Props for {@link OAuth2CredentialProvider.usingNotion}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-notion.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface NotionOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -366,6 +388,7 @@ export interface NotionOAuth2CredentialProviderProps extends OAuth2CredentialPro
  * Props for {@link OAuth2CredentialProvider.usingHubspot}.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idp-hubspot.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface HubspotOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
 }
@@ -373,6 +396,7 @@ export interface HubspotOAuth2CredentialProviderProps extends OAuth2CredentialPr
 /**
  * Optional tenant OAuth endpoints for IdPs that use CloudFormation `IncludedOauth2ProviderConfig`
  * with issuer and/or endpoints per the IdP’s outbound documentation.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IncludedOauth2TenantEndpoints {
   /**
@@ -399,6 +423,7 @@ export interface IncludedOauth2TenantEndpoints {
  * Props for `IncludedOauth2ProviderConfig` IdPs whose [outbound documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-idps.html)
  * requires `issuer`, `authorizationEndpoint`, and/or `tokenEndpoint` (for example Okta, Auth0, Amazon Cognito, OneLogin,
  * PingOne, CyberArk, FusionAuth).
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IncludedOauth2TenantCredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps, IncludedOauth2TenantEndpoints {
 }
@@ -407,6 +432,7 @@ export interface IncludedOauth2TenantCredentialProviderProps extends OAuth2Crede
  * Static OAuth2 authorization server metadata for custom credential providers.
  *
  * @see https://www.rfc-editor.org/rfc/rfc8414
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2AuthorizationServerMetadata {
   /**
@@ -437,6 +463,7 @@ export interface OAuth2AuthorizationServerMetadata {
  *
  * Set exactly one of {@link discoveryUrl} (OIDC discovery document) or {@link authorizationServerMetadata}
  * (static OAuth2 server metadata). Do not pass both.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CustomOAuth2CredentialProviderProps extends OAuth2CredentialProviderFactoryBaseProps {
   /**
@@ -455,6 +482,7 @@ export interface CustomOAuth2CredentialProviderProps extends OAuth2CredentialPro
 
 /**
  * Low-level properties when you need full control (prefer {@link OAuth2CredentialProvider.usingSlack} and other factories).
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2CredentialProviderProps {
   /**
@@ -484,6 +512,7 @@ export interface OAuth2CredentialProviderProps {
 
 /**
  * Attributes for importing an existing OAuth2 credential provider.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OAuth2CredentialProviderAttributes {
   /**
@@ -754,6 +783,10 @@ function newOAuth2WithIncludedTenant(
  * @resource AWS::BedrockAgentCore::OAuth2CredentialProvider
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class OAuth2CredentialProvider extends OAuth2CredentialProviderBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.OAuth2CredentialProvider';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/perms.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/perms.ts
@@ -19,6 +19,7 @@
  * `bedrock-agentcore` data-plane actions and read access to the backing secret.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-iam-awsmanpol.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const TOKEN_VAULT_CREDENTIAL_SECRET_READ_PERMS = [
   'secretsmanager:GetSecretValue',
@@ -31,6 +32,7 @@ export const TOKEN_VAULT_CREDENTIAL_SECRET_READ_PERMS = [
  * Create and Update control plane operations (e.g. CreateApiKeyCredentialProvider,
  * UpdateApiKeyCredentialProvider) store/update the credential in Secrets Manager,
  * requiring PutSecretValue on the backing secret.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const TOKEN_VAULT_CREDENTIAL_SECRET_WRITE_PERMS = [
   'secretsmanager:PutSecretValue',
@@ -40,6 +42,7 @@ export const TOKEN_VAULT_CREDENTIAL_SECRET_WRITE_PERMS = [
  * IAM actions for AgentCore API key credential providers (Token Vault).
  *
  * @see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ApiKeyCredentialProviderIdentityPerms {
   /**
@@ -86,6 +89,7 @@ export class ApiKeyCredentialProviderIdentityPerms {
  * IAM actions for AgentCore OAuth2 credential providers (Token Vault).
  *
  * @see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class OAuth2CredentialProviderIdentityPerms {
   /**
@@ -135,6 +139,7 @@ export class OAuth2CredentialProviderIdentityPerms {
  * IAM actions for AgentCore workload identities.
  *
  * @see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class WorkloadIdentityPerms {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/validation-helpers.ts
@@ -16,43 +16,92 @@ import type { IConstruct } from 'constructs';
 import { validateFieldPattern, validateStringFieldLength, throwIfInvalid } from '../memory/validation-helpers';
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const CREDENTIAL_PROVIDER_NAME_MIN = 1;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const CREDENTIAL_PROVIDER_NAME_MAX = 128;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const CREDENTIAL_PROVIDER_NAME_PATTERN = /^[a-zA-Z0-9\-_]+$/;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const API_KEY_VALUE_MIN = 1;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const API_KEY_VALUE_MAX = 65536;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const CREDENTIAL_PROVIDER_TAG_MIN = 1;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const CREDENTIAL_PROVIDER_TAG_MAX = 256;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const WORKLOAD_IDENTITY_NAME_MIN = 3;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const WORKLOAD_IDENTITY_NAME_MAX = 255;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const WORKLOAD_IDENTITY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const ALLOWED_OAUTH2_RETURN_URL_MIN = 1;
 
 /** @internal */
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export const ALLOWED_OAUTH2_RETURN_URL_MAX = 2048;
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateWorkloadIdentityName(name: string, scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -74,6 +123,7 @@ export function validateWorkloadIdentityName(name: string, scope?: IConstruct): 
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateAllowedResourceOauth2ReturnUrls(urls: string[] | undefined, scope?: IConstruct): string[] {
   if (urls == null) {
@@ -103,6 +153,7 @@ export function validateAllowedResourceOauth2ReturnUrls(urls: string[] | undefin
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateCredentialProviderName(name: string, scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -124,6 +175,7 @@ export function validateCredentialProviderName(name: string, scope?: IConstruct)
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateApiKeyValue(apiKey: string | undefined, scope?: IConstruct): string[] {
   if (apiKey == null || apiKey === '') {
@@ -142,6 +194,7 @@ export function validateApiKeyValue(apiKey: string | undefined, scope?: IConstru
 
 /**
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateCredentialProviderTags(tags?: { [key: string]: string }, scope?: IConstruct): string[] {
   let errors: string[] = [];

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/workload-identity.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/identity/workload-identity.ts
@@ -40,6 +40,7 @@ import {
  * for consistent authentication across environments.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/understanding-agent-identities.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IWorkloadIdentity extends IResource, iam.IGrantable, IWorkloadIdentityRef {
   /**
@@ -97,6 +98,7 @@ export interface IWorkloadIdentity extends IResource, iam.IGrantable, IWorkloadI
 
 /**
  * Properties for a new {@link WorkloadIdentity}.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface WorkloadIdentityProps {
   /**
@@ -123,6 +125,7 @@ export interface WorkloadIdentityProps {
 
 /**
  * Attributes for importing an existing workload identity.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface WorkloadIdentityAttributes {
   /**
@@ -240,6 +243,10 @@ abstract class WorkloadIdentityBase extends Resource implements IWorkloadIdentit
  * @resource AWS::BedrockAgentCore::WorkloadIdentity
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class WorkloadIdentity extends WorkloadIdentityBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.WorkloadIdentity';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/memory-strategy.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/memory-strategy.ts
@@ -25,16 +25,19 @@ import { SelfManagedMemoryStrategy } from './strategies/self-managed-strategy';
 /**
  * Minimum length for memory strategy name
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const MEMORY_NAME_MIN_LENGTH = 1;
 /**
  * Maximum length for memory strategy name
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const MEMORY_NAME_MAX_LENGTH = 48;
 
 /**
  * Long-term memory extraction strategy types.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum MemoryStrategyType {
   /**
@@ -65,6 +68,7 @@ export enum MemoryStrategyType {
  *****************************************************************************/
 /**
  * Configuration parameters common for any memory strategy
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface MemoryStrategyCommonProps {
   /**
@@ -83,6 +87,7 @@ export interface MemoryStrategyCommonProps {
  *****************************************************************************/
 /**
  * Interface for Memory strategies
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IMemoryStrategy {
   /**
@@ -118,6 +123,7 @@ export interface IMemoryStrategy {
  * Use built-in strategies for quick setup, use built-in strategies with override to specify models and prompt templates.
  *
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-strategies.html
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class MemoryStrategy {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/memory.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/memory.ts
@@ -77,6 +77,7 @@ const MEMORY_EXPIRATION_DAYS_MAX = 365;
  *****************************************************************************/
 /**
  * Interface for Memory resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IMemory extends IResource, iam.IGrantable, IMemoryRef {
   /**
@@ -189,6 +190,7 @@ export interface IMemory extends IResource, iam.IGrantable, IMemoryRef {
 /**
  * Abstract base class for a Memory.
  * Contains methods and attributes valid for Memories either created with CDK or imported.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class MemoryBase extends Resource implements IMemory {
   public abstract readonly memoryArn: string;
@@ -470,6 +472,7 @@ export abstract class MemoryBase extends Resource implements IMemory {
  *****************************************************************************/
 /**
  * Properties for creating a Memory resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface MemoryProps {
   /**
@@ -526,6 +529,7 @@ export interface MemoryProps {
  *****************************************************************************/
 /**
  * Attributes for specifying an imported Memory.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface MemoryAttributes {
   /**
@@ -572,6 +576,10 @@ export interface MemoryAttributes {
  * @resource AWS::BedrockAgentCore::Memory
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class Memory extends MemoryBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.Memory';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/strategies/managed-strategy.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/strategies/managed-strategy.ts
@@ -36,6 +36,7 @@ const PROMPT_MAX_LENGTH = 30000;
 
 /**
  * Configuration for overriding model and prompt template
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface OverrideConfig {
   /**
@@ -55,6 +56,7 @@ export interface OverrideConfig {
 
 /**
  * Configuration for episodic memory reflection
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface EpisodicReflectionConfiguration {
   /**
@@ -67,6 +69,7 @@ export interface EpisodicReflectionConfiguration {
 /**
  * Configuration parameters for a memory strategy that can override
  * existing built-in default prompts/models
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ManagedStrategyProps extends MemoryStrategyCommonProps {
   /**
@@ -114,6 +117,7 @@ export interface ManagedStrategyProps extends MemoryStrategyCommonProps {
  * Managed memory strategy that handles both built-in and override configurations.
  * This strategy can be used for quick setup with built-in defaults or customized
  * with specific models and prompt templates.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class ManagedMemoryStrategy implements IMemoryStrategy {
   public readonly name: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/strategies/self-managed-strategy.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/strategies/self-managed-strategy.ts
@@ -88,6 +88,7 @@ const DEFAULT_TOKEN_BASED_TRIGGER = 100;
 /**
  * Trigger conditions for self managed memory strategy
  * When first condition is met, batched payloads are sent to specified S3 bucket.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface TriggerConditions {
   /**
@@ -110,6 +111,7 @@ export interface TriggerConditions {
 
 /**
  * Invocation configuration for self managed memory strategy
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface InvocationConfiguration {
   /**
@@ -125,6 +127,7 @@ export interface InvocationConfiguration {
 /**
  * Configuration parameters for a self managed memory strategy
  * existing built-in default prompts/models
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface SelfManagedStrategyProps extends MemoryStrategyCommonProps {
   /**
@@ -145,6 +148,7 @@ export interface SelfManagedStrategyProps extends MemoryStrategyCommonProps {
 
 /**
  * Use AgentCore memory for event storage with custom triggers. Define memory processing logic in your own environment.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class SelfManagedMemoryStrategy implements IMemoryStrategy {
   public readonly name: string;

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/memory/validation-helpers.ts
@@ -30,6 +30,7 @@ interface StringLengthValidation extends IntervalValidation {
  * @param params - Validation parameters including value, fieldName, minLength, and maxLength
  * @param scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateStringFieldLength(params: StringLengthValidation, _scope?: IConstruct): string[] {
   const errors: string[] = [];
@@ -67,6 +68,7 @@ export function validateStringFieldLength(params: StringLengthValidation, _scope
  * @param customMessage - Optional custom error message
  * @param scope - The construct scope for error reporting (optional)
  * @returns Array of validation error messages, empty if valid
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateFieldPattern(
   value: string,
@@ -105,6 +107,10 @@ export function validateFieldPattern(
 
 export type ValidationFn<T> = (param: T, scope?: IConstruct) => string[];
 
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export function throwIfInvalid<T>(validationFn: ValidationFn<T>, param: T, scope?: IConstruct): T {
   const errors = validationFn(param, scope);
   if (errors.length > 0) {

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/network/network-configuration.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/network/network-configuration.ts
@@ -7,6 +7,7 @@ import type { Construct } from 'constructs';
 /**
  * VPC configuration properties.
  * Only used when network mode is VPC.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface VpcConfigProps {
   /**
@@ -64,6 +65,7 @@ interface NetworkConfig {
 
 /**
  * Abstract base class for network configuration.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class NetworkConfiguration {
   /**
@@ -140,6 +142,7 @@ export abstract class NetworkConfiguration {
 
 /**
  * Network configuration for the Browser tool.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class BrowserNetworkConfiguration extends NetworkConfiguration {
   /**
@@ -178,6 +181,7 @@ export class BrowserNetworkConfiguration extends NetworkConfiguration {
 
 /**
  * Network configuration for the Code Interpreter tool.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class CodeInterpreterNetworkConfiguration extends NetworkConfiguration {
   /**
@@ -225,6 +229,7 @@ export class CodeInterpreterNetworkConfiguration extends NetworkConfiguration {
 
 /**
  * Network configuration for the Runtime.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class RuntimeNetworkConfiguration extends NetworkConfiguration {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/inbound-auth/custom-claim.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/inbound-auth/custom-claim.ts
@@ -21,6 +21,7 @@ import { CustomClaimOperator, CustomClaimValueType } from '../../common/types';
  * Represents a custom claim validation configuration for Runtime JWT authorizers.
  * Custom claims allow you to validate additional fields in JWT tokens beyond
  * the standard audience, client, and scope validations.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class RuntimeCustomClaim {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/inbound-auth/runtime-authorizer-configuration.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/inbound-auth/runtime-authorizer-configuration.ts
@@ -21,6 +21,7 @@ import type { RuntimeCustomClaim } from './custom-claim';
 /**
  * Abstract base class for runtime authorizer configurations.
  * Provides static factory methods to create different authentication types.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class RuntimeAuthorizerConfiguration {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/observability.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/observability.ts
@@ -13,6 +13,7 @@ const MAX_DELIVERY_NAME_LENGTH = 60;
 
 /**
  * Log types for AgentCore Runtime observability
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export class LogType {
   /**
@@ -44,6 +45,7 @@ export class LogType {
 
 /**
  * Configuration for logging with log type and destination
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface LoggingConfig {
   /**
@@ -75,6 +77,7 @@ interface LoggingDestinationBindConfig {
  * - `LoggingDestination.cloudWatchLogs(logGroup)` - Send logs to CloudWatch Logs
  * - `LoggingDestination.s3(bucket)` - Send logs to S3
  * - `LoggingDestination.firehose(stream)` - Send logs to Kinesis Data Firehose
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class LoggingDestination {
   /**
@@ -261,6 +264,7 @@ class XRayResourcePolicy extends Construct {
  * @param scope The construct scope
  * @param sourceArn The ARN of the source resource (runtime)
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function configureTracingDelivery(
   scope: Construct,
@@ -338,6 +342,7 @@ export function configureTracingDelivery(
  * @param sourceArn The ARN of the source resource (runtime)
  * @param loggingConfigs Array of logging configurations
  * @internal
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function configureLoggingDelivery(
   scope: Construct,

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/perms.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/perms.ts
@@ -3,12 +3,14 @@
  *****************************************************************************/
 /**
  * Permissions to invoke the agent runtime
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_INVOKE_PERMS = ['bedrock-agentcore:InvokeAgentRuntime'];
 
 /**
  * Permissions to invoke the agent runtime on behalf of a user
  * Required when using the X-Amzn-Bedrock-AgentCore-Runtime-User-Id header
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_INVOKE_USER_PERMS = ['bedrock-agentcore:InvokeAgentRuntimeForUser'];
 
@@ -17,6 +19,7 @@ export const RUNTIME_INVOKE_USER_PERMS = ['bedrock-agentcore:InvokeAgentRuntimeF
  *****************************************************************************/
 /**
  * Grants control plane operations to manage the runtime (CRUD)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_ADMIN_PERMS = [
   'bedrock-agentcore:CreateAgentRuntime',
@@ -39,6 +42,7 @@ export const RUNTIME_ADMIN_PERMS = [
 /**
  * ECR permissions for pulling container images
  * Used to download container images from ECR repositories
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_ECR_IMAGE_ACTIONS = [
   'ecr:BatchGetImage',
@@ -48,12 +52,14 @@ export const RUNTIME_ECR_IMAGE_ACTIONS = [
 /**
  * ECR authorization token permissions
  * Required to authenticate with ECR (must use * resource)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_ECR_TOKEN_ACTIONS = ['ecr:GetAuthorizationToken'];
 
 /**
  * CloudWatch Logs permissions for log group operations
  * Used to create and describe log groups for runtime logs
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_LOGS_GROUP_ACTIONS = [
   'logs:DescribeLogStreams',
@@ -63,12 +69,14 @@ export const RUNTIME_LOGS_GROUP_ACTIONS = [
 /**
  * CloudWatch Logs describe permissions
  * Used to list and describe all log groups
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_LOGS_DESCRIBE_ACTIONS = ['logs:DescribeLogGroups'];
 
 /**
  * CloudWatch Logs permissions for log stream operations
  * Used to create log streams and write log events
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_LOGS_STREAM_ACTIONS = [
   'logs:CreateLogStream',
@@ -78,6 +86,7 @@ export const RUNTIME_LOGS_STREAM_ACTIONS = [
 /**
  * X-Ray tracing permissions
  * Required for distributed tracing (must use * resource)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_XRAY_ACTIONS = [
   'xray:PutTraceSegments',
@@ -89,12 +98,14 @@ export const RUNTIME_XRAY_ACTIONS = [
 /**
  * CloudWatch metrics permissions
  * Used to publish custom metrics
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_CLOUDWATCH_METRICS_ACTIONS = ['cloudwatch:PutMetricData'];
 
 /**
  * Bedrock AgentCore workload identity permissions
  * Used to obtain access tokens for workload identity
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_WORKLOAD_IDENTITY_ACTIONS = [
   'bedrock-agentcore:GetWorkloadAccessToken',
@@ -104,5 +115,6 @@ export const RUNTIME_WORKLOAD_IDENTITY_ACTIONS = [
 /**
  * CloudWatch namespace for metrics
  * Used as a condition for CloudWatch metrics permissions
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const RUNTIME_CLOUDWATCH_NAMESPACE = 'bedrock-agentcore';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-artifact.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-artifact.ts
@@ -25,6 +25,7 @@ import type { Runtime } from './runtime';
 /**
  * Bedrock AgentCore runtime environment for code execution
  * Allowed values: PYTHON_3_10 | PYTHON_3_11 | PYTHON_3_12 | PYTHON_3_13 | PYTHON_3_14 | NODE_22
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum AgentCoreRuntime {
   /**
@@ -55,6 +56,7 @@ export enum AgentCoreRuntime {
 
 /**
  * Options for configuring an S3 code asset from local files for agent runtime artifact
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CodeAssetOptions extends s3_assets.AssetOptions {
   /**
@@ -76,6 +78,7 @@ export interface CodeAssetOptions extends s3_assets.AssetOptions {
 /**
  * Abstract base class for agent runtime artifacts.
  * Provides methods to reference container images from ECR repositories or local assets.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class AgentRuntimeArtifact {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-base.ts
@@ -36,6 +36,7 @@ import { RUNTIME_INVOKE_PERMS, RUNTIME_INVOKE_USER_PERMS } from './perms';
 
 /**
  * Interface for Agent Runtime resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IBedrockAgentRuntime extends IResource, iam.IGrantable, ec2.IConnectable, IRuntimeRef {
   /**
@@ -193,6 +194,7 @@ export interface IBedrockAgentRuntime extends IResource, iam.IGrantable, ec2.ICo
 
 /**
  * Base class for Agent Runtime
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class RuntimeBase extends Resource implements IBedrockAgentRuntime {
   // Abstract properties
@@ -414,6 +416,7 @@ export abstract class RuntimeBase extends Resource implements IBedrockAgentRunti
 
 /**
  * Attributes for importing an existing Agent Runtime
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AgentRuntimeAttributes {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-endpoint-base.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-endpoint-base.ts
@@ -22,6 +22,7 @@ import type { Construct } from 'constructs';
 
 /**
  * Interface for Runtime Endpoint resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IRuntimeEndpoint extends IResource, IRuntimeEndpointRef {
   /**
@@ -78,6 +79,7 @@ export interface IRuntimeEndpoint extends IResource, IRuntimeEndpointRef {
 
 /**
  * Base class for Runtime Endpoint
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class RuntimeEndpointBase extends Resource implements IRuntimeEndpoint {
   public abstract readonly agentRuntimeEndpointArn: string;
@@ -105,6 +107,7 @@ export abstract class RuntimeEndpointBase extends Resource implements IRuntimeEn
 
 /**
  * Attributes for importing an existing Runtime Endpoint
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RuntimeEndpointAttributes {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-endpoint.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime-endpoint.ts
@@ -15,6 +15,7 @@ import { validateStringField, validateFieldPattern } from './validation-helpers'
 
 /**
  * Properties for creating a Bedrock Agent Core Runtime Endpoint resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RuntimeEndpointProps {
   /**
@@ -69,6 +70,10 @@ export interface RuntimeEndpointProps {
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-endpoint.html
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class RuntimeEndpoint extends RuntimeEndpointBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.RuntimeEndpoint';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/runtime.ts
@@ -51,6 +51,7 @@ const LIFECYCLE_MAX_LIFETIME = Duration.seconds(28800);
 
 /**
  * Properties for creating a Bedrock Agent Core Runtime resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RuntimeProps {
   /**
@@ -150,6 +151,7 @@ export interface RuntimeProps {
 
 /**
  * Options for adding an endpoint to the runtime
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface AddEndpointOptions {
   /**
@@ -177,6 +179,10 @@ export interface AddEndpointOptions {
  * @see https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class Runtime extends RuntimeBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.Runtime';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/types.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/types.ts
@@ -9,6 +9,7 @@ import type { Duration } from 'aws-cdk-lib';
  * Protocol configuration for Agent Runtime
  *
  * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-bedrockagentcore-runtime.html#cfn-bedrockagentcore-runtime-protocolconfiguration
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum ProtocolType {
   /**
@@ -34,6 +35,7 @@ export enum ProtocolType {
 
 /**
  * Configuration for HTTP request headers that will be passed through to the runtime.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RequestHeaderConfiguration {
   /**
@@ -47,6 +49,7 @@ export interface RequestHeaderConfiguration {
  * LifecycleConfiguration lets you manage the lifecycle of runtime sessions and resources in AgentCore Runtime.
  * This configuration helps optimize resource utilization by automatically cleaning up idle sessions and preventing
  * long-running instances from consuming resources indefinitely.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface LifecycleConfiguration {
   /**

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/runtime/validation-helpers.ts
@@ -20,6 +20,7 @@ interface StringLengthValidation extends IntervalValidation {
  * @param maxLength - Maximum allowed length
  * @returns true if validation passes
  * @throws Error if validation fails with current length information
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateStringField(params: StringLengthValidation): string[] {
   const errors: string[] = [];
@@ -57,6 +58,7 @@ export function validateStringField(params: StringLengthValidation): string[] {
  * @param customMessage - Optional custom error message
  * @returns true if validation passes
  * @throws Error if validation fails with detailed message
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateFieldPattern(
   value: string,
@@ -94,6 +96,10 @@ export function validateFieldPattern(
 
 export type ValidationFn<T> = (param: T) => string[];
 
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export function throwIfInvalid<T>(validationFn: ValidationFn<T>, param: T): T {
   const errors = validationFn(param);
   if (errors.length > 0) {

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/browser.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/browser.ts
@@ -70,6 +70,7 @@ const BROWSER_TAG_MAX_LENGTH = 256;
  * Browser signing. Specifies whether browser signing is enabled.
  * When enabled, the browser will cryptographically sign HTTP requests to identify
  * itself as an AI agent to bot control vendors.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export enum BrowserSigning {
   /**
@@ -88,6 +89,7 @@ export enum BrowserSigning {
 
 /**
  * Interface for Browser resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface IBrowserCustom extends IResource, iam.IGrantable, ec2.IConnectable, IBrowserCustomRef {
   /**
@@ -208,6 +210,7 @@ export interface IBrowserCustom extends IResource, iam.IGrantable, ec2.IConnecta
 /**
  * Abstract base class for a Browser.
  * Contains methods and attributes valid for Browsers either created with CDK or imported.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class BrowserCustomBase extends Resource implements IBrowserCustom {
   public abstract readonly browserArn: string;
@@ -505,6 +508,7 @@ export abstract class BrowserCustomBase extends Resource implements IBrowserCust
 
 /**
  * Recording configuration for browser
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface RecordingConfig {
   /**
@@ -525,6 +529,7 @@ export interface RecordingConfig {
  *****************************************************************************/
 /**
  * Properties for creating a Browser resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface BrowserCustomProps {
   /**
@@ -589,6 +594,7 @@ export interface BrowserCustomProps {
  *****************************************************************************/
 /**
  * Attributes for specifying an imported Browser Custom.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface BrowserCustomAttributes {
   /**
@@ -635,6 +641,10 @@ export interface BrowserCustomAttributes {
  * @resource AWS::BedrockAgentCore::BrowserCustom
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class BrowserCustom extends BrowserCustomBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.BrowserCustom';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/code-interpreter.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/code-interpreter.ts
@@ -65,6 +65,7 @@ const CODE_INTERPRETER_TAG_MAX_LENGTH = 256;
  *****************************************************************************/
 /**
  * Interface for CodeInterpreterCustom resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface ICodeInterpreterCustom extends IResource, iam.IGrantable, ec2.IConnectable, ICodeInterpreterCustomRef {
   /**
@@ -172,6 +173,7 @@ export interface ICodeInterpreterCustom extends IResource, iam.IGrantable, ec2.I
 /**
  * Abstract base class for a Code Interpreter.
  * Contains methods and attributes valid for Code Interpreters either created with CDK or imported.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export abstract class CodeInterpreterCustomBase extends Resource implements ICodeInterpreterCustom {
   public abstract readonly codeInterpreterArn: string;
@@ -444,6 +446,7 @@ export abstract class CodeInterpreterCustomBase extends Resource implements ICod
  *****************************************************************************/
 /**
  * Properties for creating a CodeInterpreter resource
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CodeInterpreterCustomProps {
   /**
@@ -494,6 +497,7 @@ export interface CodeInterpreterCustomProps {
  *****************************************************************************/
 /**
  * Attributes for specifying an imported Code Interpreter Custom.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export interface CodeInterpreterCustomAttributes {
   /**
@@ -540,6 +544,10 @@ export interface CodeInterpreterCustomAttributes {
  * @resource AWS::BedrockAgentCore::CodeInterpreterCustom
  */
 @propertyInjectable
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export class CodeInterpreterCustom extends CodeInterpreterCustomBase {
   /** Uniquely identifies this class. */
   public static readonly PROPERTY_INJECTION_ID: string = '@aws-cdk.aws-bedrock-agentcore-alpha.CodeInterpreterCustom';

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/perms.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/perms.ts
@@ -10,6 +10,7 @@
    *****************************************************************************/
 /**
  * Permissions to manage a specific browser session
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_SESSION_PERMS = [
   'bedrock-agentcore:GetBrowserSession',
@@ -20,6 +21,7 @@ export const BROWSER_SESSION_PERMS = [
 
 /**
  * Permissions to connect to a browser live view or automation stream
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_STREAM_PERMS = [
   'bedrock-agentcore:UpdateBrowserStream',
@@ -32,6 +34,7 @@ export const BROWSER_STREAM_PERMS = [
    *****************************************************************************/
 /**
  * Grants control plane operations to manage the browser (CRUD)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_ADMIN_PERMS = [
   'bedrock-agentcore:CreateBrowser',
@@ -42,6 +45,7 @@ export const BROWSER_ADMIN_PERMS = [
 
 /**
  * Permissions for reading browser information
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_READ_PERMS = [
   'bedrock-agentcore:GetBrowser',
@@ -50,6 +54,7 @@ export const BROWSER_READ_PERMS = [
 
 /**
  * Permissions for listing browser resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_LIST_PERMS = [
   'bedrock-agentcore:ListBrowsers',
@@ -58,6 +63,7 @@ export const BROWSER_LIST_PERMS = [
 
 /**
  * Permissions for using browser functionality
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const BROWSER_USE_PERMS = [
   'bedrock-agentcore:StartBrowserSession',
@@ -77,6 +83,7 @@ export const BROWSER_USE_PERMS = [
    *****************************************************************************/
 /**
  * Permissions to manage a specific code interpreter session
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_SESSION_PERMS = [
   'bedrock-agentcore:GetCodeInterpreterSession',
@@ -87,6 +94,7 @@ export const CODE_INTERPRETER_SESSION_PERMS = [
 
 /**
  * Permissions to invoke a code interpreter
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_INVOKE_PERMS = ['bedrock-agentcore:InvokeCodeInterpreter'];
 
@@ -95,6 +103,7 @@ export const CODE_INTERPRETER_INVOKE_PERMS = ['bedrock-agentcore:InvokeCodeInter
    *****************************************************************************/
 /**
  * Grants control plane operations to manage the code interpreter (CRUD)
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_ADMIN_PERMS = [
   'bedrock-agentcore:CreateCodeInterpreter',
@@ -105,6 +114,7 @@ export const CODE_INTERPRETER_ADMIN_PERMS = [
 
 /**
  * Permissions for reading code interpreter information
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_READ_PERMS = [
   'bedrock-agentcore:GetCodeInterpreter',
@@ -113,6 +123,7 @@ export const CODE_INTERPRETER_READ_PERMS = [
 
 /**
  * Permissions for listing code interpreter resources
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_LIST_PERMS = [
   'bedrock-agentcore:ListCodeInterpreters',
@@ -121,6 +132,7 @@ export const CODE_INTERPRETER_LIST_PERMS = [
 
 /**
  * Permissions for using code interpreter functionality
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export const CODE_INTERPRETER_USE_PERMS = [
   'bedrock-agentcore:StartCodeInterpreterSession',

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/validation-helpers.ts
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/lib/tools/validation-helpers.ts
@@ -20,6 +20,7 @@ interface StringLengthValidation extends IntervalValidation {
  * @param maxLength - Maximum allowed length
  * @returns true if validation passes
  * @throws Error if validation fails with current length information
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateStringFieldLength(params: StringLengthValidation): string[] {
   const errors: string[] = [];
@@ -57,6 +58,7 @@ export function validateStringFieldLength(params: StringLengthValidation): strin
  * @param customMessage - Optional custom error message
  * @returns true if validation passes
  * @throws Error if validation fails with detailed message
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
  */
 export function validateFieldPattern(
   value: string,
@@ -94,6 +96,10 @@ export function validateFieldPattern(
 
 export type ValidationFn<T> = (param: T) => string[];
 
+/**
+ * This API has been graduated to stable.
+ * @deprecated Use the equivalent construct from `aws-cdk-lib/aws-bedrockagentcore` instead.
+ */
 export function throwIfInvalid<T>(validationFn: ValidationFn<T>, param: T): T {
   const errors = validationFn(param);
   if (errors.length > 0) {


### PR DESCRIPTION
### Issue # (if applicable)

N/A — follow-up to #37876 (graduation to stable).

### Reason for this change

The bedrock-agentcore module graduated to stable (`aws-cdk-lib/aws-bedrockagentcore`) in #37876. All submodules except Policy moved to stable. This PR marks the graduated exports in the alpha package as `@deprecated` so customers know to migrate.

### Description of changes

Added `@deprecated` JSDoc tags to all non-Policy exports in `@aws-cdk/aws-bedrock-agentcore-alpha`, pointing users to `aws-cdk-lib/aws-bedrockagentcore`.

Deprecated submodules: Runtime, Gateway, Memory, Tools, Evaluation, Identity, Network, Common.

The Policy submodule (PolicyEngine, Policy, PolicyStatement, PolicyValidationMode) remains active in alpha due to a pending CloudFormation stabilization.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- Build the package with current changes

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*