### PR TITLE
feat(core): add external traces to  ConstructError

### DIFF
--- a/packages/aws-cdk-lib/core/lib/errors.ts
+++ b/packages/aws-cdk-lib/core/lib/errors.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import type { IConstruct } from 'constructs';
 import type { LiteralString } from './private/literal-string';
 import { constructInfoFromConstruct } from './private/runtime-info';
-import { captureCallStack, renderCallStackJustMyCode } from './stack-trace';
+import { enhancedStackTrace } from './stack-trace';
 import type { AssertionError } from '../../assertions/lib/private/error';
 import { ERRORFILE_ENV } from '../../cx-api';
 import type { CloudAssemblyError } from '../../cx-api/lib/private/error';
@@ -144,7 +144,7 @@ abstract class ConstructError extends Error {
 
     // The "stack" field in Node.js includes the error description. If it doesn't, Node will fall back to an
     // ugly way of rendering the error.
-    this.stack = `«${this.name}» ${msg}\n${renderCallStackJustMyCode(captureCallStack(ctr)).join('\n')}`;
+    this.stack = `«${this.name}» ${msg}\n${enhancedStackTrace(ctr).join('\n')}`;
 
     if (scope) {
       this.stack += `\nRelates to construct:\n${renderConstructRootPath(scope)}`;

--- a/packages/aws-cdk-lib/core/lib/stack-trace.ts
+++ b/packages/aws-cdk-lib/core/lib/stack-trace.ts
@@ -26,16 +26,35 @@ export function captureStackTrace(
 ): string[] {
   if (!limit) {
     // Fast path without try/finally
-    return withExternalTrace(renderCallStackJustMyCode(captureCallStack(below), false));
+    return enhancedStackTrace(below, false);
   }
 
   const previousLimit = Error.stackTraceLimit;
   try {
     Error.stackTraceLimit = limit;
-    return withExternalTrace(renderCallStackJustMyCode(captureCallStack(below), false));
+    return enhancedStackTrace(below, false);
   } finally {
     Error.stackTraceLimit = previousLimit;
   }
+}
+
+/**
+ * Builds a user-focused stack trace by combining internal JS call frames with
+ * any host-language frames provided by the jsii runtime.
+ *
+ * This helper captures the current call stack up to `upTo`, removes or groups
+ * non-user frames (such as `node_modules`, Node internals, and jsii runtime
+ * internals), optionally prefixes lines with standard stack-trace indentation,
+ * and appends external host frames when available.
+ *
+ * @param upTo the function at which stack capture should stop (exclusive). Pass
+ * `undefined` to use the default capture behavior.
+ * @param indent whether to prefix rendered lines with stack-style indentation
+ * (`"    at "` for user frames). Defaults to `true`.
+ * @returns a rendered stack trace as an array of human-readable lines.
+ */
+export function enhancedStackTrace(upTo: Function | undefined, indent = true): string[] {
+  return withExternalTrace(renderCallStackJustMyCode(captureCallStack(upTo), indent));
 }
 
 function withExternalTrace(internal: string[]) {

--- a/packages/aws-cdk-lib/core/test/errors.test.ts
+++ b/packages/aws-cdk-lib/core/test/errors.test.ts
@@ -88,6 +88,26 @@ Relates to construct:
     }
   });
 
+  test('stack includes jsii host trace frames when available', () => {
+    const TRACE_SYMBOL = Symbol.for('jsii.context.hostStackTrace');
+    (global as any)[TRACE_SYMBOL] = [
+      ['/home/user/.venv/lib/python3.14/site-packages/aws_cdk/__init__.py', 100, 0, '__init__'],
+      ['/home/user/app.py', 42, 8, 'MyStack.__init__'],
+      ['/home/user/main.py', 10, 1, '<module>'],
+    ];
+
+    try {
+      const error = new UnscopedValidationError(lit`TestError`, 'test message');
+
+      expect(error.stack).toContain('MyStack.__init__ (/home/user/app.py:42:8)');
+      expect(error.stack).toContain('<module> (/home/user/main.py:10:1)');
+      // First frame (site-packages) should be dropped
+      expect(error.stack).not.toContain('site-packages');
+    } finally {
+      delete (global as any)[TRACE_SYMBOL];
+    }
+  });
+
   test('most recent error codes is written to disk', async () => {
     const file = path.join(os.tmpdir(), 'errors.txt');
     await rm(file, { force: true });


### PR DESCRIPTION
When available, add externally provided (i.e., coming from the jsii runtime) traces to the internal ones.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
