### PR TITLE
docs: fix typo in awslint rule reference in design guidelines

### DIFF
--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -444,7 +444,7 @@ As a rule of thumb, most constructs should directly extend the **Construct** or
 behavior through interfaces and not through inheritance.
 
 Construct classes should extend only one of the following classes
-[_awslint:construct-inheritence_]:
+[_awslint:construct-inheritance_]:
 
 * The **Resource** class (if it represents an AWS resource)
 * The **Construct** class (if it represents an abstract component)


### PR DESCRIPTION
### Issue # (if applicable)
Closes #38119.

### Reason for this change
The design guidelines reference the linter rule as `awslint:construct-inheritence`,
which misspells "inheritance." The surrounding prose in the same section already
uses the correct spelling, so the rule reference is inconsistent with it.

### Description of changes
Corrected the spelling of the awslint rule reference in `docs/DESIGN_GUIDELINES.md`
from `awslint:construct-inheritence` to `awslint:construct-inheritance`.
Documentation-only change; no code or behavior is affected.

### Describe any new or updated permissions being added
None — documentation-only change, no IAM permissions involved.

### Description of how you validated changes
Documentation-only typo fix with no functional impact. Verified that the corrected
reference now matches the spelling ("inheritance") used in the surrounding text.
No unit or integration tests are applicable.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
----
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*