### PR TITLE
chore(core): annotations are always written to validation report

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/synthesis.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis.ts
@@ -17,7 +17,6 @@ import { Annotations } from '../annotations';
 import { App } from '../app';
 import { _aspectTreeRevisionReader, AspectApplication, AspectPriority, Aspects } from '../aspect';
 import { AssumptionError, UnscopedValidationError } from '../errors';
-import { FeatureFlags } from '../feature-flags';
 import { Stack } from '../stack';
 import type { ISynthesisSession } from '../stack-synthesizers/types';
 import type { StageSynthesisOptions } from '../stage';
@@ -129,11 +128,9 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
   }
 
   // 2. Construct annotations (as a plugin, only if there are annotations to report)
-  if (FeatureFlags.of(root).isEnabled(cxapi.ANNOTATIONS_IN_VALIDATION_REPORT)) {
-    const annotationReport = collectAnnotationReport(root, assembly.directory);
-    if (annotationReport) {
-      plugins.push({ plugin: new AnnotationPlugin(annotationReport), templatePaths: [] });
-    }
+  const annotationReport = collectAnnotationReport(root, assembly.directory);
+  if (annotationReport) {
+    plugins.push({ plugin: new AnnotationPlugin(annotationReport), templatePaths: [] });
   }
 
   if (plugins.length === 0) return;

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Construct } from 'constructs';
 import { table } from 'table';
-import * as cxapi from '../../../cx-api';
 import * as core from '../../lib';
 
 let consoleErrorMock: jest.SpyInstance;
