### PR TITLE
fix(ecs): suppress shouldUseCircuitBreaker warning for DAEMON scheduling strategy services

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts
@@ -1013,8 +1013,9 @@ export abstract class BaseService extends Resource
       Annotations.of(this)._addTrackableError(lit`CircuitBreakerRequiresEcsController`, 'Deployment circuit breaker requires the ECS deployment controller.');
     }
 
-    if (!props.circuitBreaker && this.isEcsDeploymentController) {
+    if (!props.circuitBreaker && this.isEcsDeploymentController && additionalProps?.schedulingStrategy !== 'DAEMON') {
       // If we *could* use a circuit breaker, then let's recommend users to do so. It makes detecting errors sooo much faster.
+      // The circuit breaker is not applicable to DAEMON services (its threshold is desiredCount-based and daemon services have no desiredCount).
       Annotations.of(this).addWarningV2('@aws-cdk/aws-ecs:shouldUseCircuitBreaker', 'Enable the \'circuitBreaker\' property to trigger a quicker deployment failure if tasks are failing to start up (without this setting deployments may take up to 3 hours to fail).');
     }
 

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
@@ -94,6 +94,33 @@ describe('ec2 service', () => {
       }
     });
 
+    test('does not suggest circuitBreaker for DAEMON scheduling strategy services', () => {
+      // GIVEN
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'Stack');
+      const vpc = new ec2.Vpc(stack, 'MyVpc', {});
+      const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+      addDefaultCapacityProvider(cluster, stack, vpc);
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+
+      taskDefinition.addContainer('web', {
+        image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        memoryLimitMiB: 512,
+      });
+
+      new ecs.Ec2Service(stack, 'Ec2Service', {
+        cluster,
+        taskDefinition,
+        daemon: true,
+        // no circuitBreaker — warning should NOT fire because daemon services
+        // have no desiredCount and the circuit breaker threshold is desiredCount-based
+      });
+
+      // THEN
+      const warnings = flattenMeta(app.synth().getStackByName('Stack').metadata)['/Stack/Ec2Service']?.['aws:cdk:warning'];
+      expect(warnings ?? []).not.toContainEqual(expect.stringContaining('Enable the \'circuitBreaker\' property'));
+    });
+
     [false, undefined].forEach((value) => {
       test('set cloudwatch permissions based on falsy feature flag when no cloudwatch log configured', () => {
         // GIVEN


### PR DESCRIPTION
## Summary

Fixes #38102

The `@aws-cdk/aws-ecs:shouldUseCircuitBreaker` warning fires for `Ec2Service` with `daemon: true`, even though the ECS deployment circuit breaker does not apply to DAEMON services. The circuit breaker threshold is `0.5 × desiredCount` (min 3), but DAEMON services have no `desiredCount` — they run one task per container instance. Following the warning's advice and setting `circuitBreaker` on a daemon service is meaningless, and the only way to silence the false positive today is `acknowledgeWarning()`.

**Root cause:** `BaseService` guards the warning with `!props.circuitBreaker && this.isEcsDeploymentController`, with no check for the scheduling strategy. `Ec2Service` passes `schedulingStrategy` only in `additionalProps`, so `BaseService` never accounts for it.

**Fix:** Add `additionalProps?.schedulingStrategy !== 'DAEMON'` to the warning guard. This is consistent with how CDK already special-cases daemon mode in multiple other places (`desiredCount` validation, `minHealthyPercent` default/warning, `availabilityZoneRebalancing` check, placement strategy checks).

## Changes

- [base-service.ts](packages/aws-cdk-lib/aws-ecs/lib/base/base-service.ts): Skip `shouldUseCircuitBreaker` warning when `schedulingStrategy` is `DAEMON`
- [ec2-service.test.ts](packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts): Add test asserting the warning is not emitted for daemon services

## Test plan

- [x] New test: `does not suggest circuitBreaker for DAEMON scheduling strategy services` — passes
- [x] Existing tests: `suggests using circuitBreaker if false set` and `suggests using circuitBreaker if true set` — still pass (non-daemon replica services are unaffected)
- [x] Existing daemon-related tests (minHealthyPercent, placement strategy, desiredCount validation) — unaffected
