### PR TITLE
feat(redshift-alpha): add RG node types

### DIFF
--- a/packages/@aws-cdk/aws-redshift-alpha/lib/cluster.ts
+++ b/packages/@aws-cdk/aws-redshift-alpha/lib/cluster.ts
@@ -75,6 +75,16 @@ export enum NodeType {
    * ra3.16xlarge
    */
   RA3_16XLARGE = 'ra3.16xlarge',
+
+  /**
+   * rg.xlarge
+   */
+  RG_XLARGE = 'rg.xlarge',
+
+  /**
+   * rg.4xlarge
+   */
+  RG_4XLARGE = 'rg.4xlarge',
 }
 
 /**


### PR DESCRIPTION
### Issue #38156

Closes #38156 

### Reason for this change

I want to deploy redshift clusters with the new [RG node types](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-redshift-cluster.html#cfn-redshift-cluster-nodetype)

### Description of changes

Added the currently available RG node types to the `NodeType` enum

### Describe any new or updated permissions being added

N/A


### Description of how you validated changes

ran the build process locally

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
