### PR TITLE
chore(core): cdk cli handles terminal output for validation report

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/synthesis.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis.ts
@@ -138,9 +138,6 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
 
   if (plugins.length === 0) return;
 
-  // eslint-disable-next-line no-console
-  console.error('Performing Policy Validations\n');
-
   // Snapshot pre-existing files so we can detect modifications while still
   // allowing plugins to create new files in the assembly directory.
   const preExistingFileHashes = snapshotFileHashes(outdir);
@@ -214,7 +211,6 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
   if (reports.length > 0) {
     const tree = new ConstructTree(root);
     const formatter = new PolicyValidationReportFormatter(tree);
-    const failOnErrors = getBooleanContext(root, cxapi.FAIL_SYNTH_ON_VALIDATION_ERRORS_CONTEXT, true);
     const writeLegacyReport = getBooleanContext(root, cxapi.VALIDATION_REPORT_JSON_CONTEXT, false);
 
     const reportFile = path.join(assembly.directory, cxapi.VALIDATION_REPORT_FILE);
@@ -225,18 +221,6 @@ function invokeValidationPlugins(root: IConstruct, outdir: string, assembly: pri
       const legacyReportFile = path.join(assembly.directory, LEGACY_POLICY_VALIDATION_FILE_PATH);
       const legacyOutput = formatter.formatLegacyJson(reports);
       fs.writeFileSync(legacyReportFile, JSON.stringify(legacyOutput, undefined, 2));
-    }
-
-    if (failOnErrors) {
-      const output = formatter.formatPrettyPrinted(reports);
-      // eslint-disable-next-line no-console
-      console.error(output);
-      const failed = reports.some(r => !r.success);
-      if (failed) {
-        // eslint-disable-next-line no-console
-        console.error(`Validation failed. A copy of this report can be found in '${reportFile}'`);
-        process.exitCode = 1;
-      }
     }
   }
 }

--- a/packages/aws-cdk-lib/core/lib/validation/private/report.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/report.ts
@@ -1,6 +1,4 @@
-import * as os from 'os';
 import * as path from 'path';
-import { table } from 'table';
 import type { ConstructTree, ConstructTrace } from './construct-tree';
 import { ReportTrace } from './trace';
 import * as report from '../report';
@@ -176,81 +174,6 @@ export class PolicyValidationReportFormatter {
     this.reportTrace = new ReportTrace(tree);
   }
 
-  public formatPrettyPrinted(reps: NamedValidationPluginReport[]): string {
-    const json = this.formatLegacyJson(reps);
-    const output = [json.title];
-    output.push('-'.repeat(json.title.length));
-
-    json.pluginReports.forEach(plugin => {
-      output.push('');
-      output.push(table([
-        [`Source: ${plugin.summary.pluginName}`],
-        [`Version: ${plugin.version ?? 'N/A'}`],
-        [`Status: ${plugin.summary.status}`],
-      ], {
-        header: { content: 'Validation Report' },
-        singleLine: true,
-        columns: [{
-          paddingLeft: 3,
-          paddingRight: 3,
-        }],
-      }));
-      if (plugin.summary.metadata) {
-        output.push('');
-        output.push(`Metadata: \n\t${Object.entries(plugin.summary.metadata).flatMap(([key, value]) => `${key}: ${value}`).join('\n\t')}`);
-      }
-
-      if (plugin.violations.length > 0) {
-        output.push('');
-        output.push('(Violations)');
-      }
-
-      plugin.violations.forEach((violation) => {
-        const constructs = violation.violatingConstructs;
-        const occurrences = constructs.length;
-        const title = reset(red(bright(`${violation.ruleName} (${occurrences} occurrences)`)));
-        output.push('');
-        output.push(title);
-        if (violation.severity) {
-          output.push(`Severity: ${violation.severity}`);
-        }
-        output.push('');
-        output.push('  Occurrences:');
-        for (const construct of constructs) {
-          output.push('');
-          output.push(`    - Construct Path: ${construct.constructPath ?? 'N/A'}`);
-          output.push(`    - Template Path: ${construct.templatePath ?? 'N/A'}`);
-          output.push(`    - Creation Stack:\n\t${this.reportTrace.formatPrettyPrinted(construct.constructPath)}`);
-          output.push(`    - Resource ID: ${construct.resourceLogicalId ?? 'N/A'}`);
-          if (construct.locations) {
-            output.push('    - Template Locations:');
-            for (const location of construct.locations) {
-              output.push(`      > ${location}`);
-            }
-          }
-        }
-        output.push('');
-        output.push(`  Description: ${violation.description }`);
-        if (violation.fix) {
-          output.push(`  How to fix: ${violation.fix}`);
-        }
-        if (violation.ruleMetadata) {
-          output.push(`  Rule Metadata: \n\t${Object.entries(violation.ruleMetadata).flatMap(([key, value]) => `${key}: ${value}`).join('\n\t')}`);
-        }
-      });
-    });
-
-    output.push('');
-    output.push('Policy Validation Report Summary');
-    output.push('');
-    output.push(table([
-      ['Source', 'Status'],
-      ...reps.map(rep => [rep.pluginName, rep.success ? 'success' : 'failure']),
-    ], { }));
-
-    return output.join(os.EOL);
-  }
-
   public formatLegacyJson(reps: NamedValidationPluginReport[]): LegacyPolicyValidationReportJson {
     return {
       title: 'Validation Report',
@@ -418,14 +341,3 @@ function normalizeSeverity(severity: string | undefined): { severity: PolicyViol
   return { severity: 'custom', customSeverity: severity };
 }
 
-function reset(s: string) {
-  return `${s}\x1b[0m`;
-}
-
-function red(s: string) {
-  return `\x1b[31m${s}`;
-}
-
-function bright(s: string) {
-  return `\x1b[1m${s}`;
-}

--- a/packages/aws-cdk-lib/core/lib/validation/private/trace.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/trace.ts
@@ -1,8 +1,5 @@
 import type { ConstructTree, ConstructTrace } from './construct-tree';
 
-const STARTER_LINE = '└── ';
-const VERTICAL_LINE = '│';
-
 /**
  * Utility class to generate the construct stack trace
  * for a report
@@ -15,43 +12,5 @@ export class ReportTrace {
    */
   public formatJson(constructPath: string): ConstructTrace | undefined {
     return this.tree.traceFromPath(constructPath);
-  }
-
-  /**
-   * This will render something like this:
-   *
-   *   Creation Stack:
-   *     └──  MyStack (MyStack)
-   *          │ Library: aws-cdk-lib.Stack
-   *          │ Library Version: 2.50.0
-   *          │ Location: Object.<anonymous> (/home/hallcor/tmp/cdk-tmp-app/src/main.ts:25:20)
-   *          └──  MyCustomL3Construct (MyStack/MyCustomL3Construct)
-   *               │ Library: N/A - (Local Construct)
-   *               │ Library Version: N/A
-   *               │ Location: new MyStack (/home/hallcor/tmp/cdk-tmp-app/src/main.ts:15:20)
-   *               └──  Bucket (MyStack/MyCustomL3Construct/Bucket)
-   *                    │ Library: aws-cdk-lib/aws-s3.Bucket
-   *                    │ Library Version: 2.50.0
-   *                    │ Location: new MyCustomL3Construct (/home/hallcor/tmp/cdk-tmp-app/src/main.ts:9:20)/
-   */
-  public formatPrettyPrinted(constructPath?: string): string {
-    const trace = constructPath ? this.formatJson(constructPath) : undefined;
-    return this.renderPrettyPrintedTraceInfo(trace);
-  }
-
-  private renderPrettyPrintedTraceInfo(info?: ConstructTrace, indent?: string, start: string = STARTER_LINE): string {
-    const notAvailableMessage = '\tConstruct trace not available. Rerun with `--debug` to see trace information';
-    if (info) {
-      const indentation = indent ?? ' '.repeat(STARTER_LINE.length+1);
-      const result: string[] = [
-        `${start} ${info?.id} (${info?.path})`,
-        `${indentation}${VERTICAL_LINE} Construct: ${info?.construct}`,
-        `${indentation}${VERTICAL_LINE} Library Version: ${info?.libraryVersion}`,
-        `${indentation}${VERTICAL_LINE} Location: ${info?.location}`,
-        ...info?.child ? [this.renderPrettyPrintedTraceInfo(info?.child, ' '.repeat(indentation.length+STARTER_LINE.length+1), indentation+STARTER_LINE)] : [],
-      ];
-      return result.join('\n\t');
-    }
-    return notAvailableMessage;
   }
 }

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -1,15 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Construct } from 'constructs';
-import { table } from 'table';
 import * as cxapi from '../../../cx-api';
 import * as core from '../../lib';
 
