### PR TITLE
fix(codedeploy): make ServerDeploymentGroup assignable to IServerDeploymentGroup under exactOptionalPropertyTypes

### DIFF
--- a/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
@@ -392,7 +392,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
     this.alarms.push(alarm);
   }
 
-  public get autoScalingGroups(): autoscaling.IAutoScalingGroup[] | undefined {
+  public get autoScalingGroups(): autoscaling.IAutoScalingGroup[] {
     return this._autoScalingGroups.get().slice();
   }
 

--- a/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/lib/server/deployment-group.ts
@@ -262,6 +262,12 @@ export interface ServerDeploymentGroupProps {
 }
 
 /**
+ * Strips `readonly` so a property that is read-only to consumers can still be
+ * maintained internally.
+ */
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+/**
  * A CodeDeploy Deployment Group that deploys to EC2/on-premise instances.
  * @resource AWS::CodeDeploy::DeploymentGroup
  */
@@ -294,6 +300,14 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
    */
   public readonly role?: iam.IRole;
 
+  /**
+   * The auto-scaling groups belonging to this Deployment Group,
+   * including any added through `addAutoScalingGroup()`.
+   *
+   * This is a copy — mutating it has no effect on the Deployment Group.
+   */
+  public readonly autoScalingGroups?: autoscaling.IAutoScalingGroup[];
+
   private readonly _autoScalingGroups: IArrayBox<autoscaling.IAutoScalingGroup>;
   private readonly installAgent: boolean;
   private readonly codeDeployBucket: s3.IBucket;
@@ -317,6 +331,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
 
     this.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSCodeDeployRole'));
     this._autoScalingGroups = Box.fromArray(props.autoScalingGroups || []);
+    this.refreshAutoScalingGroups();
     this.installAgent = props.installAgent ?? true;
     this.codeDeployBucket = s3.Bucket.fromBucketName(this, 'Bucket', `aws-codedeploy-${cdk.Stack.of(this).region}`);
     this.loadBalancers = props.loadBalancers || (props.loadBalancer ? [props.loadBalancer]: undefined);
@@ -379,6 +394,7 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
   @MethodMetadata()
   public addAutoScalingGroup(asg: autoscaling.AutoScalingGroup): void {
     this._autoScalingGroups.push(asg);
+    this.refreshAutoScalingGroups();
     this.addCodeDeployAgentInstallUserData(asg);
   }
 
@@ -392,8 +408,15 @@ export class ServerDeploymentGroup extends DeploymentGroupBase implements IServe
     this.alarms.push(alarm);
   }
 