@@ -1007,10 +1006,8 @@ Policy Validation Report Summary
   });
 
   describe('annotation report integration', () => {
-    const annotationReportContext = { [cxapi.ANNOTATIONS_IN_VALIDATION_REPORT]: true };
-
     test('annotation warnings appear in validation report', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1032,7 +1029,7 @@ Policy Validation Report Summary
     });
 
     test('annotation errors cause validation failure', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1053,7 +1050,7 @@ Policy Validation Report Summary
     });
 
     test('acknowledged warnings are excluded from annotation report', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1072,7 +1069,7 @@ Policy Validation Report Summary
     });
 
     test('partial acknowledgment only excludes acknowledged warnings', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1094,7 +1091,6 @@ Policy Validation Report Summary
 
     test('annotation report works alongside plugin reports', () => {
       const app = new core.App({
-        context: annotationReportContext,
         policyValidationBeta1: [
           new FakePlugin('test-plugin', [{
             description: 'plugin violation',
@@ -1128,7 +1124,7 @@ Policy Validation Report Summary
     });
 
     test('annotation report with no plugins registered still produces output', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1148,7 +1144,7 @@ Policy Validation Report Summary
     });
 
     test('annotations on constructs without CfnResource use construct path', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'Orphan');
       // No CfnResource child
@@ -1170,7 +1166,7 @@ Policy Validation Report Summary
     });
 
     test('Validations.of().addWarning appears in annotation report', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1188,7 +1184,7 @@ Policy Validation Report Summary
     });
 
     test('Validations.of().addError appears in annotation report and fails', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1211,7 +1207,7 @@ Policy Validation Report Summary
       // This test verifies the coupling between the [ack: <id>] tag format
       // produced by Annotations.addWarningV2 and the regex in extractRuleName.
       // If the tag format in annotations.ts changes, this test should fail.
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {
@@ -1232,7 +1228,7 @@ Policy Validation Report Summary
     });
 
     test('plugin violations can be suppressed via Validations.acknowledge()', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'MyBucket', {
         type: 'AWS::S3::Bucket',
@@ -1264,7 +1260,6 @@ Policy Validation Report Summary
     test('suppressed violations appear in validation-report.json', () => {
       const app = new core.App({
         context: {
-          ...annotationReportContext,
           '@aws-cdk/core:failSynthOnValidationErrors': false,
         },
       });
@@ -1310,7 +1305,7 @@ Policy Validation Report Summary
     });
 
     test('fatal plugin violations cannot be suppressed', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'Fake', {
         type: 'AWS::S3::Bucket',
@@ -1342,7 +1337,7 @@ Policy Validation Report Summary
     });
 
     test('plugin names with spaces use dashes in suppression IDs', () => {
-      const app = new core.App({ context: annotationReportContext });
+      const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'Fake', {
         type: 'AWS::S3::Bucket',
@@ -1372,9 +1367,7 @@ Policy Validation Report Summary
     });
 
     test('validation report JSON is always written to assembly directory', () => {
-      const app = new core.App({
-        context: annotationReportContext,
-      });
+      const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       new core.CfnResource(construct, 'Resource', {

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -155,7 +155,6 @@ export const ELB_USE_POST_QUANTUM_TLS_POLICY = '@aws-cdk/aws-elasticloadbalancin
 export const AUTOMATIC_L1_TRAITS = '@aws-cdk/core:automaticL1Traits';
 export const BATCH_DEFAULT_AL2023 = '@aws-cdk/aws-batch:defaultToAL2023';
 export const EKS_DEFAULT_AL2023 = '@aws-cdk/aws-eks:defaultToAL2023';
-export const ANNOTATIONS_IN_VALIDATION_REPORT = '@aws-cdk/core:annotationsInValidationReport';
 export const DEFAULT_CROSS_STACK_REFERENCES = '@aws-cdk/core:defaultCrossStackReferences';
 
 export const FLAGS: Record<string, FlagInfo> = {
@@ -1862,26 +1861,6 @@ export const FLAGS: Record<string, FlagInfo> = {
     compatibilityWithOldBehaviorMd: `Explicitly set \`amiType\` to the desired AL2 type (e.g., \`NodegroupAmiType.AL2_X86_64\`) in your nodegroup configuration.
 
 **Warning**: Enabling this flag on existing stacks will cause node group replacement, which terminates running pods. To migrate safely, first pin existing node groups to their current amiType explicitly, then enable the flag for new node groups.`,
-  },
-
-  //////////////////////////////////////////////////////////////////////
-  [ANNOTATIONS_IN_VALIDATION_REPORT]: {
-    type: FlagType.VisibleContext,
-    summary: 'Include construct annotations (warnings and errors) in the policy validation report',
-    detailsMd: `
-      When enabled, construct annotations added via \`Annotations.of()\` or \`Validations.of()\`
-      are collected post-synthesis and included in the policy validation report alongside
-      plugin violations. Annotations appear under a "Construct Annotations" source entry.
-
-      When disabled, annotations are only displayed through the CLI's standard metadata
-      output (e.g. \`[Warning at /path] message\`) and do not appear in the validation report.
-
-      Note: enabling this flag may cause annotations to appear twice — once in the CLI's
-      standard output and once in the validation report — until the CLI is updated to
-      consolidate both displays.`,
-    introducedIn: { v2: '2.253.0' },
-    recommendedValue: true,
-    unconfiguredBehavesLike: { v2: false },
   },
 
   //////////////////////////////////////////////////////////////////////

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -50,8 +50,6 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.DEFAULT_CROSS_STACK_REFERENCES]: 'strong',
     [feats.BATCH_DEFAULT_AL2023]: false,
     [feats.EKS_DEFAULT_AL2023]: false,
-    [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
-
   });
 });
 

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -85,6 +85,5 @@
   "@aws-cdk/aws-elasticloadbalancingv2:usePostQuantumTlsPolicy": true,
   "@aws-cdk/aws-batch:defaultToAL2023": true,
   "@aws-cdk/aws-eks:defaultToAL2023": true,
-  "@aws-cdk/core:annotationsInValidationReport": true,
   "@aws-cdk/core:defaultCrossStackReferences": "weak"
 }


### PR DESCRIPTION
This PR is part of a larger initiative to streamline the validation report. 

We will now always write annotation warnings and errors to the validation report. Therefore annotations issues will now be rendered as part of the validation report and this report will serve as the single-stop location for all validation issues going forward.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
