### PR TITLE
feat(core): append external stack traces to metadata if available

### DIFF
--- a/packages/aws-cdk-lib/core/lib/stack-trace.ts
+++ b/packages/aws-cdk-lib/core/lib/stack-trace.ts
@@ -26,16 +26,26 @@ export function captureStackTrace(
 ): string[] {
   if (!limit) {
     // Fast path without try/finally
-    return renderCallStackJustMyCode(captureCallStack(below), false);
+    return withExternalTrace(renderCallStackJustMyCode(captureCallStack(below), false));
   }
 
   const previousLimit = Error.stackTraceLimit;
   try {
     Error.stackTraceLimit = limit;
-    return renderCallStackJustMyCode(captureCallStack(below), false);
+    return withExternalTrace(renderCallStackJustMyCode(captureCallStack(below), false));
   } finally {
     Error.stackTraceLimit = previousLimit;
   }
+}
+
+function withExternalTrace(internal: string[]) {
+  const hostTrace: [string, number, number, string][] | undefined =
+    (global as any)[Symbol.for('jsii.context.hostStackTrace')];
+
+  if (hostTrace != null) {
+    return internal.concat(hostTrace.map(formatExternalFrame));
+  }
+  return internal;
 }
 
 /**
@@ -60,6 +70,11 @@ export function captureCallStack(upTo: Function | undefined): CallSite[] {
     trace = parseErrorStack(obj.stack);
   }
   return trace;
+}
+
+function formatExternalFrame(trace: [string, number, number, string]): string {
+  const [filename, line, column, name] = trace;
+  return `${name} (${filename}:${line}:${column})`;
 }
 
 /**
@@ -162,6 +177,11 @@ export function renderCallStackJustMyCode(stack: CallSite[], indent = true): str
       while (i < stack.length && stack[i].fileName.includes('node:')) {
         i++;
       }
+    } else if (isJsiiRuntime(frame)) {
+      skip({ fileName: 'jsii runtime' });
+      while (i < stack.length && isJsiiRuntime(stack[i])) {
+        i++;
+      }
     } else {
       reportSkipped(true);
       const prefix = indent ? '    at ' : '';
@@ -195,6 +215,11 @@ export function renderCallStackJustMyCode(stack: CallSite[], indent = true): str
     }
     skipped = [];
   }
+}
+
+// Detects the jsii runtime bundle (program.js in a temp directory, single-line with high column offsets).
+function isJsiiRuntime(frame: CallSite): boolean {
+  return /^1:\d{4,}$/.test(frame.sourceLocation) && /[/\\]program\.js$/.test(frame.fileName);
 }
 
 interface CallSite {

--- a/packages/aws-cdk-lib/core/lib/stack-trace.ts
+++ b/packages/aws-cdk-lib/core/lib/stack-trace.ts
@@ -43,7 +43,9 @@ function withExternalTrace(internal: string[]) {
     (global as any)[Symbol.for('jsii.context.hostStackTrace')];
 
   if (hostTrace != null) {
-    return internal.concat(hostTrace.map(formatExternalFrame));
+    // The first frame represents the last call on the non-Javascript side,
+    // to the jsii runtime. This is not interesting to the user, so we drop it
+    return internal.concat(hostTrace.slice(1).map(formatExternalFrame));
   }
   return internal;
 }

--- a/packages/aws-cdk-lib/core/lib/stack-trace.ts
+++ b/packages/aws-cdk-lib/core/lib/stack-trace.ts
@@ -74,7 +74,7 @@ export function captureCallStack(upTo: Function | undefined): CallSite[] {
 
 function formatExternalFrame(trace: [string, number, number, string]): string {
   const [filename, line, column, name] = trace;
-  return `${name} (${filename}:${line}:${column})`;
+  return `${name} (${filename}:${line}${column > 0 ? ':' + column : ''})`;
 }
 
 /**
@@ -177,9 +177,9 @@ export function renderCallStackJustMyCode(stack: CallSite[], indent = true): str
       while (i < stack.length && stack[i].fileName.includes('node:')) {
         i++;
       }
-    } else if (isJsiiRuntime(frame)) {
+    } else if (isHostInternalFrame(frame)) {
       skip({ fileName: 'jsii runtime' });
-      while (i < stack.length && isJsiiRuntime(stack[i])) {
+      while (i < stack.length && isHostInternalFrame(stack[i])) {
         i++;
       }
     } else {
@@ -217,9 +217,12 @@ export function renderCallStackJustMyCode(stack: CallSite[], indent = true): str
   }
 }
 
-// Detects the jsii runtime bundle (program.js in a temp directory, single-line with high column offsets).
-function isJsiiRuntime(frame: CallSite): boolean {
-  return /^1:\d{4,}$/.test(frame.sourceLocation) && /[/\\]program\.js$/.test(frame.fileName);
+/**
+ * Whether the call site comes from the internals of the host that sent us the stack trace
+ */
+function isHostInternalFrame(frame: CallSite): boolean {
+  const hostDirName = (global as any)[Symbol.for('jsii.context.hostDirName')];
+  return frame.fileName.includes(hostDirName);
 }
 
 interface CallSite {

--- a/packages/aws-cdk-lib/core/test/stack-trace.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack-trace.test.ts
@@ -1,25 +1,30 @@
 import { captureStackTrace, renderCallStackJustMyCode } from '../lib';
 
 describe('captureStackTrace with jsii host trace', () => {
-  const SYMBOL = Symbol.for('jsii.context.hostStackTrace');
+  const TRACE_SYMBOL = Symbol.for('jsii.context.hostStackTrace');
+  const DIR_SYMBOL = Symbol.for('jsii.context.hostDirName');
 
   afterEach(() => {
-    delete (global as any)[SYMBOL];
+    delete (global as any)[TRACE_SYMBOL];
+    delete (global as any)[DIR_SYMBOL];
   });
 
-  test('appends jsii host stack trace frames when present', () => {
-    (global as any)[SYMBOL] = [
-      ['/home/user/app.py', 42, 8, 'MyStack.__init__'],
+  test('appends jsii host stack trace frames, dropping the first frame', () => {
+    (global as any)[TRACE_SYMBOL] = [
+      ['/Users/otaviom/my_app/.venv/lib/python3.14/site-packages/aws_cdk/aws_sqs/__init__.py', 4235, 0, '__init__'],
+      ['/home/user/app.py', 42, 8, '__init__'],
       ['/home/user/main.py', 10, 1, '<module>'],
     ];
 
     const trace = captureStackTrace(captureStackTrace);
 
     expect(trace).toEqual(expect.arrayContaining([
-      'MyStack.__init__ (/home/user/app.py:42:8)',
+      '__init__ (/home/user/app.py:42:8)',
       '<module> (/home/user/main.py:10:1)',
     ]));
-    const hostIndex = trace.indexOf('MyStack.__init__ (/home/user/app.py:42:8)');
+    // The first frame (site-packages) should have been dropped
+    expect(trace.join('\n')).not.toContain('site-packages');
+    const hostIndex = trace.indexOf('__init__ (/home/user/app.py:42:8)');
     const moduleIndex = trace.indexOf('<module> (/home/user/main.py:10:1)');
     expect(hostIndex).toBeGreaterThan(0);
     expect(moduleIndex).toBe(hostIndex + 1);
@@ -35,7 +40,7 @@ describe('captureStackTrace with jsii host trace', () => {
   });
 
   test('handles empty jsii host trace array', () => {
-    (global as any)[SYMBOL] = [];
+    (global as any)[TRACE_SYMBOL] = [];
 
     const trace = captureStackTrace(captureStackTrace);
 
@@ -45,7 +50,8 @@ describe('captureStackTrace with jsii host trace', () => {
   });
 
   test('formats external frame with all components', () => {
-    (global as any)[SYMBOL] = [
+    (global as any)[TRACE_SYMBOL] = [
+      ['/home/user/app.py', 42, 8, '__init__'],
       ['src/my_stack.py', 100, 12, 'MyStack.add_bucket'],
     ];
 
@@ -53,9 +59,26 @@ describe('captureStackTrace with jsii host trace', () => {
 
     expect(trace[trace.length - 1]).toBe('MyStack.add_bucket (src/my_stack.py:100:12)');
   });
+
+  test('omits column from external frame when column is 0', () => {
+    (global as any)[TRACE_SYMBOL] = [
+      ['/home/user/ignored.py', 1, 0, 'ignored'],
+      ['src/my_stack.py', 16, 0, '__init__'],
+    ];
+
+    const trace = captureStackTrace(captureStackTrace);
+
+    expect(trace[trace.length - 1]).toBe('__init__ (src/my_stack.py:16)');
+  });
 });
 
 describe('renderCallStackJustMyCode', () => {
+  const DIR_SYMBOL = Symbol.for('jsii.context.hostDirName');
+
+  afterEach(() => {
+    delete (global as any)[DIR_SYMBOL];
+  });
+
   test('renders namespaced packages correctly', () => {
     const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
       {
@@ -93,7 +116,9 @@ describe('renderCallStackJustMyCode', () => {
     ]);
   });
 
-  test('filters out jsii runtime (bundled code) frames', () => {
+  test('filters out jsii runtime frames identified by hostDirName', () => {
+    (global as any)[DIR_SYMBOL] = '/private/var/folders/zv/tmpjph88goj/lib';
+
     const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
       {
         fileName: '/path/to/project/node_modules/aws-cdk-lib/aws-sqs/lib/queue.js',
@@ -134,6 +159,8 @@ describe('renderCallStackJustMyCode', () => {
   });
 
   test('filters jsii runtime frames between user code and external trace', () => {
+    (global as any)[DIR_SYMBOL] = '/private/var/folders/zv/tmpjph88goj/lib';
+
     const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
       {
         fileName: '/path/to/project/node_modules/aws-cdk-lib/aws-sqs/lib/queue.js',

--- a/packages/aws-cdk-lib/core/test/stack-trace.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack-trace.test.ts
@@ -1,4 +1,59 @@
-import { renderCallStackJustMyCode } from '../lib';
+import { captureStackTrace, renderCallStackJustMyCode } from '../lib';
+
+describe('captureStackTrace with jsii host trace', () => {
+  const SYMBOL = Symbol.for('jsii.context.hostStackTrace');
+
+  afterEach(() => {
+    delete (global as any)[SYMBOL];
+  });
+
+  test('appends jsii host stack trace frames when present', () => {
+    (global as any)[SYMBOL] = [
+      ['/home/user/app.py', 42, 8, 'MyStack.__init__'],
+      ['/home/user/main.py', 10, 1, '<module>'],
+    ];
+
+    const trace = captureStackTrace(captureStackTrace);
+
+    expect(trace).toEqual(expect.arrayContaining([
+      'MyStack.__init__ (/home/user/app.py:42:8)',
+      '<module> (/home/user/main.py:10:1)',
+    ]));
+    const hostIndex = trace.indexOf('MyStack.__init__ (/home/user/app.py:42:8)');
+    const moduleIndex = trace.indexOf('<module> (/home/user/main.py:10:1)');
+    expect(hostIndex).toBeGreaterThan(0);
+    expect(moduleIndex).toBe(hostIndex + 1);
+    expect(moduleIndex).toBe(trace.length - 1);
+  });
+
+  test('returns only internal trace when jsii host trace is not set', () => {
+    const trace = captureStackTrace(captureStackTrace);
+
+    for (const frame of trace) {
+      expect(frame).not.toMatch(/\.py:\d+:\d+/);
+    }
+  });
+
+  test('handles empty jsii host trace array', () => {
+    (global as any)[SYMBOL] = [];
+
+    const trace = captureStackTrace(captureStackTrace);
+
+    for (const frame of trace) {
+      expect(frame).not.toMatch(/\.py:\d+:\d+/);
+    }
+  });
+
+  test('formats external frame with all components', () => {
+    (global as any)[SYMBOL] = [
+      ['src/my_stack.py', 100, 12, 'MyStack.add_bucket'],
+    ];
+
+    const trace = captureStackTrace(captureStackTrace);
+
+    expect(trace[trace.length - 1]).toBe('MyStack.add_bucket (src/my_stack.py:100:12)');
+  });
+});
 
 describe('renderCallStackJustMyCode', () => {
   test('renders namespaced packages correctly', () => {
@@ -35,6 +90,97 @@ describe('renderCallStackJustMyCode', () => {
     expect(renderCallStackJustMyCode(stack, false)).toEqual([
       '...aws-cdk-lib, new PythonFunction in @aws-cdk/aws-lambda-python-alpha...',
       'new PythonFunction (/path/to/project/myfile.js:70:5)',
+    ]);
+  });
+
+  test('filters out jsii runtime (bundled code) frames', () => {
+    const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
+      {
+        fileName: '/path/to/project/node_modules/aws-cdk-lib/aws-sqs/lib/queue.js',
+        functionName: 'new Queue',
+        sourceLocation: '2:512',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'Kernel._Kernel_create',
+        sourceLocation: '1:61224',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'Kernel.create',
+        sourceLocation: '1:51955',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'KernelHost.processRequest',
+        sourceLocation: '1:212180',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'KernelHost.run',
+        sourceLocation: '1:211164',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'Immediate._onImmediate',
+        sourceLocation: '1:211208',
+      },
+    ];
+
+    expect(renderCallStackJustMyCode(stack, false)).toEqual([
+      '...aws-cdk-lib, jsii runtime...',
+      expect.stringContaining('use --stack-trace-limit to capture more'),
+    ]);
+  });
+
+  test('filters jsii runtime frames between user code and external trace', () => {
+    const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
+      {
+        fileName: '/path/to/project/node_modules/aws-cdk-lib/aws-sqs/lib/queue.js',
+        functionName: 'new Queue',
+        sourceLocation: '2:512',
+      },
+      {
+        fileName: '/path/to/project/myfile.ts',
+        functionName: 'myFunction',
+        sourceLocation: '10:5',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'Kernel._Kernel_create',
+        sourceLocation: '1:61224',
+      },
+      {
+        fileName: '/private/var/folders/zv/tmpjph88goj/lib/program.js',
+        functionName: 'KernelHost.run',
+        sourceLocation: '1:211164',
+      },
+    ];
+
+    expect(renderCallStackJustMyCode(stack, false)).toEqual([
+      '...new Queue in aws-cdk-lib...',
+      'myFunction (/path/to/project/myfile.ts:10:5)',
+      '...jsii runtime...',
+    ]);
+  });
+
+  test('does not filter user bundled code (e.g. esbuild output)', () => {
+    const stack: Parameters<typeof renderCallStackJustMyCode>[0] = [
+      {
+        fileName: '/path/to/project/dist/bundle.js',
+        functionName: 'MyStack.constructor',
+        sourceLocation: '1:84320',
+      },
+      {
+        fileName: '/path/to/project/dist/bundle.js',
+        functionName: 'createApp',
+        sourceLocation: '1:91000',
+      },
+    ];
+
+    expect(renderCallStackJustMyCode(stack, false)).toEqual([
+      'MyStack.constructor (/path/to/project/dist/bundle.js:1:84320)',
+      'createApp (/path/to/project/dist/bundle.js:1:91000)',
     ]);
   });
 


### PR DESCRIPTION
If the app is being run via language bindings, and the jsii runtime [sends stack traces over the wire][1], append it to the native stack traces.

The contract with the jsii host, is that this information will be available in the global state, using the symbol `'jsii.context.hostStackTrace'` as the key.

While we're at it, also filter out the host's own stack trace frames:

```
"Kernel._Kernel_create (/private/var/folders/zv/w_jr20795_92wxprq4lp57540000gq/T/tmpjph88goj/lib/program.js:1:61224)",
"Kernel.create (/private/var/folders/zv/w_jr20795_92wxprq4lp57540000gq/T/tmpjph88goj/lib/program.js:1:51955)",
"KernelHost.processRequest (/private/var/folders/zv/w_jr20795_92wxprq4lp57540000gq/T/tmpjph88goj/lib/program.js:1:212180)",
"KernelHost.run (/private/var/folders/zv/w_jr20795_92wxprq4lp57540000gq/T/tmpjph88goj/lib/program.js:1:211164)",
"Immediate._onImmediate (/private/var/folders/zv/w_jr20795_92wxprq4lp57540000gq/T/tmpjph88goj/lib/program.js:1:211208)",
```

so that the final result looks like:

```json
{
  "type": "aws:cdk:creationStack",
  "data": [
    "...aws-cdk-lib, jsii runtime, node internals...",
    "(no user code in 10 frames, use --stack-trace-limit to capture more)",
    "__init__ (/Users/otaviom/my_app/my_app/my_app_stack.py:16:0)",
    "<module> (/Users/otaviom/my_app/app.py:10:0)"
  ]
}
```
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

[1]: https://github.com/aws/jsii/pull/5153