### PR TITLE
chore(lambda-go-alpha): update docker.test.ts path after Dockerfile move

### DIFF
--- a/packages/@aws-cdk/aws-lambda-go-alpha/test/docker.test.ts
+++ b/packages/@aws-cdk/aws-lambda-go-alpha/test/docker.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 const docker = process.env.CDK_DOCKER ?? 'docker';
 beforeAll(() => {
-  spawnSync(docker, ['build', '-t', 'golang', path.join(__dirname, '..', 'lib')]);
+  spawnSync(docker, ['build', '-t', 'golang', path.join(__dirname, '..', 'lib', 'docker')]);
 });
 
 test('golang is available', async () => {


### PR DESCRIPTION
### Issue # (if applicable)

None

### Reason for this change

PR #38134 moved the Dockerfile from `lib/Dockerfile` to `lib/docker/Dockerfile` but did not update the test path in `@aws-cdk/aws-lambda-go-alpha`. The `"golang is available"` test fails with Docker exit code 125 because no Dockerfile is found at the old build context path, blocking the pipeline.

### Description of changes

Updated `packages/@aws-cdk/aws-lambda-go-alpha/test/docker.test.ts` to use `path.join(__dirname, .., lib, docker)` instead of `path.join(__dirname, .., lib)` to match the new Dockerfile location.

This is the same fix that was applied to `aws-lambda-nodejs/test/docker.test.ts` in PR #38134 but was missed for `aws-lambda-go-alpha`.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

- Verified that `packages/@aws-cdk/aws-lambda-go-alpha/lib/docker/Dockerfile` exists at the new path
- Confirmed the equivalent fix was applied to `aws-lambda-nodejs` in PR #38134

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*