### PR TITLE
fix(iam): make InstanceProfile assignable to IInstanceProfile under exactOptionalPropertyTypes

### DIFF
--- a/packages/aws-cdk-lib/aws-iam/lib/instance-profile.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/instance-profile.ts
@@ -84,6 +84,22 @@ export interface InstanceProfileAttributes {
   readonly role?: IRole;
 }
 
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+/**
+ * Assigns the `role` on an `InstanceProfileBase`.
+ *
+ * `role` is declared `readonly` (to match the `IInstanceProfile` contract under
+ * `exactOptionalPropertyTypes`) but is set after construction, so the write goes
+ * through a `Writeable` cast. The `undefined` check keeps the property absent
+ * rather than set to `undefined`, which `exactOptionalPropertyTypes` forbids.
+ */
+function setRole(instanceProfile: InstanceProfileBase, role: IRole | undefined): void {
+  if (role !== undefined) {
+    (instanceProfile as Writeable<InstanceProfileBase>).role = role;
+  }
+}
+
 /**
  * Base class for an Instance Profile
  */
@@ -93,16 +109,8 @@ abstract class InstanceProfileBase extends Resource implements IInstanceProfile 
 
   /**
    * The role associated with the InstanceProfile.
-   * @internal
    */
-  protected _role?: IRole;
-
-  /**
-   * Returns the role associated with this InstanceProfile.
-   */
-  public get role(): IRole | undefined {
-    return this._role;
-  }
+  public readonly role?: IRole;
 
   public get instanceProfileRef(): InstanceProfileReference {
     return {
@@ -168,7 +176,7 @@ export class InstanceProfile extends InstanceProfileBase {
 
       constructor(s: Construct, i: string) {
         super(s, i);
-        this._role = attrs.role;
+        setRole(this, attrs.role);
       }
     }
     return new Import(scope, id);
@@ -207,15 +215,16 @@ export class InstanceProfile extends InstanceProfileBase {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    this._role = props.role || new Role(this, 'InstanceRole', {
+    const role = props.role ?? new Role(this, 'InstanceRole', {
       roleName: PhysicalName.GENERATE_IF_NEEDED,
       assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
     });
+    setRole(this, role);
 
     this._path = props.path;
 
     this._resource = new CfnInstanceProfile(this, 'Resource', {
-      roles: [this._role.roleName],
+      roles: [role.roleName],
       instanceProfileName: this.physicalName,
       path: props.path,
     });

--- a/packages/aws-cdk-lib/aws-iam/test/exact-optional-property-types.test.ts
+++ b/packages/aws-cdk-lib/aws-iam/test/exact-optional-property-types.test.ts
@@ -1,0 +1,33 @@
+import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools';
+
+/**
+ * Regression guard for https://github.com/aws/aws-cdk/issues/37996.
+ *
+ * Consumers who enable TypeScript's `exactOptionalPropertyTypes` can't pass a
+ * concrete construct where its interface is expected, and type-checking
+ * `aws-cdk-lib` fails for them outright — because a class member typed
+ * `T | undefined` is not assignable to an interface's optional `?: T`. The
+ * library doesn't build with the flag, so these breaks slip past its own compile
+ * and only surface downstream.
+ *
+ * The shared harness compiles this snippet with the flag on; the assertion is
+ * that this package's concrete classes stay assignable to their interfaces.
+ */
+
+// One type-only assignment per concrete class -> interface pair to lock in.
+// `declare const` avoids constructor boilerplate; the assignment is the assertion.
+const ASSIGNABILITY_SNIPPET = `
+import { InstanceProfile, IInstanceProfile } from '../lib';
+
+declare const instanceProfile: InstanceProfile;
+const _instanceProfile: IInstanceProfile = instanceProfile;
+void _instanceProfile;
+`;
+
+describe('exactOptionalPropertyTypes assignability (issue #37996)', () => {
+  // Compiling the source graph through the compiler API is heavier than a normal
+  // unit test; give it room under the suite's 60s ceiling.
+  test('aws-iam concrete classes are assignable to their interfaces under the flag', () => {
+    expect(exactOptionalAssignabilityDiagnostics(__dirname, ASSIGNABILITY_SNIPPET)).toEqual([]);
+  }, 30_000);
+});

--- a/packages/aws-cdk-lib/aws-iam/test/exact-optional-property-types.test.ts
+++ b/packages/aws-cdk-lib/aws-iam/test/exact-optional-property-types.test.ts
@@ -1,4 +1,4 @@
-import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools';
+import { exactOptionalAssignabilityDiagnosticsForPackage } from '@aws-cdk/cdk-build-tools';
 
 /**
  * Regression guard for https://github.com/aws/aws-cdk/issues/37996.
@@ -10,24 +10,16 @@ import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools'
  * library doesn't build with the flag, so these breaks slip past its own compile
  * and only surface downstream.
  *
- * The shared harness compiles this snippet with the flag on; the assertion is
- * that this package's concrete classes stay assignable to their interfaces.
+ * The shared harness enumerates every exported, non-abstract class in this
+ * package and compiles `const _: IFoo = foo` for each interface it implements
+ * (its own and inherited) with the flag on. Enumerating — rather than listing
+ * classes by hand — keeps the guard complete by construction: a newly-added
+ * class, or a new optional getter on an existing one, is caught automatically.
  */
-
-// One type-only assignment per concrete class -> interface pair to lock in.
-// `declare const` avoids constructor boilerplate; the assignment is the assertion.
-const ASSIGNABILITY_SNIPPET = `
-import { InstanceProfile, IInstanceProfile } from '../lib';
-
-declare const instanceProfile: InstanceProfile;
-const _instanceProfile: IInstanceProfile = instanceProfile;
-void _instanceProfile;
-`;
-
 describe('exactOptionalPropertyTypes assignability (issue #37996)', () => {
-  // Compiling the source graph through the compiler API is heavier than a normal
-  // unit test; give it room under the suite's 60s ceiling.
+  // Enumerating + compiling the source graph through the compiler API is heavier
+  // than a normal unit test; give it room under the suite's 60s ceiling.
   test('aws-iam concrete classes are assignable to their interfaces under the flag', () => {
-    expect(exactOptionalAssignabilityDiagnostics(__dirname, ASSIGNABILITY_SNIPPET)).toEqual([]);
-  }, 30_000);
+    expect(exactOptionalAssignabilityDiagnosticsForPackage(__dirname)).toEqual([]);
+  }, 45_000);
 });

--- a/packages/aws-cdk-lib/aws-iam/test/instance-profile.test.ts
+++ b/packages/aws-cdk-lib/aws-iam/test/instance-profile.test.ts
@@ -1,5 +1,6 @@
 import { Template } from '../../assertions';
 import { Stack, Token, App, CfnResource } from '../../core';
+import type { IInstanceProfile } from '../lib';
 import { InstanceProfile, Role, ServicePrincipal } from '../lib';
 
 describe('IAM instance profiles', () => {
@@ -331,5 +332,47 @@ describe('IAM instance profiles', () => {
 
     // THEN
     expect(stack.resolve(instanceProfile.instanceProfileName)).toStrictEqual(instanceProfileName);
+  });
+
+  describe('role / IInstanceProfile assignability', () => {
+    // Regression coverage for issue #37996: under `exactOptionalPropertyTypes`,
+    // `InstanceProfile` must stay assignable to the optional `IInstanceProfile.role`.
+    // The `IInstanceProfile` annotations below are the type-level guard; the runtime
+    // expectations confirm the getter -> readonly-field refactor preserves behavior.
+    test('a concrete InstanceProfile is assignable to IInstanceProfile and auto-creates a role', () => {
+      const stack = new Stack();
+      const instanceProfile = new InstanceProfile(stack, 'InstanceProfile');
+
+      const asInterface: IInstanceProfile = instanceProfile;
+
+      expect(asInterface.role).toBeDefined();
+    });
+
+    test('role reflects the role passed in props', () => {
+      const stack = new Stack();
+      const role = new Role(stack, 'Role', { assumedBy: new ServicePrincipal('ec2.amazonaws.com') });
+      const instanceProfile: IInstanceProfile = new InstanceProfile(stack, 'InstanceProfile', { role });
+
+      expect(instanceProfile.role).toBe(role);
+    });
+
+    test('role is undefined when imported without one', () => {
+      const stack = new Stack();
+      const instanceProfile: IInstanceProfile = InstanceProfile.fromInstanceProfileArn(
+        stack, 'Imported', 'arn:aws:iam::account-id:instance-profile/MyInstanceProfile');
+
+      expect(instanceProfile.role).toBeUndefined();
+    });
+
+    test('role is carried through fromInstanceProfileAttributes', () => {
+      const stack = new Stack();
+      const role = new Role(stack, 'Role', { assumedBy: new ServicePrincipal('ec2.amazonaws.com') });
+      const instanceProfile: IInstanceProfile = InstanceProfile.fromInstanceProfileAttributes(stack, 'Imported', {
+        instanceProfileArn: 'arn:aws:iam::account-id:instance-profile/MyInstanceProfile',
+        role,
+      });
+
+      expect(instanceProfile.role).toBe(role);
+    });
   });
 });

--- a/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
@@ -2,8 +2,87 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 /**
- * Type-check a consumer `snippet` under `exactOptionalPropertyTypes` and return
- * the diagnostics anchored to the snippet itself.
+ * Compiler options for an `exactOptionalPropertyTypes` assignability check rooted
+ * at `testDir`. Mirrors the package's own tsconfig but turns the flag on and
+ * neutralises the `composite` settings so a single virtual file can be checked
+ * against the in-repo source (otherwise the program rejects the un-listed source
+ * files with TS6307 instead of type-checking).
+ */
+function exactOptionalOptions(testDir: string): ts.CompilerOptions {
+  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
+  if (!tsconfigPath) {
+    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+  }
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
+  return {
+    ...parsed.options,
+    exactOptionalPropertyTypes: true,
+    skipLibCheck: true,
+    noEmit: true,
+    composite: false,
+    incremental: false,
+    declaration: false,
+    declarationMap: false,
+    tsBuildInfoFile: undefined,
+  };
+}
+
+/** The `<pkg>/lib` directory that a source file under `<pkg>/lib/...` belongs to. */
+function libDirOf(fileName: string): string | undefined {
+  const marker = `${path.sep}lib${path.sep}`;
+  const idx = fileName.lastIndexOf(marker);
+  return idx === -1 ? undefined : fileName.slice(0, idx) + path.sep + 'lib';
+}
+
+interface InterfaceRef {
+  readonly name: string;
+  readonly libDir: string;
+}
+
+/**
+ * Collect every interface a class implements — from its own `implements` clause
+ * and, recursively, every ancestor class's `implements`. Interface and base-class
+ * symbols are resolved through aliases (an imported `implements ISomething`
+ * otherwise yields no declaration), which is essential to catch members the class
+ * inherits via an abstract base.
+ */
+function collectImplementedInterfaces(
+  checker: ts.TypeChecker,
+  classDecl: ts.ClassDeclaration,
+  acc: InterfaceRef[],
+  seen: Set<string>,
+): void {
+  for (const clause of classDecl.heritageClauses ?? []) {
+    if (clause.token === ts.SyntaxKind.ImplementsKeyword) {
+      for (const t of clause.types) {
+        // The type's symbol is the resolved interface (not an import alias).
+        const isym = checker.getTypeAtLocation(t.expression).symbol;
+        const decl = isym?.getDeclarations()?.find(ts.isInterfaceDeclaration);
+        if (!decl) continue;
+        const libDir = libDirOf(decl.getSourceFile().fileName);
+        if (!libDir) continue;
+        const key = `${decl.name.text}@${libDir}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        acc.push({ name: decl.name.text, libDir });
+      }
+    } else if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
+      for (const t of clause.types) {
+        // The type's symbol is the resolved base class (not an import alias).
+        const baseSym = checker.getTypeAtLocation(t.expression).symbol;
+        for (const d of baseSym?.getDeclarations() ?? []) {
+          if (ts.isClassDeclaration(d)) collectImplementedInterfaces(checker, d, acc, seen);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Assert that every exported, non-abstract class in a package is assignable to
+ * each interface it implements (its own and inherited) under
+ * `exactOptionalPropertyTypes`, returning a diagnostic line per offending pair.
  *
  * Shared harness for the per-package assignability guards tracked by
  * https://github.com/aws/aws-cdk/issues/37996. `aws-cdk-lib` does not build with
@@ -11,44 +90,79 @@ import * as ts from 'typescript';
  * interface's optional `?: T` slips past the library's own compile and only
  * breaks downstream consumers who enable the flag. A normal `const x: IFoo = foo`
  * assertion can't catch this (the lib test build has the flag off); this compiles
- * the snippet with the flag explicitly on.
+ * the assignments with the flag explicitly on.
  *
- * `testDir` is the calling test's directory (`__dirname`). The snippet is compiled
- * as a virtual file in that directory, so its `import ... from '../lib'` resolves
- * to the package under test and the package's own tsconfig is picked up. The
- * snippet is checked against the in-repo source, which drags the wider source
- * graph and emits many unrelated diagnostics in source `.ts` files; those are
- * intentionally ignored — only diagnostics anchored to the snippet are returned.
+ * Enumerating the package's classes — rather than listing them by hand — keeps the
+ * guard complete by construction: a newly-added class (or a new optional getter on
+ * an existing one) whose concrete member is typed `T | undefined` against an
+ * optional `?: T` is caught with no list to maintain.
  *
- * Other packages adopt this guard by passing their test directory (`__dirname`)
- * and a package-specific snippet; the harness needs no per-package changes.
+ * Pass the calling test's directory (`__dirname`); the package barrel is located
+ * by walking up to the nearest `lib/index.ts`. A clean package returns `[]`.
  */
-export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: string): string[] {
-  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
-
-  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
-  if (!tsconfigPath) {
-    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+export function exactOptionalAssignabilityDiagnosticsForPackage(testDir: string): string[] {
+  let pkgRoot = testDir;
+  while (pkgRoot !== path.dirname(pkgRoot) && !ts.sys.fileExists(path.join(pkgRoot, 'lib', 'index.ts'))) {
+    pkgRoot = path.dirname(pkgRoot);
   }
-  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
-  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
-  const options: ts.CompilerOptions = {
-    ...parsed.options,
-    exactOptionalPropertyTypes: true,
-    skipLibCheck: true,
-    noEmit: true,
-    // The lib tsconfig is a `composite` project; without these the program rejects
-    // the un-listed source files (TS6307) instead of type-checking the snippet.
-    composite: false,
-    incremental: false,
-    declaration: false,
-    declarationMap: false,
-    tsBuildInfoFile: undefined,
+  const barrelPath = path.join(pkgRoot, 'lib', 'index.ts');
+  if (!ts.sys.fileExists(barrelPath)) {
+    throw new Error(`could not locate a lib/index.ts above ${testDir}`);
+  }
+
+  const options = exactOptionalOptions(testDir);
+
+  // Pass 1: enumerate exported, non-abstract class declarations in the package's
+  // `lib` source files. Importing each from the barrel below naturally drops any
+  // class that the barrel does not re-export (i.e. is not part of the public API).
+  const enumProgram = ts.createProgram([barrelPath], options);
+  const checker = enumProgram.getTypeChecker();
+  const libPrefix = path.join(pkgRoot, 'lib') + path.sep;
+
+  interface Pair { readonly cls: string; readonly iface: string; readonly ifaceLibDir: string }
+  const pairs: Pair[] = [];
+  const hasModifier = (node: ts.ClassDeclaration, kind: ts.SyntaxKind) =>
+    ts.getModifiers(node)?.some((m) => m.kind === kind) ?? false;
+
+  for (const sf of enumProgram.getSourceFiles()) {
+    if (!sf.fileName.startsWith(libPrefix)) continue;
+    if (/\.generated\.ts$|\.d\.ts$/.test(sf.fileName)) continue;
+    ts.forEachChild(sf, (node) => {
+      if (!ts.isClassDeclaration(node) || !node.name) return;
+      if (!hasModifier(node, ts.SyntaxKind.ExportKeyword)) return;
+      if (hasModifier(node, ts.SyntaxKind.AbstractKeyword)) return;
+      const ifaces: InterfaceRef[] = [];
+      collectImplementedInterfaces(checker, node, ifaces, new Set());
+      for (const iface of ifaces) {
+        pairs.push({ cls: node.name.text, iface: iface.name, ifaceLibDir: iface.libDir });
+      }
+    });
+  }
+  if (pairs.length === 0) return [];
+
+  // Pass 2: one assignment per pair, compiled as a virtual file in `testDir`.
+  // Classes always come from the package barrel; interfaces from their own `lib`
+  // (which may be a different package). The wider source graph emits many
+  // unrelated diagnostics; only those anchored to the assignments are returned.
+  const rel = (toDir: string) => {
+    const r = path.relative(testDir, toDir).split(path.sep).join('/');
+    return r.startsWith('.') ? r : `./${r}`;
   };
+  const classBarrel = rel(path.join(pkgRoot, 'lib'));
+  let snippet = '';
+  pairs.forEach((p, i) => {
+    snippet += `import { ${p.cls} as C${i} } from '${classBarrel}';\n`;
+    snippet += `import { ${p.iface} as I${i} } from '${rel(p.ifaceLibDir)}';\n`;
+  });
+  pairs.forEach((_, i) => {
+    snippet += `declare const v${i}: C${i}; const a${i}: I${i} = v${i}; void a${i};\n`;
+  });
+
+  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
+  const resolvedSnippetPath = path.resolve(snippetPath);
+  const isSnippet = (fileName: string) => path.resolve(fileName) === resolvedSnippetPath;
 
   const host = ts.createCompilerHost(options, true);
-  const isSnippet = (fileName: string) => path.resolve(fileName) === path.resolve(snippetPath);
-
   const baseGetSourceFile = host.getSourceFile.bind(host);
   host.getSourceFile = (fileName, langVersion, onError, shouldCreate) =>
     isSnippet(fileName)
@@ -58,7 +172,17 @@ export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: 
   const program = ts.createProgram([snippetPath], options, host);
   const snippetSource = program.getSourceFile(snippetPath);
 
-  return ts.getPreEmitDiagnostics(program, snippetSource)
-    .filter((d) => d.file && isSnippet(d.file.fileName))
-    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, '\n')}`);
+  // Assignments occupy the lines after the imports; map a diagnostic back to its pair.
+  const importLineCount = pairs.length * 2;
+  const results: string[] = [];
+  for (const d of ts.getPreEmitDiagnostics(program, snippetSource)) {
+    if (!d.file || !isSnippet(d.file.fileName) || d.start === undefined) continue;
+    const { line } = d.file.getLineAndCharacterOfPosition(d.start);
+    const idx = line - importLineCount;
+    if (idx < 0 || idx >= pairs.length) continue; // ignore import-resolution noise
+    const message = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+    const props = [...message.matchAll(/Types of property '([^']+)' are incompatible/g)].map((m) => m[1]);
+    results.push(`${pairs[idx].cls} -> ${pairs[idx].iface}: TS${d.code}${props.length ? ` [${props.join(', ')}]` : ''}`);
+  }
+  return [...new Set(results)];
 }

--- a/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
@@ -1,0 +1,64 @@
+import * as path from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Type-check a consumer `snippet` under `exactOptionalPropertyTypes` and return
+ * the diagnostics anchored to the snippet itself.
+ *
+ * Shared harness for the per-package assignability guards tracked by
+ * https://github.com/aws/aws-cdk/issues/37996. `aws-cdk-lib` does not build with
+ * the flag, so a class member typed `T | undefined` that is not assignable to an
+ * interface's optional `?: T` slips past the library's own compile and only
+ * breaks downstream consumers who enable the flag. A normal `const x: IFoo = foo`
+ * assertion can't catch this (the lib test build has the flag off); this compiles
+ * the snippet with the flag explicitly on.
+ *
+ * `testDir` is the calling test's directory (`__dirname`). The snippet is compiled
+ * as a virtual file in that directory, so its `import ... from '../lib'` resolves
+ * to the package under test and the package's own tsconfig is picked up. The
+ * snippet is checked against the in-repo source, which drags the wider source
+ * graph and emits many unrelated diagnostics in source `.ts` files; those are
+ * intentionally ignored — only diagnostics anchored to the snippet are returned.
+ *
+ * Other packages adopt this guard by passing their test directory (`__dirname`)
+ * and a package-specific snippet; the harness needs no per-package changes.
+ */
+export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: string): string[] {
+  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
+
+  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
+  if (!tsconfigPath) {
+    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+  }
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
+  const options: ts.CompilerOptions = {
+    ...parsed.options,
+    exactOptionalPropertyTypes: true,
+    skipLibCheck: true,
+    noEmit: true,
+    // The lib tsconfig is a `composite` project; without these the program rejects
+    // the un-listed source files (TS6307) instead of type-checking the snippet.
+    composite: false,
+    incremental: false,
+    declaration: false,
+    declarationMap: false,
+    tsBuildInfoFile: undefined,
+  };
+
+  const host = ts.createCompilerHost(options, true);
+  const isSnippet = (fileName: string) => path.resolve(fileName) === path.resolve(snippetPath);
+
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, langVersion, onError, shouldCreate) =>
+    isSnippet(fileName)
+      ? ts.createSourceFile(fileName, snippet, langVersion, true)
+      : baseGetSourceFile(fileName, langVersion, onError, shouldCreate);
+
+  const program = ts.createProgram([snippetPath], options, host);
+  const snippetSource = program.getSourceFile(snippetPath);
+
+  return ts.getPreEmitDiagnostics(program, snippetSource)
+    .filter((d) => d.file && isSnippet(d.file.fileName))
+    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, '\n')}`);
+}

--- a/tools/@aws-cdk/cdk-build-tools/lib/index.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/index.ts
@@ -1,4 +1,5 @@
 export { shell } from './os';
 export * from './deprecated-symbols';
+export { exactOptionalAssignabilityDiagnostics } from './exact-optional-property-types';
 import bockfs from './bockfs';
 export { bockfs };

--- a/tools/@aws-cdk/cdk-build-tools/lib/index.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/index.ts
@@ -1,5 +1,5 @@
 export { shell } from './os';
 export * from './deprecated-symbols';
-export { exactOptionalAssignabilityDiagnostics } from './exact-optional-property-types';
+export { exactOptionalAssignabilityDiagnosticsForPackage } from './exact-optional-property-types';
 import bockfs from './bockfs';
 export { bockfs };


### PR DESCRIPTION
### Issue # (if applicable)

Relates to #37996 (one module of the cross-cutting sweep). Establishes the reusable per-package guard pattern; follows the shape of https://github.com/aws/aws-cdk/pull/38036 (ec2/VpcBase).

### Reason for this change

`IInstanceProfile` declares `role?: IRole` (optional), but the abstract base `InstanceProfileBase` implemented it as a getter returning `IRole | undefined`. Under [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), `T | undefined` is not assignable to an optional `T?`, so consumers with that compiler option enabled hit:

- `TS2420` — `Class 'InstanceProfileBase' incorrectly implements interface 'IInstanceProfile'` when type-checking aws-cdk-lib's declarations (`skipLibCheck: false`);
- `TS2379` / `TS2375` — when passing an `InstanceProfile` (or any `IInstanceProfile`) where the interface is expected.

### Description of changes

- Replace the `_role` private field + `role` getter with a single `public readonly role?: IRole` that matches the `IInstanceProfile` contract exactly.
- Set the value through a module-private `setRole` helper that performs the `Writeable` cast and skips `undefined` (which an optional property may not hold under the flag). The main constructor resolves the role into a local (`props.role ?? new Role(...)`) used for both the assignment and the `roles: [role.roleName]` wiring.
- No change to synthesized CloudFormation: the role is always present for a concrete `InstanceProfile` (auto-created when not supplied) and absent only for imports without one — exactly as before. `yarn compat` passes (jsii models `get role(): IRole | undefined` and `readonly role?: IRole` identically).

This PR also introduces the **reusable, auto-enumerating guard** for the rest of the #37996 sweep:

- `tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts` — a shared test helper `exactOptionalAssignabilityDiagnosticsForPackage(testDir)`, exported from `@aws-cdk/cdk-build-tools` (the established home for shared test utilities such as `testDeprecated`/`bockfs`). Given a package's test directory, it **enumerates every exported, non-abstract class** in the package and type-checks `const _: IFoo = foo` for each interface that class implements (its own **and inherited**) under `exactOptionalPropertyTypes`, returning only the diagnostics anchored to those assignments. aws-cdk-lib does not build with the flag, so an ordinary `const x: IFoo = foo` assertion in a normal test can't catch this regression; this helper runs the check with the flag explicitly on. Enumerating — rather than hand-listing classes per package — keeps each package's guard **complete by construction**: a newly-added offending class, or a new optional getter on an existing one, is caught automatically.
- `aws-iam/test/exact-optional-property-types.test.ts` — the per-package guard for aws-iam (a one-liner over the helper).

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- Added 4 behavior tests in `aws-iam/test/instance-profile.test.ts` (concrete profile auto-creates a role and is assignable to `IInstanceProfile`; role reflects props; role is `undefined` when imported without one; role is carried through `fromInstanceProfileAttributes`).
- Added the flag-on assignability guard; verified it is **red** (`InstanceProfile -> IInstanceProfile: TS2375 [role]`) if the `| undefined` shape is reintroduced and **green** with this fix. The auto-enumerating guard also re-confirms `role` is the only offender in aws-iam.
- `yarn build`, `yarn compat`, `eslint`, and the aws-iam unit tests (19) all pass.

> **Integ test:** this is a type-only change with no effect on synthesized templates, so an integration test is not applicable. Requesting the `pr-linter/exempt-integ-test` label.

> The guard helper is shared across the #37996 sweep PRs (each carries a byte-identical copy and imports it); whichever lands first establishes it, and the others rebase to drop the duplicate.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
