### PR TITLE
fix(core): include build context fingerprint in DockerImage.fromBuild cache key

### DIFF
--- a/packages/aws-cdk-lib/core/lib/bundling.ts
+++ b/packages/aws-cdk-lib/core/lib/bundling.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from 'child_process';
-import * as crypto from 'crypto';
 import { isAbsolute, join } from 'path';
 import type { DockerCacheOption } from './assets';
 import { ExecutionError, UnscopedValidationError } from './errors';
@@ -352,13 +351,16 @@ export class DockerImage extends BundlingDockerImage {
       throw new UnscopedValidationError(lit`MustBeFileRelativeDocker`, `"file" must be relative to the docker build directory. Got ${options.file}`);
     }
 
-    // Image tag derived from path and build options
-    const input = JSON.stringify({ path, ...options });
-    const tagHash = crypto.createHash('sha256').update(input).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    // Fingerprints the directory containing the Dockerfile we're building and
+    // differentiates the fingerprint based on build arguments. We do this so
+    // we can provide a stable image hash. Otherwise, the image ID will be
+    // different every time the Docker layer cache is cleared, due primarily to
+    // timestamps.
+    const hash = FileSystem.fingerprint(path, { extraHash: JSON.stringify(options) });
+    const tag = `cdk-${hash}`;
 
     // Skip the build if the image already exists in the local Docker daemon.
-    // The tag is deterministic (content-addressed from path + all options),
+    // The tag is content-addressed from the build context and all options,
     // so an existing image with this tag is guaranteed to be up-to-date.
     if (!this.isImageCached(tag)) {
       const dockerArgs: string[] = [
@@ -378,12 +380,6 @@ export class DockerImage extends BundlingDockerImage {
       dockerExec(dockerArgs);
     }
 
-    // Fingerprints the directory containing the Dockerfile we're building and
-    // differentiates the fingerprint based on build arguments. We do this so
-    // we can provide a stable image hash. Otherwise, the image ID will be
-    // different every time the Docker layer cache is cleared, due primarily to
-    // timestamps.
-    const hash = FileSystem.fingerprint(path, { extraHash: JSON.stringify(options) });
     return new DockerImage(tag, hash);
   }
 

--- a/packages/aws-cdk-lib/core/test/bundling.test.ts
+++ b/packages/aws-cdk-lib/core/test/bundling.test.ts
@@ -1,5 +1,4 @@
 import child_process from 'child_process';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import sinon from 'sinon';
 import { DockerBuildSecret, DockerImage, FileSystem } from '../lib';
@@ -76,13 +75,7 @@ describe('bundling', () => {
     });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      buildArgs: {
-        TEST_ARG: 'cdk-test',
-      },
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.firstCall.calledWith(dockerCmd, [
       'image', 'inspect', tag,
@@ -117,11 +110,7 @@ describe('bundling', () => {
       buildArgs: { TEST_ARG: 'cdk-test' },
     });
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      buildArgs: { TEST_ARG: 'cdk-test' },
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     // Only the image inspect call should have been made — no build
     expect(spawnSyncStub.calledOnce).toEqual(true);
@@ -129,6 +118,23 @@ describe('bundling', () => {
       'image', 'inspect', tag,
     ], { stdio: 'ignore' })).toEqual(true);
     expect(image.image).toEqual(tag);
+  });
+
+  test('fromBuild rebuilds when source content changes', () => {
+    const spawnSyncStub = sinon.stub(child_process, 'spawnSync').callsFake((_cmd, args) => ({
+      // inspect always misses; build always succeeds
+      status: (args as string[])[0] === 'image' ? 1 : 0,
+      stderr: Buffer.from(''), stdout: Buffer.from(''), pid: 123, output: ['', ''], signal: null,
+    }));
+
+    const fingerprintStub = sinon.stub(FileSystem, 'fingerprint').returns('aaa');
+    DockerImage.fromBuild('docker-path');
+    expect(spawnSyncStub.calledWith(dockerCmd, ['build', '-t', 'cdk-aaa', 'docker-path'])).toEqual(true);
+
+    // Simulate source change by returning a different fingerprint
+    fingerprintStub.returns('bbb');
+    DockerImage.fromBuild('docker-path');
+    expect(spawnSyncStub.calledWith(dockerCmd, ['build', '-t', 'cdk-bbb', 'docker-path'])).toEqual(true);
   });
 
   test('bundling with image from asset with cache disabled', () => {
@@ -158,11 +164,7 @@ describe('bundling', () => {
     });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      cacheDisabled: true,
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -202,11 +204,7 @@ describe('bundling', () => {
     const image = DockerImage.fromBuild('docker-path', { platform: platform });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      platform,
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -253,11 +251,7 @@ describe('bundling', () => {
     const image = DockerImage.fromBuild('docker-path', options);
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      ...options,
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -299,11 +293,7 @@ describe('bundling', () => {
     const image = DockerImage.fromBuild('docker-path', { targetStage: targetStage });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      targetStage,
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -343,11 +333,7 @@ describe('bundling', () => {
     const image = DockerImage.fromBuild('docker-path', { network });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      network,
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -419,11 +405,7 @@ describe('bundling', () => {
 
     const image = DockerImage.fromBuild('docker-path');
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-    })).digest('hex');
-
-    expect(image.image).toEqual(`cdk-${tagHash}`);
+    expect(image.image).toEqual(`cdk-${imageHash}`);
     expect(image.toJSON()).toEqual(imageHash);
     expect(fingerprintStub.calledWith('docker-path', sinon.match({ extraHash: JSON.stringify({}) }))).toEqual(true);
   });
@@ -887,14 +869,7 @@ describe('bundling', () => {
     });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      buildContexts: {
-        mycontext: '/path/to/context',
-        alpine: 'docker-image://alpine:latest',
-      },
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,
@@ -941,16 +916,7 @@ describe('bundling', () => {
     });
     image.run();
 
-    const tagHash = crypto.createHash('sha256').update(JSON.stringify({
-      path: 'docker-path',
-      buildArgs: {
-        TEST_ARG: 'cdk-test',
-      },
-      buildContexts: {
-        mycontext: '/path/to/context',
-      },
-    })).digest('hex');
-    const tag = `cdk-${tagHash}`;
+    const tag = `cdk-${imageHash}`;
 
     expect(spawnSyncStub.secondCall.calledWith(dockerCmd, [
       'build', '-t', tag,


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38112.

### Reason for this change

`DockerImage.fromBuild` computes its image tag from `JSON.stringify({ path, ...options })`. The `path` value is a plain string and `options` are the build options — neither includes the contents of the Dockerfile or any files in the build context. As a result the tag is identical across synths regardless of what files have changed, so the `isImageCached` check introduced in #37951 causes `docker build` to be permanently skipped after the first run.

### Description of changes

Move `FileSystem.fingerprint` to before the `isImageCached` check, and use it directly as the tag (`cdk-${hash}`). The fingerprint already incorporates both the build context files and all options via `extraHash`.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

All core unit tests pass. Validated by hand that a file change caused a docker rebuild.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*