-let consoleErrorMock: jest.SpyInstance;
 beforeEach(() => {
-  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => { return true; });
+  jest.spyOn(console, 'error').mockImplementation(() => { return true; });
   jest.spyOn(console, 'log').mockImplementation(() => { return true; });
-  process.exitCode = undefined;
 });
 
 afterEach(() => {
@@ -21,7 +18,7 @@ afterAll(() => {
 });
 
 describe('validations', () => {
-  test('validation failure', () => {
+  test('validation failure writes report with violations', () => {
     const app = new core.App({
       policyValidationBeta1: [
         new FakePlugin('test-plugin', [{
@@ -48,33 +45,30 @@ describe('validations', () => {
     });
 
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    expect(consoleErrorMock.mock.calls[1][0].split('\n')).toEqual(expect.arrayContaining(validationReport([{
-      templatePath: '/path/to/Default.template.json',
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(report.pluginReports).toHaveLength(1);
+    expect(report.pluginReports[0].pluginName).toEqual('test-plugin');
+    expect(report.pluginReports[0].conclusion).toEqual('failure');
+    expect(report.pluginReports[0].violations[0]).toEqual(expect.objectContaining({
+      ruleName: 'test-rule',
+      description: 'test recommendation',
+      severity: 'custom',
+      customSeverity: 'medium',
+      ruleMetadata: { id: 'abcdefg' },
+    }));
+    expect(report.pluginReports[0].violations[0].violatingConstructs[0]).toEqual(expect.objectContaining({
       constructPath: 'Default/Fake',
-      title: 'test-rule',
-      pluginName: 'test-plugin',
-      status: 'failure',
-      ruleMetadata: {
-        id: 'abcdefg',
+      cloudFormationResource: {
+        templatePath: '/path/to/Default.template.json',
+        logicalId: 'Fake',
+        propertyPaths: ['test-location'],
       },
-      severity: 'medium',
-      creationStack: [
-        expect.stringMatching(/Default \(Default\)/),
-        expect.stringMatching(/│ Construct: (aws-cdk-lib.Stack|constructs.Construct)/),
-        expect.stringMatching(/│ Library Version: .*/),
-        expect.stringMatching(/│ Location:/),
-        expect.stringMatching(/└──  Fake \(Default\/Fake\)/),
-        expect.stringMatching(/│ Construct: (aws-cdk-lib.CfnResource|constructs.Construct)/),
-        expect.stringMatching(/│ Library Version: .*/),
-        expect.stringMatching(/│ Location:/),
-      ],
-      resourceLogicalId: 'Fake',
-    }])));
+    }));
   });
 
-  test('validation success', () => {
+  test('validation success writes no plugin reports', () => {
     const app = new core.App({
       policyValidationBeta1: [
         new FakePlugin('test-plugin', []),
@@ -91,29 +85,13 @@ describe('validations', () => {
     });
 
     app.synth();
-    expect(process.exitCode).toBeUndefined();
 
-    expect(consoleErrorMock.mock.calls[0]).toEqual([
-      expect.stringMatching(/Performing Policy Validations/),
-    ]);
-    expect(consoleErrorMock.mock.calls[1][0]).toEqual(`Validation Report
------------------
-
-Policy Validation Report Summary
-
-╔══════════════╤═════════╗
-║ Source       │ Status  ║
-╟──────────────┼─────────╢
-║ test-plugin  │ success ║
-╟──────────────┼─────────╢
-║ test-plugin2 │ success ║
-╟──────────────┼─────────╢
-║ test-plugin3 │ success ║
-╚══════════════╧═════════╝
-`);
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(report.pluginReports).toHaveLength(0);
   });
 
-  test('multiple stacks', () => {
+  test('multiple stacks - only violating stack appears in report', () => {
     const app = new core.App({
       policyValidationBeta1: [
         new FakePlugin('test-plugin', [{
@@ -143,12 +121,11 @@ Policy Validation Report Summary
     });
 
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    const report = consoleErrorMock.mock.calls[1][0];
-    // Assuming the rest of the report's content is checked by another test
-    expect(report).toContain('- Template Path: /path/to/stack1.template.json');
-    expect(report).not.toContain('- Template Path: /path/to/stack2.template.json');
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const cfnResource = report.pluginReports[0].violations[0].violatingConstructs[0].cloudFormationResource;
+    expect(cfnResource.templatePath).toEqual('/path/to/stack1.template.json');
   });
 
   test('multiple stages', () => {
@@ -227,65 +204,14 @@ Policy Validation Report Summary
     });
 
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    const report = consoleErrorMock.mock.calls[1][0].split('\n');
-    // Assuming the rest of the report's content is checked by another test
-    expect(report).toEqual(expect.arrayContaining(
-      validationReport([
-        {
-          pluginName: 'test-plugin2',
-          status: 'failure',
-          templatePath: '/path/to/Stage1stack1DDED8B6C.template.json',
-          constructPath: 'Stage1/stack1/DefaultResource',
-          title: 'test-rule2',
-          creationStack: [
-            expect.stringMatching(/Stage1 \(Stage1\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.Stage|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-            expect.stringMatching(/└──  stack1 \(Stage1\/stack1\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.Stack|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-            expect.stringMatching(/└──  DefaultResource \(Stage1\/stack1\/DefaultResource\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.CfnResource|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-          ],
-          resourceLogicalId: 'DefaultResource',
-          description: 'do something',
-          version: '1.2.3',
-        },
-        {
-          pluginName: 'test-plugin4',
-          status: 'failure',
-          templatePath: '/path/to/Stage2Stage3stack10CD36915.template.json',
-          constructPath: 'Stage2/Stage3/stack1/DefaultResource',
-          description: 'do something',
-          title: 'test-rule4',
-          resourceLogicalId: 'DefaultResource',
-        },
-        {
-          pluginName: 'test-plugin3',
-          status: 'failure',
-          templatePath: '/path/to/Stage2stack259BA718E.template.json',
-          constructPath: 'Stage2/stack2/DefaultResource',
-          title: 'test-rule3',
-          resourceLogicalId: 'DefaultResource',
-          description: 'do something',
-        },
-        {
-          pluginName: 'test-plugin1',
-          status: 'failure',
-          templatePath: '/path/to/Stage1stack1DDED8B6C.template.json',
-          constructPath: 'Stage1/stack1/DefaultResource',
-          title: 'test-rule1',
-          resourceLogicalId: 'DefaultResource',
-          description: 'do something',
-        },
-      ]),
-    ));
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const pluginNames = report.pluginReports.map((r: any) => r.pluginName);
+    expect(pluginNames).toContain('test-plugin1');
+    expect(pluginNames).toContain('test-plugin2');
+    expect(pluginNames).toContain('test-plugin3');
+    expect(pluginNames).toContain('test-plugin4');
   });
 
   test('multiple stages, multiple plugins', () => {
@@ -403,7 +329,7 @@ Policy Validation Report Summary
     }));
   });
 
-  test('multiple constructs', () => {
+  test('multiple constructs - only violating construct in report', () => {
     const app = new core.App({
       policyValidationBeta1: [
         new FakePlugin('test-plugin', [{
@@ -421,12 +347,11 @@ Policy Validation Report Summary
     new LevelTwoConstruct(stack, 'SomeResource');
     new LevelTwoConstruct(stack, 'AnotherResource');
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    const report = consoleErrorMock.mock.calls[1][0];
-    // Assuming the rest of the report's content is checked by another test
-    expect(report).toContain('- Construct Path: Default/SomeResource');
-    expect(report).not.toContain('- Construct Path: Default/AnotherResource');
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const constructPath = report.pluginReports[0].violations[0].violatingConstructs[0].constructPath;
+    expect(constructPath).toEqual('Default/SomeResource/Resource');
   });
 
   test('multiple plugins', () => {
@@ -460,108 +385,20 @@ Policy Validation Report Summary
       },
     });
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    const report = consoleErrorMock.mock.calls[1][0].split('\n');
-    expect(report).toEqual(expect.arrayContaining(
-      validationReport([
-        {
-          pluginName: 'plugin1',
-          status: 'failure',
-          templatePath: '/path/to/Default.template.json',
-          constructPath: 'Default/Fake',
-          title: 'rule-1',
-          creationStack: [
-            expect.stringMatching(/Default \(Default\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.Stack|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-            expect.stringMatching(/└──  Fake \(Default\/Fake\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.CfnResource|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-          ],
-          description: 'do something',
-          resourceLogicalId: 'Fake',
-        },
-        {
-          pluginName: 'plugin2',
-          status: 'failure',
-          templatePath: '/path/to/Default.template.json',
-          constructPath: 'Default/Fake',
-          title: 'rule-2',
-          description: 'do another thing',
-          resourceLogicalId: 'Fake',
-        },
-      ]),
-    ));
-  });
-
-  test('multiple plugins with mixed results', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('plugin1', []),
-        new FakePlugin('plugin2', [{
-          description: 'do another thing',
-          ruleName: 'rule-2',
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: {
-        result: 'failure',
-      },
-    });
-    app.synth();
-
-    const report = consoleErrorMock.mock.calls[1][0].split('\n');
-    expect(report).toEqual(expect.arrayContaining(
-      validationReport([
-        {
-          pluginName: 'plugin1',
-          status: 'success',
-          constructPath: '',
-          resourceLogicalId: '',
-          templatePath: '',
-          title: '',
-        },
-        {
-          pluginName: 'plugin2',
-          status: 'failure',
-          templatePath: '/path/to/Default.template.json',
-          constructPath: 'Default/Fake',
-          title: 'rule-2',
-          creationStack: [
-            expect.stringMatching(/Default \(Default\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.Stack|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-            expect.stringMatching(/└──  Fake \(Default\/Fake\)/),
-            expect.stringMatching(/│ Construct: (aws-cdk-lib.CfnResource|constructs.Construct)/),
-            expect.stringMatching(/│ Library Version: .*/),
-            expect.stringMatching(/│ Location:/),
-          ],
-          description: 'do another thing',
-          resourceLogicalId: 'Fake',
-        },
-      ]),
-    ));
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(report.pluginReports).toHaveLength(2);
+    expect(report.pluginReports[0].pluginName).toEqual('plugin1');
+    expect(report.pluginReports[0].violations[0].ruleName).toEqual('rule-1');
+    expect(report.pluginReports[1].pluginName).toEqual('plugin2');
+    expect(report.pluginReports[1].violations[0].ruleName).toEqual('rule-2');
   });
 
   test('plugin throws an error', () => {
     const app = new core.App({
       policyValidationBeta1: [
-        // This plugin will throw an error
         new BrokenPlugin(),
-
-        // But this one should still run
         new FakePlugin('test-plugin', [{
           description: 'test recommendation',
           ruleName: 'test-rule',
@@ -583,11 +420,12 @@ Policy Validation Report Summary
     });
 
     app.synth();
-    expect(process.exitCode).toEqual(1);
 
-    const report = consoleErrorMock.mock.calls[1][0];
-    expect(report).toContain('error: Validation plugin \'broken-plugin\' failed: Something went wrong');
-    expect(report).toContain(generateTable('test-plugin', 'failure', 'N/A'));
+    const file = path.join(app.outdir, 'validation-report.json');
+    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const brokenReport = report.pluginReports.find((r: any) => r.pluginName === 'broken-plugin');
+    expect(brokenReport.conclusion).toEqual('failure');
+    expect(brokenReport.metadata.error).toContain("Validation plugin 'broken-plugin' failed: Something went wrong");
   });
 
   test('plugin tries to modify a template', () => {
@@ -652,7 +490,7 @@ Policy Validation Report Summary
     expect(() => app.synth()).toThrow(/Illegal operation: validation plugin 'deleter-plugin' modified the cloud assembly/);
   });
 
-  test('failSynthOnValidationErrors=false writes JSON but does not print or fail', () => {
+  test('validation report JSON is written with correct structure', () => {
     const app = new core.App({
       policyValidationBeta1: [
         new FakePlugin('test-plugin', [{
@@ -668,9 +506,6 @@ Policy Validation Report Summary
           }],
         }]),
       ],
-      context: {
-        '@aws-cdk/core:failSynthOnValidationErrors': false,
-      },
     });
     const stack = new core.Stack(app);
     new core.CfnResource(stack, 'Fake', {
@@ -681,10 +516,6 @@ Policy Validation Report Summary
     });
     app.synth();
 
-    // No exit code set
-    expect(process.exitCode).toBeUndefined();
-
-    // JSON file is written in the new v2 format
     const file = path.join(app.outdir, 'validation-report.json');
     const report = JSON.parse(fs.readFileSync(file).toString('utf-8'));
     expect(report).toEqual(expect.objectContaining({
@@ -718,149 +549,6 @@ Policy Validation Report Summary
         },
       ],
     }));
-
-    // No console output about validation
-    const allOutput = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-    expect(allOutput).not.toContain('Validation failed');
-    expect(allOutput).not.toContain('Validation Report');
-  });
-
-  test('failSynthOnValidationErrors="false" (string) works the same as boolean false', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('test-plugin', [{
-          description: 'test recommendation',
-          ruleName: 'test-rule',
-          ruleMetadata: {
-            id: 'abcdefg',
-          },
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-      context: {
-        '@aws-cdk/core:failSynthOnValidationErrors': 'false',
-      },
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: {
-        result: 'failure',
-      },
-    });
-    app.synth();
-
-    expect(process.exitCode).toBeUndefined();
-
-    const file = path.join(app.outdir, 'validation-report.json');
-    expect(fs.existsSync(file)).toBe(true);
-
-    const allOutput = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-    expect(allOutput).not.toContain('Validation failed');
-    expect(allOutput).not.toContain('Validation Report');
-  });
-
-  test('Pretty print as default', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('test-plugin', [{
-          description: 'test recommendation',
-          ruleName: 'test-rule',
-          ruleMetadata: {
-            id: 'abcdefg',
-          },
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-      context: {
-      },
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: {
-        result: 'failure',
-      },
-    });
-    app.synth();
-    expect(process.exitCode).toEqual(1);
-    const consoleOut = consoleErrorMock.mock.calls[2][0];
-    expect(consoleOut).toContain('Validation failed. A copy of this report can be found in');
-    const consoleReport = consoleErrorMock.mock.calls[1][0];
-    expect(consoleReport).toContain('Validation Report');
-  });
-
-  test('both formats enabled by default', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('test-plugin', [{
-          description: 'test recommendation',
-          ruleName: 'test-rule',
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: { result: 'failure' },
-    });
-    app.synth();
-    expect(process.exitCode).toEqual(1);
-
-    // JSON file written
-    const file = path.join(app.outdir, 'validation-report.json');
-    expect(fs.existsSync(file)).toBe(true);
-
-    // Pretty print also output
-    const consoleReport = consoleErrorMock.mock.calls[1][0];
-    expect(consoleReport).toContain('Validation Report');
-  });
-
-  test('failSynthOnValidationErrors=false succeeds even with validation failures', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('test-plugin', [{
-          description: 'test recommendation',
-          ruleName: 'test-rule',
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-      context: {
-        '@aws-cdk/core:failSynthOnValidationErrors': false,
-      },
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: { result: 'failure' },
-    });
-    app.synth();
-
-    // No failure exit code
-    expect(process.exitCode).toBeUndefined();
-
-    // JSON file is still written
-    const file = path.join(app.outdir, 'validation-report.json');
-    expect(fs.existsSync(file)).toBe(true);
-    const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(report.pluginReports[0].conclusion).toEqual('failure');
   });
 
   test('validationReportJson=true writes legacy report alongside new report', () => {
@@ -930,71 +618,6 @@ Policy Validation Report Summary
     expect(fs.existsSync(path.join(app.outdir, 'policy-validation-report.json'))).toBe(false);
   });
 
-  test('Multi format', () => {
-    const app = new core.App({
-      policyValidationBeta1: [
-        new FakePlugin('test-plugin', [{
-          description: 'test recommendation',
-          ruleName: 'test-rule',
-          ruleMetadata: {
-            id: 'abcdefg',
-          },
-          violatingResources: [{
-            locations: ['test-location'],
-            resourceLogicalId: 'Fake',
-            templatePath: '/path/to/Default.template.json',
-          }],
-        }]),
-      ],
-    });
-    const stack = new core.Stack(app);
-    new core.CfnResource(stack, 'Fake', {
-      type: 'Test::Resource::Fake',
-      properties: {
-        result: 'failure',
-      },
-    });
-    app.synth();
-    expect(process.exitCode).toEqual(1);
-    const file = path.join(app.outdir, 'validation-report.json');
-    const report = JSON.parse(fs.readFileSync(file).toString('utf-8'));
-    expect(report).toEqual(expect.objectContaining({
-      version: expect.any(String),
-      title: 'Validation Report',
-      pluginReports: [
-        {
-          pluginName: 'test-plugin',
-          conclusion: 'failure',
-          violations: [
-            {
-              ruleName: 'test-rule',
-              description: 'test recommendation',
-              severity: 'error',
-              ruleMetadata: { id: 'abcdefg' },
-              violatingConstructs: [
-                {
-                  constructPath: 'Default/Fake',
-                  constructFqn: expect.stringMatching(/(aws-cdk-lib.CfnResource|Construct)/),
-                  libraryVersion: expect.any(String),
-                  cloudFormationResource: {
-                    templatePath: '/path/to/Default.template.json',
-                    logicalId: 'Fake',
-                    propertyPaths: ['test-location'],
-                  },
-                  stackTraces: expect.any(Array),
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    }));
-    const consoleOut = consoleErrorMock.mock.calls[2][0];
-    expect(consoleOut).toContain(`Validation failed. A copy of this report can be found in '${file}'`);
-    const consoleReport = consoleErrorMock.mock.calls[1][0];
-    expect(consoleReport).toContain('Validation Report');
-  });
-
   test('a plugin implementing Beta1 is assignable to IPolicyValidationPlugin', () => {
     // GIVEN
     const beta1Plugin: core.IPolicyValidationPluginBeta1 = new FakePlugin('beta1-plugin', []);
@@ -1022,16 +645,14 @@ Policy Validation Report Summary
 
       app.synth();
 
-      // Warnings alone should not fail
-      expect(process.exitCode).toBeUndefined();
-
-      // Should show the annotation report
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('my-lib:SomeWarning');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      expect(annotationPlugin).toBeDefined();
+      expect(annotationPlugin.violations[0].ruleName).toContain('my-lib:SomeWarning');
     });
 
-    test('annotation errors cause validation failure', () => {
+    test('annotation errors appear in validation report as errors', () => {
       const app = new core.App({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
@@ -1044,12 +665,11 @@ Policy Validation Report Summary
 
       app.synth();
 
-      expect(process.exitCode).toEqual(1);
-
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('Something is broken');
-      expect(output).toContain('Severity: error');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      expect(annotationPlugin).toBeDefined();
+      expect(annotationPlugin.conclusion).toEqual('failure');
     });
 
     test('acknowledged warnings are excluded from annotation report', () => {
@@ -1066,9 +686,9 @@ Policy Validation Report Summary
 
       app.synth();
 
-      // No annotations left, so no report at all
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).not.toContain('Construct Annotations');
+      // No annotations left, so no report file has plugin entries
+      const file = path.join(app.outdir, 'validation-report.json');
+      expect(fs.existsSync(file)).toBe(false);
     });
 
     test('partial acknowledgment only excludes acknowledged warnings', () => {
@@ -1086,10 +706,13 @@ Policy Validation Report Summary
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).not.toContain('annotation::AckedRule');
-      expect(output).toContain('annotation::KeptRule');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      expect(annotationPlugin).toBeDefined();
+      const ruleNames = annotationPlugin.violations.map((v: any) => v.ruleName);
+      expect(ruleNames).not.toContain('annotation::AckedRule');
+      expect(ruleNames).toContain('annotation::KeptRule');
     });
 
     test('annotation report works alongside plugin reports', () => {
@@ -1117,17 +740,14 @@ Policy Validation Report Summary
 
       app.synth();
 
-      expect(process.exitCode).toEqual(1);
-
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      // Both plugin and annotation reports should appear
-      expect(output).toContain('test-plugin');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('plugin-rule');
-      expect(output).toContain('my-lib:StackWarning');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginNames = report.pluginReports.map((r: any) => r.pluginName);
+      expect(pluginNames).toContain('test-plugin');
+      expect(pluginNames).toContain('Construct Annotations');
     });
 
-    test('annotation report with no plugins registered still produces output', () => {
+    test('annotation report with no plugins registered still produces report', () => {
       const app = new core.App({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
@@ -1140,33 +760,26 @@ Policy Validation Report Summary
 
       app.synth();
 
-      expect(process.exitCode).toEqual(1);
-
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('Error without plugins');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      expect(report.pluginReports[0].pluginName).toEqual('Construct Annotations');
+      expect(report.pluginReports[0].conclusion).toEqual('failure');
     });
 
     test('annotations on constructs without CfnResource use construct path', () => {
       const app = new core.App({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'Orphan');
-      // No CfnResource child
 
       core.Annotations.of(construct).addWarningV2('my-lib:OrphanWarning', 'Warning on orphan');
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('my-lib:OrphanWarning');
-      // Construct path is provided directly
-      expect(output).toContain('Construct Path: MyStack/Orphan');
-      // Resource ID is N/A for annotation-sourced violations
-      expect(output).toContain('Resource ID: N/A');
-      // templatePath should still resolve via Stack.of()
-      expect(output).toContain('Template Path:');
-      expect(output).toContain('MyStack.template.json');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      const violatingConstruct = annotationPlugin.violations[0].violatingConstructs[0];
+      expect(violatingConstruct.constructPath).toEqual('MyStack/Orphan');
     });
 
     test('Validations.of().addWarning appears in annotation report', () => {
@@ -1182,12 +795,14 @@ Policy Validation Report Summary
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('annotation::MyRule');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      const ruleNames = annotationPlugin.violations.map((v: any) => v.ruleName);
+      expect(ruleNames).toContain('annotation::MyRule');
     });
 
-    test('Validations.of().addError appears in annotation report and fails', () => {
+    test('Validations.of().addError appears in annotation report as failure', () => {
       const app = new core.App({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
@@ -1200,17 +815,13 @@ Policy Validation Report Summary
 
       app.synth();
 
-      expect(process.exitCode).toEqual(1);
-
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('Construct Annotations');
-      expect(output).toContain('Severity: error');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      expect(annotationPlugin.conclusion).toEqual('failure');
     });
 
     test('extractRuleName regex matches addWarningV2 ack tag format', () => {
-      // This test verifies the coupling between the [ack: <id>] tag format
-      // produced by Annotations.addWarningV2 and the regex in extractRuleName.
-      // If the tag format in annotations.ts changes, this test should fail.
       const app = new core.App({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
@@ -1227,8 +838,11 @@ Policy Validation Report Summary
 
       // Verify the report extracts the ID correctly
       app.synth();
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('my-lib:TestId (');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const annotationPlugin = report.pluginReports.find((r: any) => r.pluginName === 'Construct Annotations');
+      const ruleNames = annotationPlugin.violations.map((v: any) => v.ruleName);
+      expect(ruleNames).toContain('my-lib:TestId');
     });
 
     test('plugin violations can be suppressed via Validations.acknowledge()', () => {
@@ -1252,21 +866,20 @@ Policy Validation Report Summary
         }]),
       );
 
-      // Suppress the error-level violation using <pluginName>::<ruleId>
       core.Validations.of(stack).acknowledge({ id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED', reason: 'Not needed for this bucket' });
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).not.toContain('S3_BUCKET_VERSIONING_ENABLED');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginReport = report.pluginReports.find((r: any) => r.pluginName === 'test-plugin');
+      expect(pluginReport.violations).toHaveLength(0);
+      expect(pluginReport.suppressedViolations).toHaveLength(1);
     });
 
     test('suppressed violations appear in validation-report.json', () => {
       const app = new core.App({
-        context: {
-          ...annotationReportContext,
-          '@aws-cdk/core:failSynthOnValidationErrors': false,
-        },
+        context: annotationReportContext,
       });
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'MyBucket', {
@@ -1330,15 +943,15 @@ Policy Validation Report Summary
         }]),
       );
 
-      // Attempt to suppress the fatal violation
       core.Validations.of(stack).acknowledge({ id: 'test-plugin::E9001', reason: 'Trying to suppress fatal' });
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginReport = report.pluginReports.find((r: any) => r.pluginName === 'test-plugin');
       // Fatal violations remain despite acknowledgment
-      expect(output).toContain('E9001');
-      expect(output).toContain('Unknown resource type');
+      expect(pluginReport.violations[0].ruleName).toEqual('E9001');
     });
 
     test('plugin names with spaces use dashes in suppression IDs', () => {
@@ -1362,13 +975,14 @@ Policy Validation Report Summary
         }]),
       );
 
-      // Suppress using dashes instead of spaces
       core.Validations.of(stack).acknowledge({ id: 'My-Plugin::MY-RULE', reason: 'OK' });
 
       app.synth();
 
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).not.toContain('MY RULE');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginReport = report.pluginReports.find((r: any) => r.pluginName === 'My Plugin');
+      expect(pluginReport.violations).toHaveLength(0);
     });
 
     test('validation report JSON is always written to assembly directory', () => {
@@ -1395,40 +1009,31 @@ Policy Validation Report Summary
 
   describe('Validations.of()', () => {
     test('addPlugins adds plugin to enclosing stage', () => {
-      // GIVEN
       const app = new core.App();
       const plugin = new FakePlugin('test-plugin', []);
 
-      // WHEN
       core.Validations.of(app).addPlugins(plugin);
 
-      // THEN
       expect(app.policyValidationBeta1.map(p => p.name)).toContain('test-plugin');
     });
 
     test('addPlugins from nested construct resolves to enclosing stage', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const plugin = new FakePlugin('test-plugin', []);
 
-      // WHEN
       core.Validations.of(stack).addPlugins(plugin);
 
-      // THEN - plugin is registered on the app (enclosing stage), not the stack
       expect(app.policyValidationBeta1.map(p => p.name)).toContain('test-plugin');
     });
 
     test('throws when addPlugins called without enclosing stage', () => {
-      // GIVEN
       const construct = new Construct(undefined as any, '');
 
-      // THEN
       expect(() => core.Validations.of(construct).addPlugins(new FakePlugin('test', []))).toThrow(/without an enclosing Stage/);
     });
 
     test('plugin added via addPlugins runs during synth', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'Fake', {
@@ -1436,7 +1041,6 @@ Policy Validation Report Summary
         properties: { result: 'success' },
       });
 
-      // WHEN
       core.Validations.of(app).addPlugins(new FakePlugin('added-plugin', [{
         description: 'test recommendation',
         ruleName: 'test-rule',
@@ -1448,20 +1052,19 @@ Policy Validation Report Summary
       }]));
       app.synth();
 
-      // THEN - exitCode 1 means the plugin ran and reported violations
-      expect(process.exitCode).toEqual(1);
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      expect(report.pluginReports[0].pluginName).toEqual('added-plugin');
+      expect(report.pluginReports[0].conclusion).toEqual('failure');
     });
 
     test('addWarning adds warning metadata to construct', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
 
-      // WHEN
       core.Validations.of(construct).addWarning('my-lib:MyWarning', 'Something is off');
 
-      // THEN
       const warnings = construct.node.metadata.filter(m => m.type === 'aws:cdk:warning');
       expect(warnings).toHaveLength(1);
       expect(warnings[0].data).toContain('Something is off');
@@ -1469,48 +1072,39 @@ Policy Validation Report Summary
     });
 
     test('addError adds error metadata with id to construct', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
 
-      // WHEN
       core.Validations.of(construct).addError('my-lib:MyError', 'Something is wrong');
 
-      // THEN
       const errors = construct.node.metadata.filter(m => m.type === 'aws:cdk:error');
       expect(errors).toHaveLength(1);
       expect(errors[0].data).toBe('Something is wrong (annotation::my-lib:MyError)');
     });
 
     test('acknowledge routes annotation rules to Annotations.acknowledgeWarning', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
       core.Validations.of(construct).addWarning('SomeWarning', 'This is a warning');
 
-      // WHEN - no prefix defaults to annotation rule
       core.Validations.of(construct).acknowledge({ id: 'SomeWarning', reason: 'Accepted risk' });
 
-      // THEN - existing warning is removed
       const warningsAfterAck = construct.node.metadata.filter(m => m.type === 'aws:cdk:warning');
       expect(warningsAfterAck).toHaveLength(0);
     });
 
     test('acknowledge records to construct metadata', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
 
-      // WHEN
       core.Validations.of(construct).acknowledge(
         { id: 'annotation::SomeWarning', reason: 'Accepted risk per team review' },
         { id: 'some-plugin::RuleX', reason: 'Not applicable' },
       );
 
-      // THEN - one metadata entry per acknowledgement
       const ackEntries = construct.node.metadata.filter(
         m => m.type === core.Validations.ACKNOWLEDGED_RULES_METADATA_KEY,
       );
@@ -1521,16 +1115,13 @@ Policy Validation Report Summary
     });
 
     test('multiple acknowledge calls accumulate in metadata', () => {
-      // GIVEN
       const app = new core.App();
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
 
-      // WHEN - two separate calls
       core.Validations.of(construct).acknowledge({ id: 'RuleA', reason: 'reason A' });
       core.Validations.of(construct).acknowledge({ id: 'RuleB', reason: 'reason B' });
 
-      // THEN - separate metadata entries, each with stack trace
       const ackEntries = construct.node.metadata.filter(
         m => m.type === core.Validations.ACKNOWLEDGED_RULES_METADATA_KEY,
       );
@@ -1581,7 +1172,6 @@ Policy Validation Report Summary
     });
 
     test('non-Beta1 plugin with constructPath runs through synth', () => {
-      // GIVEN - a plugin returning violations with optional fields (constructPath instead of resourceLogicalId)
       const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'Fake', {
@@ -1589,7 +1179,6 @@ Policy Validation Report Summary
         properties: {},
       });
 
-      // WHEN
       core.Validations.of(app).addPlugins(new FakeNonBeta1Plugin('non-beta1-plugin', [{
         description: 'construct-level violation',
         ruleName: 'construct-rule',
@@ -1600,16 +1189,15 @@ Policy Validation Report Summary
       }]));
       app.synth();
 
-      // THEN
-      expect(process.exitCode).toEqual(1);
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('non-beta1-plugin');
-      expect(output).toContain('construct-rule');
-      expect(output).toContain('Default/Fake');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginReport = report.pluginReports.find((r: any) => r.pluginName === 'non-beta1-plugin');
+      expect(pluginReport.conclusion).toEqual('failure');
+      expect(pluginReport.violations[0].ruleName).toEqual('construct-rule');
+      expect(pluginReport.violations[0].violatingConstructs[0].constructPath).toEqual('Default/Fake');
     });
 
     test('non-Beta1 plugin accessed via policyValidationBeta1 getter has defaults for optional fields', () => {
-      // GIVEN - a plugin returning violations without resourceLogicalId or templatePath
       const app = new core.App();
       core.Validations.of(app).addPlugins(new FakeNonBeta1Plugin('non-beta1-plugin', [{
         description: 'test',
@@ -1620,17 +1208,14 @@ Policy Validation Report Summary
         }],
       }]));
 
-      // WHEN - access via Beta1 getter
       const beta1Plugins = app.policyValidationBeta1;
       const report = beta1Plugins[0].validate({ templatePaths: ['/tmp/test.template.json'], appConstruct: app });
 
-      // THEN - optional fields are filled with defaults
       expect(report.violations[0].violatingResources[0].resourceLogicalId).toEqual('');
       expect(report.violations[0].violatingResources[0].templatePath).toEqual('');
     });
 
     test('non-Beta1 plugin with all fields populated works identically to Beta1', () => {
-      // GIVEN - a non-Beta1 plugin that provides all fields (same as Beta1 would)
       const app = new core.App();
       const stack = new core.Stack(app);
       new core.CfnResource(stack, 'Fake', {
@@ -1649,12 +1234,11 @@ Policy Validation Report Summary
       }]));
       app.synth();
 
-      // THEN
-      expect(process.exitCode).toEqual(1);
-      const output = consoleErrorMock.mock.calls.map((c: any[]) => c[0]).join('\n');
-      expect(output).toContain('full-fields-plugin');
-      expect(output).toContain('full-rule');
-      expect(output).toContain('Resource ID: Fake');
+      const file = path.join(app.outdir, 'validation-report.json');
+      const report = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const pluginReport = report.pluginReports.find((r: any) => r.pluginName === 'full-fields-plugin');
+      expect(pluginReport.conclusion).toEqual('failure');
+      expect(pluginReport.violations[0].violatingConstructs[0].cloudFormationResource.logicalId).toEqual('Fake');
     });
   });
 });
@@ -1709,81 +1293,6 @@ class FakeNonBeta1Plugin implements core.IPolicyValidationPlugin {
       violations: this.violations,
     };
   }
-}
-
-interface ValidationReportData {
-  templatePath: string;
-  title: string;
-  status: string;
-  pluginName: string;
-  constructPath: string;
-  creationStack?: string[];
-  description?: string;
-  resourceLogicalId: string;
-  severity?: string;
-  version?: string;
-  ruleMetadata?: { [key: string]: string };
-}
-
-function generateTable(pluginName: string, status: string, pluginVersion: string): string {
-  return table([
-    [`Source: ${pluginName}`],
-    [`Version: ${pluginVersion}`],
-    [`Status: ${status}`],
-  ], {
-    header: { content: 'Validation Report' },
-    singleLine: true,
-    columns: [{
-      paddingLeft: 3,
-      paddingRight: 3,
-    }],
-  });
-}
-
-const validationReport = (data: ValidationReportData[]) => {
-  const result = data.flatMap(d => {
-    if (d.status === 'failure') {
-      const title = reset(red(bright(`${d.title} (1 occurrences)`)));
-      return [
-        expect.stringMatching(new RegExp('Validation Report')),
-        expect.stringMatching(new RegExp('-----------------')),
-        expect.stringMatching(new RegExp(`Source: ${d.pluginName}`)),
-        expect.stringMatching(new RegExp(`Version: ${d.version ?? 'N/A'}`)),
-        expect.stringMatching(new RegExp(`Status: ${d.status}`)),
-        expect.stringMatching(new RegExp('\\(Violations\\)')),
-        title,
-        ...d.severity ? [expect.stringMatching(new RegExp(`Severity: ${d.severity}`))] : [],
-        expect.stringMatching(new RegExp('  Occurrences:')),
-        expect.stringMatching(new RegExp(`    - Construct Path: ${d.constructPath}`)),
-        expect.stringMatching(new RegExp(`    - Template Path: ${d.templatePath}`)),
-        expect.stringMatching(new RegExp('    - Creation Stack:')),
-        ...d.creationStack ?? [],
-        expect.stringMatching(new RegExp(`    - Resource ID: ${d.resourceLogicalId}`)),
-        expect.stringMatching(new RegExp('    - Template Locations:')),
-        expect.stringMatching(new RegExp('      > test-location')),
-        expect.stringMatching(new RegExp(`  Description: ${d.description ?? 'test recommendation'}`)),
-        ...d.ruleMetadata ? [expect.stringMatching('  Rule Metadata:'), ...Object.entries(d.ruleMetadata).flatMap(([key, value]) => expect.stringMatching(`${key}: ${value}`))] : [],
-      ];
-    }
-    return [];
-  });
-  result.push(
-    expect.stringMatching(new RegExp('Policy Validation Report Summary')),
-    ...data.map(d => expect.stringMatching(new RegExp(`.*${d.pluginName}.*${d.status}.*`))),
-  );
-  return result;
-};
-
-function reset(s: string) {
-  return `${s}\x1b[0m`;
-}
-
-function red(s: string) {
-  return `\x1b[31m${s}`;
-}
-
-function bright(s: string) {
-  return `\x1b[1m${s}`;
 }
 
 class LevelTwoConstruct extends Construct {


### PR DESCRIPTION
In conjunction with a CLI change https://github.com/aws/aws-cdk-cli/pull/1633, the CLI now handles terminal output for validation. the core library handles writing the validation report as part of the cloud assembly _only_. It always writes `validation-report.json`, and will write the legacy `policy-validation-report.json` if a flag is set.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
