### PR TITLE
fix(lambda): explicitly provided function name is not returned by `functionName`

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function.ts
@@ -951,7 +951,7 @@ export class Function extends FunctionBase {
    */
   @memoizedGetter
   public get functionName(): string {
-    return this.getResourceNameAttribute(this.resource.ref);
+    return this._functionName ?? this.getResourceNameAttribute(this.resource.ref);
   }
 
   /**
@@ -977,6 +977,7 @@ export class Function extends FunctionBase {
 
   private _architecture?: Architecture;
   private hashMixins = Box.fromArray<string>([], { omitEmpty: false });
+  private _functionName?: string;
 
   /**
    * The tenancy configuration for this function.
@@ -987,6 +988,7 @@ export class Function extends FunctionBase {
     super(scope, id, {
       physicalName: props.functionName,
     });
+    this._functionName = props.functionName;
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 

--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -3736,6 +3736,18 @@ describe('function', () => {
     })).toThrow(/Function name can not be longer than 64 characters/);
   });
 
+  test('Returns the function name when provided with one', () => {
+    const stack = new cdk.Stack();
+    const fn = new lambda.Function(stack, 'MyFunction', {
+      code: lambda.Code.fromInline('foo'),
+      runtime: lambda.Runtime.NODEJS_LATEST,
+      handler: 'index.handler',
+      functionName: 'Banana',
+    });
+
+    expect(fn.functionName).toEqual('Banana');
+  });
+
   test('Error when function name contains invalid characters', () => {
     const stack = new cdk.Stack();
     [' ', '\n', '\r', '[', ']', '<', '>', '$'].forEach(invalidChar => {


### PR DESCRIPTION
### Reason for this change

When a Lambda function is created with an explicitly provided function name, its `functionName` property returns a token.

### Description of changes

Store the function name in a private variable, if provided, and give preference to it, in `get functionName()`.

### Description of how you validated changes

New unit test.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