-  public get autoScalingGroups(): autoscaling.IAutoScalingGroup[] {
-    return this._autoScalingGroups.get().slice();
+  /**
+   * Refreshes the public `autoScalingGroups` view from the accumulator backing it.
+   *
+   * Must be called from every site that mutates `_autoScalingGroups`. The property is
+   * `readonly` to consumers, so the write goes through a `Writeable` cast, and a fresh
+   * copy is taken so consumers cannot reach the accumulator that drives synthesis.
+   */
+  private refreshAutoScalingGroups(): void {
+    (this as Writeable<ServerDeploymentGroup>).autoScalingGroups = this._autoScalingGroups.get().slice();
   }
 
   private addCodeDeployAgentInstallUserData(asg: autoscaling.IAutoScalingGroup): void {

--- a/packages/aws-cdk-lib/aws-codedeploy/test/exact-optional-property-types.test.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/test/exact-optional-property-types.test.ts
@@ -1,0 +1,31 @@
+import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools';
+
+/**
+ * Regression guard for https://github.com/aws/aws-cdk/issues/37996.
+ *
+ * Consumers who enable TypeScript's `exactOptionalPropertyTypes` can't pass a
+ * concrete construct where its interface is expected, and type-checking
+ * `aws-cdk-lib` fails for them outright — because a class member typed
+ * `T | undefined` is not assignable to an interface's optional `?: T`. The
+ * library doesn't build with the flag, so these breaks slip past its own compile
+ * and only surface downstream.
+ *
+ * The shared harness compiles this snippet with the flag on; the assertion is
+ * that this package's concrete classes stay assignable to their interfaces.
+ */
+
+// One type-only assignment per concrete class -> interface pair to lock in.
+// `declare const` avoids constructor boilerplate; the assignment is the assertion.
+const ASSIGNABILITY_SNIPPET = `
+import { ServerDeploymentGroup, IServerDeploymentGroup } from '../lib';
+
+declare const group: ServerDeploymentGroup;
+const _group: IServerDeploymentGroup = group;
+void _group;
+`;
+
+describe('exactOptionalPropertyTypes assignability (issue #37996)', () => {
+  test('aws-codedeploy concrete classes are assignable to their interfaces under the flag', () => {
+    expect(exactOptionalAssignabilityDiagnostics(__dirname, ASSIGNABILITY_SNIPPET)).toEqual([]);
+  }, 30_000);
+});

--- a/packages/aws-cdk-lib/aws-codedeploy/test/exact-optional-property-types.test.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/test/exact-optional-property-types.test.ts
@@ -1,4 +1,4 @@
-import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools';
+import { exactOptionalAssignabilityDiagnosticsForPackage } from '@aws-cdk/cdk-build-tools';
 
 /**
  * Regression guard for https://github.com/aws/aws-cdk/issues/37996.
@@ -10,22 +10,16 @@ import { exactOptionalAssignabilityDiagnostics } from '@aws-cdk/cdk-build-tools'
  * library doesn't build with the flag, so these breaks slip past its own compile
  * and only surface downstream.
  *
- * The shared harness compiles this snippet with the flag on; the assertion is
- * that this package's concrete classes stay assignable to their interfaces.
+ * The shared harness enumerates every exported, non-abstract class in this
+ * package and compiles `const _: IFoo = foo` for each interface it implements
+ * (its own and inherited) with the flag on. Enumerating — rather than listing
+ * classes by hand — keeps the guard complete by construction: a newly-added
+ * class, or a new optional getter on an existing one, is caught automatically.
  */
-
-// One type-only assignment per concrete class -> interface pair to lock in.
-// `declare const` avoids constructor boilerplate; the assignment is the assertion.
-const ASSIGNABILITY_SNIPPET = `
-import { ServerDeploymentGroup, IServerDeploymentGroup } from '../lib';
-
-declare const group: ServerDeploymentGroup;
-const _group: IServerDeploymentGroup = group;
-void _group;
-`;
-
 describe('exactOptionalPropertyTypes assignability (issue #37996)', () => {
+  // Enumerating + compiling the source graph through the compiler API is heavier
+  // than a normal unit test; give it room under the suite's 60s ceiling.
   test('aws-codedeploy concrete classes are assignable to their interfaces under the flag', () => {
-    expect(exactOptionalAssignabilityDiagnostics(__dirname, ASSIGNABILITY_SNIPPET)).toEqual([]);
-  }, 30_000);
+    expect(exactOptionalAssignabilityDiagnosticsForPackage(__dirname)).toEqual([]);
+  }, 45_000);
 });

--- a/packages/aws-cdk-lib/aws-codedeploy/test/server/deployment-group.test.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/test/server/deployment-group.test.ts
@@ -181,6 +181,59 @@ describe('CodeDeploy Server Deployment Group', () => {
     });
   });
 
