### PR TITLE
fix(glue-alpha): strip COMMENT from nested struct inputString

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/schema.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/schema.ts
@@ -205,13 +205,7 @@ export class Schema {
   public static struct(columns: Column[]): Type {
     return {
       isPrimitive: false,
-      inputString: `struct<${columns.map(column => {
-        if (column.comment === undefined) {
-          return `${column.name}:${column.type.inputString}`;
-        } else {
-          return `${column.name}:${column.type.inputString} COMMENT '${column.comment}'`;
-        }
-      }).join(',')}>`,
+      inputString: `struct<${columns.map(column => `${column.name}:${column.type.inputString}`).join(',')}>`,
     };
   }
 }

--- a/packages/@aws-cdk/aws-glue-alpha/test/schema.test.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/test/schema.test.ts
@@ -233,7 +233,6 @@ test('struct type', () => {
 
   expect(type.isPrimitive).toEqual(false);
   expect(type.inputString).toEqual(
-
-    'struct<primitive:string,with_comment:string COMMENT \'this has a comment\',array:array<string>,map:map<string,string>,nested_struct:struct<nested:string COMMENT \'nested comment\'>>',
+    'struct<primitive:string,with_comment:string,array:array<string>,map:map<string,string>,nested_struct:struct<nested:string>>',
   );
 });


### PR DESCRIPTION
Nested struct columns with comments generated invalid inputStrings like
struct<name:string COMMENT '...'> which Athena/Glue reject. Comments
are only valid at the top-level column definition, not inside nested
struct type strings.

Fixes #26935

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*