### PR TITLE
fix(batch): use uppercase MANAGED/UNMANAGED for ComputeEnvironment type to avoid CloudFormation drift (under feature flag)

### DIFF
--- a/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/managed-compute-environment.ts
@@ -2,6 +2,7 @@ import type { Construct, IConstruct } from 'constructs';
 import { CfnComputeEnvironment } from './batch.generated';
 import type { IComputeEnvironment, ComputeEnvironmentProps } from './compute-environment-base';
 import { ComputeEnvironmentBase } from './compute-environment-base';
+import { ComputeEnvironmentType } from './private/compute-environment-type';
 import * as ec2 from '../../aws-ec2';
 import type * as eks from '../../aws-eks';
 import * as iam from '../../aws-iam';
@@ -1398,6 +1399,7 @@ function validateVCpus(scope: Construct, minvCpus: number, maxvCpus: number): vo
 }
 
 function baseManagedResourceProperties(baseComputeEnvironment: ManagedComputeEnvironmentBase, subnetIds: string[]) {
+  const isUppercase = FeatureFlags.of(baseComputeEnvironment).isEnabled(cxapi.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE);
   return {
     serviceRole: baseComputeEnvironment.serviceRole?.roleArn,
     state: baseComputeEnvironment.enabled ? 'ENABLED' : 'DISABLED',
@@ -1413,7 +1415,7 @@ function baseManagedResourceProperties(baseComputeEnvironment: ManagedComputeEnv
       jobExecutionTimeoutMinutes: baseComputeEnvironment.updateTimeout?.toMinutes(),
     },
     replaceComputeEnvironment: baseComputeEnvironment.replaceComputeEnvironment,
-    type: 'managed',
+    type: isUppercase ? ComputeEnvironmentType.MANAGED : 'managed',
   };
 }
 

--- a/packages/aws-cdk-lib/aws-batch/lib/private/compute-environment-type.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/private/compute-environment-type.ts
@@ -1,0 +1,15 @@
+/**
+ * The type of the compute environment.
+ * @internal
+ */
+export enum ComputeEnvironmentType {
+  /**
+   * Batch manages the compute environment.
+   */
+  MANAGED = 'MANAGED',
+
+  /**
+   * You manage the compute environment.
+   */
+  UNMANAGED = 'UNMANAGED',
+}

--- a/packages/aws-cdk-lib/aws-batch/lib/unmanaged-compute-environment.ts
+++ b/packages/aws-cdk-lib/aws-batch/lib/unmanaged-compute-environment.ts
@@ -2,11 +2,13 @@ import type { Construct } from 'constructs';
 import { CfnComputeEnvironment } from './batch.generated';
 import type { IComputeEnvironment, ComputeEnvironmentProps } from './compute-environment-base';
 import { ComputeEnvironmentBase } from './compute-environment-base';
+import { ComputeEnvironmentType } from './private/compute-environment-type';
 import { ManagedPolicy, Role, ServicePrincipal } from '../../aws-iam';
