### PR TITLE
chore(deps): bump brace-expansion version to 5.0.6 to address CVE-2026-45149

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7166,9 +7166,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Bumps brace-expansion from 5.0.5 to 5.0.6, which fixes https://github.com/advisories/GHSA-jxxr-4gwj-5jf2 (large numeric range defeats documented max DoS protection) affecting versions >=5.0.0, <5.0.6.

### Issue # (if applicable)

Closes #37927.

### Reason for this change

Current version has CVE

Copy of Contributor @davidkonigsberg's PR as his PR could not be merged. Thank you @davidkonigsberg.
FYI @kumvprat

### Description of changes

Bump to non-vulnerable version

### Describe any new or updated permissions being added

NA

### Description of how you validated changes

CI

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
