### PR TITLE
feat(core): trace property assignments in CfnResource.addPropertyOverride

### DIFF
--- a/packages/aws-cdk-lib/core/lib/cfn-resource.ts
+++ b/packages/aws-cdk-lib/core/lib/cfn-resource.ts
@@ -12,6 +12,7 @@ import { CfnReference } from './private/cfn-reference';
 import type { Reference } from './reference';
 import type { RemovalPolicyOptions } from './removal-policy';
 import { RemovalPolicy } from './removal-policy';
+import { traceProperty } from './stack-trace';
 import { TagManager } from './tag-manager';
 import { capitalizePropertyNames, ignoreEmpty, PostResolveToken } from './util';
 import { FeatureFlags } from './feature-flags';
@@ -309,6 +310,8 @@ export class CfnResource extends CfnRefElement {
    * @param value The value
    */
   public addPropertyOverride(propertyPath: string, value: any) {
+    const parts = splitOnPeriods(propertyPath);
+    traceProperty(this.node, parts[0]);
     this.addOverride(`Properties.${propertyPath}`, value);
   }
 

--- a/packages/aws-cdk-lib/core/test/cfn-resource.test.ts
+++ b/packages/aws-cdk-lib/core/test/cfn-resource.test.ts
@@ -474,4 +474,58 @@ describe('cfn resource', () => {
       res.addOverride('__proto__.evil', 'true');
     });
   });
+
+  describe('addPropertyOverride traces the top-level property', () => {
+    const originalCdkDebug = process.env.CDK_DEBUG;
+
+    beforeEach(() => {
+      process.env.CDK_DEBUG = '1';
+    });
+
+    afterEach(() => {
+      if (originalCdkDebug === undefined) {
+        delete process.env.CDK_DEBUG;
+      } else {
+        process.env.CDK_DEBUG = originalCdkDebug;
+      }
+    });
+
+    test('traces the top-level property for a simple path', () => {
+      const app = new core.App();
+      const stack = new core.Stack(app, 'Stack');
+      const res = new core.CfnResource(stack, 'Resource', { type: 'AWS::S3::Bucket' });
+
+      res.addPropertyOverride('VersioningConfiguration', { Status: 'Enabled' });
+
+      const metadata = res.node.metadata.filter(m => m.type === 'aws:cdk:propertyAssignment');
+      expect(metadata.length).toBe(1);
+      expect(metadata[0].data.propertyName).toBe('VersioningConfiguration');
+      expect(metadata[0].data.stackTrace).toBeDefined();
+    });
+
+    test('traces only the top-level property for a nested path', () => {
+      const app = new core.App();
+      const stack = new core.Stack(app, 'Stack');
+      const res = new core.CfnResource(stack, 'Resource', { type: 'AWS::S3::Bucket' });
+
+      res.addPropertyOverride('VersioningConfiguration.Status', 'Enabled');
+
+      const metadata = res.node.metadata.filter(m => m.type === 'aws:cdk:propertyAssignment');
+      expect(metadata.length).toBe(1);
+      expect(metadata[0].data.propertyName).toBe('VersioningConfiguration');
+    });
+
+    test('does not trace when debug mode is disabled', () => {
+      delete process.env.CDK_DEBUG;
+
+      const app = new core.App();
+      const stack = new core.Stack(app, 'Stack');
+      const res = new core.CfnResource(stack, 'Resource', { type: 'AWS::S3::Bucket' });
+
+      res.addPropertyOverride('VersioningConfiguration', { Status: 'Enabled' });
+
+      const metadata = res.node.metadata.filter(m => m.type === 'aws:cdk:propertyAssignment');
+      expect(metadata.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
When `CDK_DEBUG` is enabled, L1 property setters already record stack traces via `traceProperty()`, and stack traces from `Box`ed properties are also recorded on creation, and written to the cloud assembly by `PropertyAssignmentMetadataWriter`.

The missing piece was to record the stack trace on `CfnResource.addPropertyOverride()`, the escape-hatch API.

Instrument `CfnResource.addPropertyOverride()`, tracing only the top-level CFN name, as is done in the other two cases.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
