### PR TITLE
fix(lambda-nodejs): perf counters e2e test uses incorrect filename

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/e2e/bundling-e2e.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/e2e/bundling-e2e.test.ts
@@ -267,7 +267,10 @@ describeDockerSuite((forceDockerBundling) => {
     test('performance counters are emitted', () => {
       project = createProject(pkgManager, '.ts');
 
-      const countersFile = path.join(project.outdir, 'counters.json');
+      // The CLI writes perf counters to 'performance-counters.json' in the output
+      // directory. We set the env var to the same path for older CLI versions that
+      // pass through the env var instead of setting their own.
+      const countersFile = path.join(project.outdir, 'performance-counters.json');
       process.env[cx_api.PERF_COUNTERS_FILE_ENV] = countersFile;
       try {
         cdkSynth(project, {


### PR DESCRIPTION
### Reason for this change

The `performance counters are emitted` e2e test in `aws-lambda-nodejs` fails deterministically after upgrading `@aws-cdk/integ-runner` to `^2.198.0` (which pulls in `aws-cdk@2.1125.0`).

The new CLI version unconditionally sets `CDK_PERF_COUNTERS_FILE` to `performance-counters.json` in the output directory, overriding the value the test sets. The test then looks for `counters.json` which was never written.

### Description of changes

Update the test to set `CDK_PERF_COUNTERS_FILE` to `performance-counters.json` (matching the filename the new CLI uses). This makes the test work with both old CLI versions (which pass through the env var) and new ones (which override it to the same value).

### Description of how you validated changes

Reproduced the failure locally, applied the fix, confirmed both `local` and `in docker` variants pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*