-import { ArnFormat, Stack } from '../../core';
+import { ArnFormat, FeatureFlags, Stack } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import * as cxapi from '../../cx-api';
 
 /**
  * Represents an UnmanagedComputeEnvironment. Batch will not provision instances on your behalf
@@ -93,8 +95,9 @@ export class UnmanagedComputeEnvironment extends ComputeEnvironmentBase implemen
     addConstructMetadata(this, props);
 
     this.unmanagedvCPUs = props?.unmanagedvCpus;
+    const isUppercase = FeatureFlags.of(this).isEnabled(cxapi.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE);
     this.resource = new CfnComputeEnvironment(this, 'Resource', {
-      type: 'unmanaged',
+      type: isUppercase ? ComputeEnvironmentType.UNMANAGED : 'unmanaged',
       state: this.enabled ? 'ENABLED' : 'DISABLED',
       computeEnvironmentName: props?.computeEnvironmentName,
       unmanagedvCpus: this.unmanagedvCPUs,

--- a/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
+++ b/packages/aws-cdk-lib/aws-batch/test/managed-compute-environment.test.ts
@@ -1154,6 +1154,21 @@ describe('ManagedEc2EcsComputeEnvironment', () => {
       });
     }).toThrow(/Managed ComputeEnvironment 'MyCE' specifies 'spotFleetRole' without specifying 'spot'/);
   });
+
+  test('uses uppercase MANAGED type when feature flag is enabled', () => {
+    // GIVEN
+    const app = new App({ context: { [cxapi.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE]: true } });
+    const flagStack = new Stack(app, 'FlagStack');
+    const flagVpc = new ec2.Vpc(flagStack, 'vpc');
+
+    // WHEN
+    new ManagedEc2EcsComputeEnvironment(flagStack, 'MyCE', { vpc: flagVpc });
+
+    // THEN
+    Template.fromStack(flagStack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+      Type: 'MANAGED',
+    });
+  });
 });
 
 describe('ManagedEc2EksComputeEnvironment', () => {
@@ -1470,5 +1485,20 @@ describe('FargateComputeEnvironment', () => {
 
     // THEN
     expect(ce.computeEnvironmentArn).toEqual('arn:aws:batch:us-east-1:123456789012:compute-environment/ce-name');
+  });
+
+  test('uses uppercase MANAGED type when feature flag is enabled', () => {
+    // GIVEN
+    const app = new App({ context: { [cxapi.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE]: true } });
+    const flagStack = new Stack(app, 'FlagStack');
+    const flagVpc = new ec2.Vpc(flagStack, 'vpc');
+
+    // WHEN
+    new FargateComputeEnvironment(flagStack, 'MyCE', { vpc: flagVpc });
+
+    // THEN
+    Template.fromStack(flagStack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+      Type: 'MANAGED',
+    });
   });
 });

--- a/packages/aws-cdk-lib/aws-batch/test/unmanaged-compute-environment.test.ts
+++ b/packages/aws-cdk-lib/aws-batch/test/unmanaged-compute-environment.test.ts
@@ -1,7 +1,8 @@
 import { capitalizePropertyNames } from './utils';
 import { Template } from '../../assertions';
 import { Role, ServicePrincipal } from '../../aws-iam';
-import { Stack } from '../../core';
+import { App, Stack } from '../../core';
+import * as cxapi from '../../cx-api';
 import type { CfnComputeEnvironmentProps } from '../lib/';
 import { UnmanagedComputeEnvironment } from '../lib/';
 
@@ -101,5 +102,19 @@ test('respects unmanagedvCpus', () => {
   Template.fromStack(stack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
     ...pascalCaseExpectedProps,
     UnmanagedvCpus: 256,
+  });
+});
+
+test('uses uppercase UNMANAGED type when feature flag is enabled', () => {
+  // GIVEN
+  const app = new App({ context: { [cxapi.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE]: true } });
+  const flagStack = new Stack(app, 'FlagStack');
+
+  // WHEN
+  new UnmanagedComputeEnvironment(flagStack, 'MyCE');
+
+  // THEN
+  Template.fromStack(flagStack).hasResourceProperties('AWS::Batch::ComputeEnvironment', {
+    Type: 'UNMANAGED',
   });
 });

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -118,6 +118,7 @@ Flags come in three types:
 | [@aws-cdk/core:defaultCrossStackReferences](#aws-cdkcoredefaultcrossstackreferences) | Controls whether cross-stack references are strong, weak, or both | 2.254.0 | config |
 | [@aws-cdk/aws-eks:defaultToAL2023](#aws-cdkaws-eksdefaulttoal2023) | Use AL2023 as the default AMI type for EKS managed node groups using non-GPU instance types instead of the deprecated AL2 | 2.259.0 | new default |
 | [@aws-cdk/core:validateAgainstDefaultRules](#aws-cdkcorevalidateagainstdefaultrules) | Treat CloudFormation Validate findings as errors | 2.262.0 | config |
+| [@aws-cdk/aws-batch:computeEnvironmentTypeUppercase](#aws-cdkaws-batchcomputeenvironmenttypeuppercase) | Use uppercase MANAGED/UNMANAGED for Batch ComputeEnvironment type to avoid CloudFormation drift | V2NEXT | fix |
 
 <!-- END table -->
 
@@ -136,6 +137,7 @@ The following json shows the current recommended set of flags, as `cdk init` wou
     "@aws-cdk/aws-appsync:appSyncGraphQLAPIScopeLambdaPermission": true,
     "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
     "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/aws-batch:computeEnvironmentTypeUppercase": true,
     "@aws-cdk/aws-batch:defaultToAL2023": true,
     "@aws-cdk/aws-cloudfront:defaultFunctionRuntimeV2_0": true,
     "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
@@ -2549,6 +2551,29 @@ fail synthesis. When unconfigured, violations are reported as warnings only.
 | ----- | ----- | ----- |
 | (not in v1) |  |  |
 | 2.262.0 | `false` | `true` |
+
+
+### @aws-cdk/aws-batch:computeEnvironmentTypeUppercase
+
+*Use uppercase MANAGED/UNMANAGED for Batch ComputeEnvironment type to avoid CloudFormation drift*
+
+Flag type: Backwards incompatible bugfix
+
+When enabled, the `Type` property of `AWS::Batch::ComputeEnvironment` is set to uppercase
+`MANAGED` or `UNMANAGED` instead of lowercase `managed` or `unmanaged`.
+
+CloudFormation returns the uppercase value in drift detection, so using lowercase causes
+false positive drift results. Enabling this flag fixes the drift issue.
+
+**Warning**: Enabling this flag on existing stacks will cause the `Type` property value to
+change from lowercase to uppercase in the synthesized template, which may trigger a
+compute environment replacement during deployment.
+
+
+| Since | Unset behaves like | Recommended value |
+| ----- | ----- | ----- |
+| (not in v1) |  |  |
+| V2NEXT | `false` | `true` |
 
 
 <!-- END details -->

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -794,3 +794,21 @@ _cdk.json_
   }
 }
 ```
+
+* `@aws-cdk/aws-batch:computeEnvironmentTypeUppercase`
+
+When enabled, the `Type` property of `AWS::Batch::ComputeEnvironment` is set to uppercase
+`MANAGED` or `UNMANAGED` instead of lowercase `managed` or `unmanaged`.
+
+CloudFormation returns the uppercase value in drift detection, so using lowercase causes
+false positive drift results. Enabling this flag fixes the drift issue.
+
+_cdk.json_
+
+```json
+{
+  "context": {
+    "@aws-cdk/aws-batch:computeEnvironmentTypeUppercase": true
+  }
+}
+```

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -158,6 +158,7 @@ export const EKS_DEFAULT_AL2023 = '@aws-cdk/aws-eks:defaultToAL2023';
 export const ANNOTATIONS_IN_VALIDATION_REPORT = '@aws-cdk/core:annotationsInValidationReport';
 export const DEFAULT_CROSS_STACK_REFERENCES = '@aws-cdk/core:defaultCrossStackReferences';
 export const VALIDATE_AGAINST_DEFAULT_RULES = '@aws-cdk/core:validateAgainstDefaultRules';
+export const BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE = '@aws-cdk/aws-batch:computeEnvironmentTypeUppercase';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1927,6 +1928,25 @@ export const FLAGS: Record<string, FlagInfo> = {
       When this flag is explicitly set to \`true\`, violations are treated as errors and will
       fail synthesis. When unconfigured, violations are reported as warnings only.`,
     introducedIn: { v2: '2.262.0' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE]: {
+    type: FlagType.BugFix,
+    summary: 'Use uppercase MANAGED/UNMANAGED for Batch ComputeEnvironment type to avoid CloudFormation drift',
+    detailsMd: `
+      When enabled, the \`Type\` property of \`AWS::Batch::ComputeEnvironment\` is set to uppercase
+      \`MANAGED\` or \`UNMANAGED\` instead of lowercase \`managed\` or \`unmanaged\`.
+
+      CloudFormation returns the uppercase value in drift detection, so using lowercase causes
+      false positive drift results. Enabling this flag fixes the drift issue.
+
+      **Warning**: Enabling this flag on existing stacks will cause the \`Type\` property value to
+      change from lowercase to uppercase in the synthesized template, which may trigger a
+      compute environment replacement during deployment.`,
+    introducedIn: { v2: 'V2NEXT' },
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: false },
   },

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -52,6 +52,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.EKS_DEFAULT_AL2023]: false,
     [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
     [feats.VALIDATE_AGAINST_DEFAULT_RULES]: false,
+    [feats.BATCH_COMPUTE_ENVIRONMENT_TYPE_UPPERCASE]: false,
 
   });
 });

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -87,5 +87,6 @@
   "@aws-cdk/aws-eks:defaultToAL2023": true,
   "@aws-cdk/core:annotationsInValidationReport": true,
   "@aws-cdk/core:defaultCrossStackReferences": "weak",
-  "@aws-cdk/core:validateAgainstDefaultRules": true
+  "@aws-cdk/core:validateAgainstDefaultRules": true,
+  "@aws-cdk/aws-batch:computeEnvironmentTypeUppercase": true
 }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #31621 

### Reason for this change

<!--What is the bug or use case behind this change?-->

`ManagedEc2EcsComputeEnvironment`, `FargateComputeEnvironment`, and `UnmanagedComputeEnvironment` set the `Type` property to lowercase (`managed`/`unmanaged`), which causes false positive drift detection in CloudFormation. Verified by reproducing the drift locally.

This is a regression from the previous L2 (`ComputeEnvironment`), which used uppercase `MANAGED` ([source](https://github.com/aws/aws-cdk/blob/4bc965102f/packages/%40aws-cdk/aws-batch/lib/compute-environment.ts#L430)). 
The new L2 constructs introduced in v2.74.0 ([#24775](https://github.com/aws/aws-cdk/pull/24775)) inadvertently changed this to lowercase, which also causes a replacement when migrating from the old L2.

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

Introduced a feature flag `@aws-cdk/aws-batch:computeEnvironmentTypeUppercase` that, when enabled, sets the `Type` property to uppercase `MANAGED`/`UNMANAGED` to match what CloudFormation returns in drift detection.

A feature flag is used because changing the `Type` value from lowercase to uppercase triggers a compute environment replacement during deployment, which would be disruptive to existing users.


### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->

None.

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->

Unit tests for both managed and unmanaged compute environments, verifying:

- Flag ON → uppercase `MANAGED`/`UNMANAGED`
- Flag OFF (default) → lowercase `managed`/`unmanaged` (covered by existing tests)


### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