+  describe('the autoScalingGroups property', () => {
+    function newAsg(stack: cdk.Stack, id: string): autoscaling.AutoScalingGroup {
+      return new autoscaling.AutoScalingGroup(stack, id, {
+        instanceType: ec2.InstanceType.of(ec2.InstanceClass.STANDARD3, ec2.InstanceSize.SMALL),
+        machineImage: new ec2.AmazonLinuxImage(),
+        vpc: new ec2.Vpc(stack, `VPC${id}`),
+      });
+    }
+
+    test('is an empty array by default', () => {
+      const stack = new cdk.Stack();
+
+      const deploymentGroup = new codedeploy.ServerDeploymentGroup(stack, 'DeploymentGroup');
+
+      expect(deploymentGroup.autoScalingGroups).toEqual([]);
+    });
+
+    test('reflects the ASGs passed at construction', () => {
+      const stack = new cdk.Stack();
+      const asg = newAsg(stack, 'ASG');
+
+      const deploymentGroup = new codedeploy.ServerDeploymentGroup(stack, 'DeploymentGroup', {
+        autoScalingGroups: [asg],
+      });
+
+      expect(deploymentGroup.autoScalingGroups).toEqual([asg]);
+    });
+
+    test('is a live view that reflects ASGs added after construction', () => {
+      const stack = new cdk.Stack();
+      const asg = newAsg(stack, 'ASG');
+
+      const deploymentGroup = new codedeploy.ServerDeploymentGroup(stack, 'DeploymentGroup');
+      expect(deploymentGroup.autoScalingGroups).toEqual([]);
+
+      deploymentGroup.addAutoScalingGroup(asg);
+
+      expect(deploymentGroup.autoScalingGroups).toEqual([asg]);
+    });
+
+    test('is undefined on an imported Deployment Group', () => {
+      const stack = new cdk.Stack();
+
+      const deploymentGroup: codedeploy.IServerDeploymentGroup =
+        codedeploy.ServerDeploymentGroup.fromServerDeploymentGroupAttributes(stack, 'MyDG', {
+          application: codedeploy.ServerApplication.fromServerApplicationName(stack, 'MyApp', 'MyApp'),
+          deploymentGroupName: 'MyDG',
+        });
+
+      expect(deploymentGroup.autoScalingGroups).toBeUndefined();
+    });
+  });
+
   test('can be created with an ALB Target Group as the load balancer', () => {
     const stack = new cdk.Stack();
 

--- a/packages/aws-cdk-lib/aws-codedeploy/test/server/deployment-group.test.ts
+++ b/packages/aws-cdk-lib/aws-codedeploy/test/server/deployment-group.test.ts
@@ -209,7 +209,7 @@ describe('CodeDeploy Server Deployment Group', () => {
       expect(deploymentGroup.autoScalingGroups).toEqual([asg]);
     });
 
-    test('is a live view that reflects ASGs added after construction', () => {
+    test('reflects ASGs added after construction', () => {
       const stack = new cdk.Stack();
       const asg = newAsg(stack, 'ASG');
 
@@ -219,6 +219,20 @@ describe('CodeDeploy Server Deployment Group', () => {
       deploymentGroup.addAutoScalingGroup(asg);
 
       expect(deploymentGroup.autoScalingGroups).toEqual([asg]);
+    });
+
+    test('is a copy — mutating it does not affect the synthesized Deployment Group', () => {
+      const stack = new cdk.Stack();
+      const asg = newAsg(stack, 'ASG');
+      const deploymentGroup = new codedeploy.ServerDeploymentGroup(stack, 'DeploymentGroup', {
+        autoScalingGroups: [asg],
+      });
+
+      deploymentGroup.autoScalingGroups!.push(newAsg(stack, 'SmuggledASG'));
+
+      Template.fromStack(stack).hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
+        AutoScalingGroups: [{ Ref: 'ASG46ED3070' }],
+      });
     });
 
     test('is undefined on an imported Deployment Group', () => {

--- a/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
@@ -2,8 +2,87 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 /**
- * Type-check a consumer `snippet` under `exactOptionalPropertyTypes` and return
- * the diagnostics anchored to the snippet itself.
+ * Compiler options for an `exactOptionalPropertyTypes` assignability check rooted
+ * at `testDir`. Mirrors the package's own tsconfig but turns the flag on and
+ * neutralises the `composite` settings so a single virtual file can be checked
+ * against the in-repo source (otherwise the program rejects the un-listed source
+ * files with TS6307 instead of type-checking).
+ */
+function exactOptionalOptions(testDir: string): ts.CompilerOptions {
+  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
+  if (!tsconfigPath) {
+    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+  }
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
+  return {
+    ...parsed.options,
+    exactOptionalPropertyTypes: true,
+    skipLibCheck: true,
+    noEmit: true,
+    composite: false,
+    incremental: false,
+    declaration: false,
+    declarationMap: false,
+    tsBuildInfoFile: undefined,
+  };
+}
+
+/** The `<pkg>/lib` directory that a source file under `<pkg>/lib/...` belongs to. */
+function libDirOf(fileName: string): string | undefined {
+  const marker = `${path.sep}lib${path.sep}`;
+  const idx = fileName.lastIndexOf(marker);
+  return idx === -1 ? undefined : fileName.slice(0, idx) + path.sep + 'lib';
+}
+
+interface InterfaceRef {
+  readonly name: string;
+  readonly libDir: string;
+}
+
+/**
+ * Collect every interface a class implements — from its own `implements` clause
+ * and, recursively, every ancestor class's `implements`. Interface and base-class
+ * symbols are resolved through aliases (an imported `implements ISomething`
+ * otherwise yields no declaration), which is essential to catch members the class
+ * inherits via an abstract base.
+ */
+function collectImplementedInterfaces(
+  checker: ts.TypeChecker,
+  classDecl: ts.ClassDeclaration,
+  acc: InterfaceRef[],
+  seen: Set<string>,
+): void {
+  for (const clause of classDecl.heritageClauses ?? []) {
+    if (clause.token === ts.SyntaxKind.ImplementsKeyword) {
+      for (const t of clause.types) {
+        // The type's symbol is the resolved interface (not an import alias).
+        const isym = checker.getTypeAtLocation(t.expression).symbol;
+        const decl = isym?.getDeclarations()?.find(ts.isInterfaceDeclaration);
+        if (!decl) continue;
+        const libDir = libDirOf(decl.getSourceFile().fileName);
+        if (!libDir) continue;
+        const key = `${decl.name.text}@${libDir}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        acc.push({ name: decl.name.text, libDir });
+      }
+    } else if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
+      for (const t of clause.types) {
+        // The type's symbol is the resolved base class (not an import alias).
+        const baseSym = checker.getTypeAtLocation(t.expression).symbol;
+        for (const d of baseSym?.getDeclarations() ?? []) {
+          if (ts.isClassDeclaration(d)) collectImplementedInterfaces(checker, d, acc, seen);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Assert that every exported, non-abstract class in a package is assignable to
+ * each interface it implements (its own and inherited) under
+ * `exactOptionalPropertyTypes`, returning a diagnostic line per offending pair.
  *
  * Shared harness for the per-package assignability guards tracked by
  * https://github.com/aws/aws-cdk/issues/37996. `aws-cdk-lib` does not build with
@@ -11,44 +90,79 @@ import * as ts from 'typescript';
  * interface's optional `?: T` slips past the library's own compile and only
  * breaks downstream consumers who enable the flag. A normal `const x: IFoo = foo`
  * assertion can't catch this (the lib test build has the flag off); this compiles
- * the snippet with the flag explicitly on.
+ * the assignments with the flag explicitly on.
  *
- * `testDir` is the calling test's directory (`__dirname`). The snippet is compiled
- * as a virtual file in that directory, so its `import ... from '../lib'` resolves
- * to the package under test and the package's own tsconfig is picked up. The
- * snippet is checked against the in-repo source, which drags the wider source
- * graph and emits many unrelated diagnostics in source `.ts` files; those are
- * intentionally ignored — only diagnostics anchored to the snippet are returned.
+ * Enumerating the package's classes — rather than listing them by hand — keeps the
+ * guard complete by construction: a newly-added class (or a new optional getter on
+ * an existing one) whose concrete member is typed `T | undefined` against an
+ * optional `?: T` is caught with no list to maintain.
  *
- * Other packages adopt this guard by passing their test directory (`__dirname`)
- * and a package-specific snippet; the harness needs no per-package changes.
+ * Pass the calling test's directory (`__dirname`); the package barrel is located
+ * by walking up to the nearest `lib/index.ts`. A clean package returns `[]`.
  */
-export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: string): string[] {
-  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
-
-  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
-  if (!tsconfigPath) {
-    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+export function exactOptionalAssignabilityDiagnosticsForPackage(testDir: string): string[] {
+  let pkgRoot = testDir;
+  while (pkgRoot !== path.dirname(pkgRoot) && !ts.sys.fileExists(path.join(pkgRoot, 'lib', 'index.ts'))) {
+    pkgRoot = path.dirname(pkgRoot);
   }
-  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
-  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
-  const options: ts.CompilerOptions = {
-    ...parsed.options,
-    exactOptionalPropertyTypes: true,
-    skipLibCheck: true,
-    noEmit: true,
-    // The lib tsconfig is a `composite` project; without these the program rejects
-    // the un-listed source files (TS6307) instead of type-checking the snippet.
-    composite: false,
-    incremental: false,
-    declaration: false,
-    declarationMap: false,
-    tsBuildInfoFile: undefined,
+  const barrelPath = path.join(pkgRoot, 'lib', 'index.ts');
+  if (!ts.sys.fileExists(barrelPath)) {
+    throw new Error(`could not locate a lib/index.ts above ${testDir}`);
+  }
+
+  const options = exactOptionalOptions(testDir);
+
+  // Pass 1: enumerate exported, non-abstract class declarations in the package's
+  // `lib` source files. Importing each from the barrel below naturally drops any
+  // class that the barrel does not re-export (i.e. is not part of the public API).
+  const enumProgram = ts.createProgram([barrelPath], options);
+  const checker = enumProgram.getTypeChecker();
+  const libPrefix = path.join(pkgRoot, 'lib') + path.sep;
+
+  interface Pair { readonly cls: string; readonly iface: string; readonly ifaceLibDir: string }
+  const pairs: Pair[] = [];
+  const hasModifier = (node: ts.ClassDeclaration, kind: ts.SyntaxKind) =>
+    ts.getModifiers(node)?.some((m) => m.kind === kind) ?? false;
+
+  for (const sf of enumProgram.getSourceFiles()) {
+    if (!sf.fileName.startsWith(libPrefix)) continue;
+    if (/\.generated\.ts$|\.d\.ts$/.test(sf.fileName)) continue;
+    ts.forEachChild(sf, (node) => {
+      if (!ts.isClassDeclaration(node) || !node.name) return;
+      if (!hasModifier(node, ts.SyntaxKind.ExportKeyword)) return;
+      if (hasModifier(node, ts.SyntaxKind.AbstractKeyword)) return;
+      const ifaces: InterfaceRef[] = [];
+      collectImplementedInterfaces(checker, node, ifaces, new Set());
+      for (const iface of ifaces) {
+        pairs.push({ cls: node.name.text, iface: iface.name, ifaceLibDir: iface.libDir });
+      }
+    });
+  }
+  if (pairs.length === 0) return [];
+
+  // Pass 2: one assignment per pair, compiled as a virtual file in `testDir`.
+  // Classes always come from the package barrel; interfaces from their own `lib`
+  // (which may be a different package). The wider source graph emits many
+  // unrelated diagnostics; only those anchored to the assignments are returned.
+  const rel = (toDir: string) => {
+    const r = path.relative(testDir, toDir).split(path.sep).join('/');
+    return r.startsWith('.') ? r : `./${r}`;
   };
+  const classBarrel = rel(path.join(pkgRoot, 'lib'));
+  let snippet = '';
+  pairs.forEach((p, i) => {
+    snippet += `import { ${p.cls} as C${i} } from '${classBarrel}';\n`;
+    snippet += `import { ${p.iface} as I${i} } from '${rel(p.ifaceLibDir)}';\n`;
+  });
+  pairs.forEach((_, i) => {
+    snippet += `declare const v${i}: C${i}; const a${i}: I${i} = v${i}; void a${i};\n`;
+  });
+
+  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
+  const resolvedSnippetPath = path.resolve(snippetPath);
+  const isSnippet = (fileName: string) => path.resolve(fileName) === resolvedSnippetPath;
 
   const host = ts.createCompilerHost(options, true);
-  const isSnippet = (fileName: string) => path.resolve(fileName) === path.resolve(snippetPath);
-
   const baseGetSourceFile = host.getSourceFile.bind(host);
   host.getSourceFile = (fileName, langVersion, onError, shouldCreate) =>
     isSnippet(fileName)
@@ -58,7 +172,17 @@ export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: 
   const program = ts.createProgram([snippetPath], options, host);
   const snippetSource = program.getSourceFile(snippetPath);
 
-  return ts.getPreEmitDiagnostics(program, snippetSource)
-    .filter((d) => d.file && isSnippet(d.file.fileName))
-    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, '\n')}`);
+  // Assignments occupy the lines after the imports; map a diagnostic back to its pair.
+  const importLineCount = pairs.length * 2;
+  const results: string[] = [];
+  for (const d of ts.getPreEmitDiagnostics(program, snippetSource)) {
+    if (!d.file || !isSnippet(d.file.fileName) || d.start === undefined) continue;
+    const { line } = d.file.getLineAndCharacterOfPosition(d.start);
+    const idx = line - importLineCount;
+    if (idx < 0 || idx >= pairs.length) continue; // ignore import-resolution noise
+    const message = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+    const props = [...message.matchAll(/Types of property '([^']+)' are incompatible/g)].map((m) => m[1]);
+    results.push(`${pairs[idx].cls} -> ${pairs[idx].iface}: TS${d.code}${props.length ? ` [${props.join(', ')}]` : ''}`);
+  }
+  return [...new Set(results)];
 }

--- a/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/exact-optional-property-types.ts
@@ -1,0 +1,64 @@
+import * as path from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Type-check a consumer `snippet` under `exactOptionalPropertyTypes` and return
+ * the diagnostics anchored to the snippet itself.
+ *
+ * Shared harness for the per-package assignability guards tracked by
+ * https://github.com/aws/aws-cdk/issues/37996. `aws-cdk-lib` does not build with
+ * the flag, so a class member typed `T | undefined` that is not assignable to an
+ * interface's optional `?: T` slips past the library's own compile and only
+ * breaks downstream consumers who enable the flag. A normal `const x: IFoo = foo`
+ * assertion can't catch this (the lib test build has the flag off); this compiles
+ * the snippet with the flag explicitly on.
+ *
+ * `testDir` is the calling test's directory (`__dirname`). The snippet is compiled
+ * as a virtual file in that directory, so its `import ... from '../lib'` resolves
+ * to the package under test and the package's own tsconfig is picked up. The
+ * snippet is checked against the in-repo source, which drags the wider source
+ * graph and emits many unrelated diagnostics in source `.ts` files; those are
+ * intentionally ignored — only diagnostics anchored to the snippet are returned.
+ *
+ * Other packages adopt this guard by passing their test directory (`__dirname`)
+ * and a package-specific snippet; the harness needs no per-package changes.
+ */
+export function exactOptionalAssignabilityDiagnostics(testDir: string, snippet: string): string[] {
+  const snippetPath = path.join(testDir, '__exact-optional-snippet__.ts');
+
+  const tsconfigPath = ts.findConfigFile(testDir, ts.sys.fileExists.bind(ts.sys));
+  if (!tsconfigPath) {
+    throw new Error(`could not locate a tsconfig.json above ${testDir}`);
+  }
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile.bind(ts.sys));
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath));
+  const options: ts.CompilerOptions = {
+    ...parsed.options,
+    exactOptionalPropertyTypes: true,
+    skipLibCheck: true,
+    noEmit: true,
+    // The lib tsconfig is a `composite` project; without these the program rejects
+    // the un-listed source files (TS6307) instead of type-checking the snippet.
+    composite: false,
+    incremental: false,
+    declaration: false,
+    declarationMap: false,
+    tsBuildInfoFile: undefined,
+  };
+
+  const host = ts.createCompilerHost(options, true);
+  const isSnippet = (fileName: string) => path.resolve(fileName) === path.resolve(snippetPath);
+
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, langVersion, onError, shouldCreate) =>
+    isSnippet(fileName)
+      ? ts.createSourceFile(fileName, snippet, langVersion, true)
+      : baseGetSourceFile(fileName, langVersion, onError, shouldCreate);
+
+  const program = ts.createProgram([snippetPath], options, host);
+  const snippetSource = program.getSourceFile(snippetPath);
+
+  return ts.getPreEmitDiagnostics(program, snippetSource)
+    .filter((d) => d.file && isSnippet(d.file.fileName))
+    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, '\n')}`);
+}

--- a/tools/@aws-cdk/cdk-build-tools/lib/index.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/index.ts
@@ -1,4 +1,5 @@
 export { shell } from './os';
 export * from './deprecated-symbols';
+export { exactOptionalAssignabilityDiagnostics } from './exact-optional-property-types';
 import bockfs from './bockfs';
 export { bockfs };

--- a/tools/@aws-cdk/cdk-build-tools/lib/index.ts
+++ b/tools/@aws-cdk/cdk-build-tools/lib/index.ts
@@ -1,5 +1,5 @@
 export { shell } from './os';
 export * from './deprecated-symbols';
-export { exactOptionalAssignabilityDiagnostics } from './exact-optional-property-types';
+export { exactOptionalAssignabilityDiagnosticsForPackage } from './exact-optional-property-types';
 import bockfs from './bockfs';
 export { bockfs };


### PR DESCRIPTION
### Issue # (if applicable)

Refs #37996

### Reason for this change

`IServerDeploymentGroup.autoScalingGroups` is declared optional (`?: IAutoScalingGroup[]`), but the concrete `ServerDeploymentGroup` exposed it through a getter typed `IAutoScalingGroup[] | undefined`. Under TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), a member typed `T | undefined` is **not** assignable to an optional `?: T`, so consumers who enable that flag hit a `TS2420` error and type-checking `aws-cdk-lib` fails for them outright:

```
error TS2420: Class 'ServerDeploymentGroup' incorrectly implements interface 'IServerDeploymentGroup'.
  Types of property 'autoScalingGroups' are incompatible.
    Type 'IAutoScalingGroup[] | undefined' is not assignable to type 'IAutoScalingGroup[]'.
```

`aws-cdk-lib` does not build with the flag, so the break is invisible to the library's own compile and only surfaces downstream. This is one package in the sweep tracked by #37996.

### Description of changes

`autoScalingGroups` becomes an optional **field** on `ServerDeploymentGroup`, refreshed from the backing `Box` wherever that accumulator changes (`addAutoScalingGroup` is the only such site):

```ts
public readonly autoScalingGroups?: autoscaling.IAutoScalingGroup[];
```

`?:` is the only declaration form that is simultaneously jsii-legal (the member stays optional) and assignable under `exactOptionalPropertyTypes`, and TypeScript has no optional accessor — so the getter has to become a field.

Properties of this fix:

- **Not an API change.** The jsii assembly is unchanged — the property remains `optional: true, immutable: true`, typed as an array of `IAutoScalingGroup`. `yarn compat` passes with no new entry.
- **No behaviour change.** Reads still reflect auto-scaling groups added after construction through `addAutoScalingGroup()`, and the value is still a defensive copy of the private accumulator, so mutating it cannot reach the synthesized template. A test asserts that.
- One nuance for the record: reads now return the same array instance between mutations, where the getter re-sliced on every read. Since it remains a copy, CloudFormation output is unaffected, and other languages can't observe it at all — jsii marshals arrays by value.

The imported variant (`ImportedServerDeploymentGroup`, from `fromServerDeploymentGroupAttributes`) is unchanged: an imported group has no knowledge of its ASGs, so its `autoScalingGroups` remains genuinely `undefined`. Both `[]` (owned) and `undefined` (imported) are valid for the optional interface member.

#### Approaches that don't work

An earlier revision of this PR narrowed the getter's return type to `IAutoScalingGroup[]`. **That is not legal in jsii** and broke the build:

```
error JSII5009: "ServerDeploymentGroup#autoScalingGroups" turns required when implementing
IServerDeploymentGroup. Make it optional [language-compatibility/override-changes-prop-optional]
```

That revision also claimed jsii tolerates this for collection-typed members. It does not — arrays behave exactly like single objects. A minimal repro fails identically on jsii 5.9.37 and 5.9.44, so it was never version-specific.

Declaring the property as a `readonly` array to prevent consumer mutation is also not available: it fails `TS2416` against the interface, and `ReadonlyArray` is rejected by jsii itself (`JSII3001`) because jsii's type model has a single array kind that maps onto `List`/`IList`/slices in the other target languages.

### Description of how you validated your changes

- **Behaviour tests** for the property: empty array by default, populated from props, reflects `addAutoScalingGroup()` after construction, `undefined` on an imported group, and a new test asserting that mutating the returned array does not change the synthesized template.
- A **package-local guard** (`aws-codedeploy/test/exact-optional-property-types.test.ts`) that type-checks the package's concrete classes against their interfaces with `exactOptionalPropertyTypes` on, asserting the package stays clean. Verified it goes **red** (`ServerDeploymentGroup -> IServerDeploymentGroup: TS2375 [autoScalingGroups]`) if the fix is reverted.
- Full `aws-cdk-lib` build green (jsii `Errors: 0`), `yarn compat` clean, lint clean, 129 tests pass.

#### Note on the shared test harness and PR ordering

The guard uses a small shared helper, `exactOptionalAssignabilityDiagnosticsForPackage`, added to `@aws-cdk/cdk-build-tools`. Several sweep PRs (one per package) each carry a **byte-identical** copy of this helper **and** import it, so they are **ordering-agnostic** and can land in any order. Whichever lands first establishes the helper; the others can be rebased to drop the duplicate before merge.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
