### PR TITLE
test(ec2): guard IVpc assignability under exactOptionalPropertyTypes

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/test/exact-optional-property-types.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/exact-optional-property-types.test.ts
@@ -1,0 +1,82 @@
+import * as path from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Regression guard for https://github.com/aws/aws-cdk/issues/37996.
+ *
+ * Consumers who enable TypeScript's `exactOptionalPropertyTypes` can't pass a
+ * concrete construct where its interface is expected, and type-checking
+ * `aws-cdk-lib` fails for them outright — because a class member typed
+ * `T | undefined` is not assignable to an interface's optional `?: T`. The
+ * library doesn't build with the flag, so these breaks slip past its own compile
+ * and only surface downstream.
+ *
+ * This test compiles a consumer snippet with the flag on and asserts that this
+ * package's concrete classes stay assignable to their interfaces.
+ */
+
+// One type-only assignment per concrete class -> interface pair to lock in.
+// `declare const` avoids constructor boilerplate; the assignment is the assertion.
+const ASSIGNABILITY_SNIPPET = `
+import { Vpc, IVpc } from '../lib';
+
+declare const vpc: Vpc;
+const _vpc: IVpc = vpc;
+void _vpc;
+`;
+
+/**
+ * Compile the snippet under \`exactOptionalPropertyTypes\` and return only the
+ * diagnostics anchored to the snippet (lib-source noise is filtered out).
+ */
+function snippetDiagnosticsUnderExactOptional(snippet: string): string[] {
+  // Virtual file placed in this directory so `import ... from '../lib'` resolves
+  // to the aws-ec2 source barrel.
+  const snippetPath = path.join(__dirname, '__exact-optional-snippet__.ts');
+
+  // Reuse the package's own tsconfig (target/module/lib/skipLibCheck) so dragging
+  // the source graph does not inject spurious errors, then force the flag on.
+  const tsconfigPath = ts.findConfigFile(__dirname, ts.sys.fileExists);
+  if (!tsconfigPath) {
+    throw new Error(`could not locate a tsconfig.json above ${__dirname}`);
+  }
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
+  const options: ts.CompilerOptions = {
+    ...parsed.options,
+    exactOptionalPropertyTypes: true,
+    skipLibCheck: true,
+    noEmit: true,
+    // The lib tsconfig is a `composite` project; without these the program rejects
+    // the un-listed source files (TS6307) instead of type-checking the snippet.
+    composite: false,
+    incremental: false,
+    declaration: false,
+    declarationMap: false,
+    tsBuildInfoFile: undefined,
+  };
+
+  const host = ts.createCompilerHost(options, true);
+  const isSnippet = (fileName: string) => path.resolve(fileName) === path.resolve(snippetPath);
+
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, langVersion, onError, shouldCreate) =>
+    isSnippet(fileName)
+      ? ts.createSourceFile(fileName, snippet, langVersion, true)
+      : baseGetSourceFile(fileName, langVersion, onError, shouldCreate);
+
+  const program = ts.createProgram([snippetPath], options, host);
+  const snippetSource = program.getSourceFile(snippetPath);
+
+  return ts.getPreEmitDiagnostics(program, snippetSource)
+    .filter((d) => d.file && isSnippet(d.file.fileName))
+    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, '\n')}`);
+}
+
+describe('exactOptionalPropertyTypes assignability (issue #37996)', () => {
+  // Compiling the source graph through the compiler API is heavier than a normal
+  // unit test; give it room under the suite's 60s ceiling.
+  test('aws-ec2 concrete classes are assignable to their interfaces under the flag', () => {
+    expect(snippetDiagnosticsUnderExactOptional(ASSIGNABILITY_SNIPPET)).toEqual([]);
+  }, 30_000);
+});


### PR DESCRIPTION
### Issue # (if applicable)

Relates to #37996. Depends on #38036 (this guard goes green once that fix merges).

### Reason for this change

Consumers who enable TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/exactOptionalPropertyTypes.html) cannot pass a concrete construct where its interface is expected: a class member typed `T | undefined` is not assignable to an interface's optional `?: T`. `aws-cdk-lib` does not build with the flag, so these breaks slip past the library's own compile and only surface downstream (e.g. the `VpcBase`/`IVpc` case fixed in #38036).

An ordinary `const x: IVpc = vpc` assertion in a normal unit test cannot catch this, because the lib test build has the flag **off** — the assignment compiles regardless. The check only fails under the flag.

### Description of changes

Add a committed, package-local test (`aws-ec2/test/exact-optional-property-types.test.ts`) that, via the TypeScript compiler API, compiles a tiny consumer snippet **with `exactOptionalPropertyTypes` on** and asserts aws-ec2's concrete classes stay assignable to their interfaces. It type-checks against the in-repo source and filters diagnostics to the snippet, so unrelated lib-source diagnostics are ignored and a regression in this package's classes is what turns it red.

This serves two purposes:

1. **An interim, per-package regression guard** for the types fixed under #37996, until a library-wide compiler check can be added.
2. **Coverage for the VpcBase fix (#38036)** that its own unit tests cannot provide — assignability only fails under the flag, so a normal test can't guard it.

Notes for reviewers:

- This is a **new test mechanic** (compiler-API-in-jest) that the repo hasn't used before. It is intentionally scoped to one package and self-contained; if the pattern is adopted across the modules listed in #37996, the harness would be factored into a shared test helper. Feedback on the mechanic is welcome.
- It **does not gate the VpcBase fix** — #38036 stands on its own. This PR is a draft and stays red until #38036 lands; once it does, **aws-ec2 is clean of this class of error**.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- With #38036 applied locally the test passes; on unfixed source it fails with exactly `TS2375 … property 'vpnGatewayId' … 'string | undefined' is not assignable to 'string'`. Runtime ~2s.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*