### PR TITLE
docs(agents): added more quick reference commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,20 @@ Principles:
 
 | Task | Command | Working Directory |
 |------|---------|-------------------|
+| Install dependencies | `yarn install` | repo root |
 | Build everything | `npx lerna run build --skip-nx-cache` | repo root |
+| Build aws-cdk-lib | `npx lerna run build --scope=aws-cdk-lib --stream` | repo root |
+| Build alpha module | `yarn build` | `packages/@aws-cdk/aws-{service}-alpha` |
+| Build integ tests | `npx lerna run build --scope=@aws-cdk-testing/framework-integ --stream` | repo root |
+| Test all in package | `yarn test` | `packages/aws-cdk-lib` |
 | Test one module | `yarn test aws-lambda` | `packages/aws-cdk-lib` |
 | Test one file | `npx jest aws-lambda/test/function.test.ts` | `packages/aws-cdk-lib` |
 | Lint | `npx lerna run lint` | repo root |
+| Lint with auto-fix | `yarn lint --fix` | repo root |
 | Rosetta (README compile check) | `/bin/bash ./scripts/run-rosetta.sh` | repo root |
-| Run integ snapshots | `yarn integ --directory test/aws-lambda/test` | `packages/@aws-cdk-testing/framework-integ` |
+| Run all integ snapshots | `yarn integ` | `packages/@aws-cdk-testing/framework-integ` |
+| Run integ snapshots in module | `yarn integ --directory test/aws-lambda/test` | `packages/@aws-cdk-testing/framework-integ` |
+| Update integ snapshots (no deploy) | `yarn integ --dry-run --update-on-failed` | `packages/@aws-cdk-testing/framework-integ` |
 | Run integ with deploy | `yarn integ test/aws-lambda/test/integ.lambda.js --update-on-failed` | `packages/@aws-cdk-testing/framework-integ` |
 
 > **Note:** All test, lint, integ, and rosetta commands require the project to be compiled first. Run the build command above before any of these.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Principles:
 | Install dependencies | `yarn install` | repo root |
 | Build everything | `npx lerna run build --skip-nx-cache` | repo root |
 | Build aws-cdk-lib | `npx lerna run build --scope=aws-cdk-lib --stream` | repo root |
-| Build alpha module | `yarn build` | `packages/@aws-cdk/aws-{service}-alpha` |
+| Build module | `yarn build` | `packages/aws-cdk-lib/aws-{service}` or `packages/@aws-cdk/aws-{service}-alpha` |
 | Build integ tests | `npx lerna run build --scope=@aws-cdk-testing/framework-integ --stream` | repo root |
 | Test all in package | `yarn test` | `packages/aws-cdk-lib` |
 | Test one module | `yarn test aws-lambda` | `packages/aws-cdk-lib` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ Principles:
 |------|---------|-------------------|
 | Install dependencies | `yarn install` | repo root |
 | Build everything | `npx lerna run build --skip-nx-cache` | repo root |
-| Build aws-cdk-lib | `npx lerna run build --scope=aws-cdk-lib --stream` | repo root |
-| Build module | `yarn build` | `packages/aws-cdk-lib/aws-{service}` or `packages/@aws-cdk/aws-{service}-alpha` |
-| Build integ tests | `npx lerna run build --scope=@aws-cdk-testing/framework-integ --stream` | repo root |
+| Build aws-cdk-lib package only | `npx lerna run build --scope=aws-cdk-lib --stream` | repo root |
+| Build one module | `yarn build` | `packages/aws-cdk-lib/aws-{service}` or `packages/@aws-cdk/aws-{service}-alpha` |
+| Build stable module integ tests | `npx lerna run build --scope=@aws-cdk-testing/framework-integ --stream` | repo root |
 | Test all in package | `yarn test` | `packages/aws-cdk-lib` |
 | Test one module | `yarn test aws-lambda` | `packages/aws-cdk-lib` |
 | Test one file | `npx jest aws-lambda/test/function.test.ts` | `packages/aws-cdk-lib` |


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Added more granular commands to the "Quick Reference" table in AGENTS.md so that they can be referenced easily

### Description of changes

Added granular commands to the Quick Reference — Commands table

### Describe any new or updated permissions being added

N/A


### Description of how you validated changes

Verified generated markdown

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
