### PR TITLE
feat(core): add git source metadata to CloudFormation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ This solution collects anonymous operational metrics to help AWS improve the
 quality and features of the CDK. For more information, including how to disable
 this capability, please see the [developer guide](https://docs.aws.amazon.com/cdk/v2/guide/cdktelemetry.html).
 
+## Git source metadata
+
+The CDK can record the git repository URL and commit hash in your synthesized CloudFormation
+templates. This is disabled by default. To enable it, set `trackSourceCommit` in your
+CDK app:
+
+```ts
+new App({
+  trackSourceCommit: true,
+});
+```
+
+Or use the `@aws-cdk/core:trackSourceCommit` context key in your `cdk.json`:
+
+```json
+{
+  "context": {
+    "@aws-cdk/core:trackSourceCommit": true
+  }
+}
+```
+
+When enabled, the git remote URL and current commit hash are added as `AWS::CDK::Source` metadata to
+the template of each stack that has this feature enabled.
+
 ## More Resources
 
 * [AWS CDK Immersion Day Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/10141411-0192-4021-afa8-2436f3c66bd8/en-US)

--- a/packages/aws-cdk-lib/core/lib/app.ts
+++ b/packages/aws-cdk-lib/core/lib/app.ts
@@ -1,6 +1,7 @@
 import { performance } from 'perf_hooks';
 import type { Construct, IConstruct } from 'constructs';
 import * as fs from 'fs-extra';
+import { GIT_SOURCE_CONTEXT } from './git-source';
 import { readPerfCounters, TELEMETRY_FIELD } from './helpers-internal';
 import { PRIVATE_CONTEXT_DEFAULT_STACK_SYNTHESIZER } from './private/private-context';
 import type { ICustomSynthesis } from './private/synthesis';
@@ -131,6 +132,17 @@ export interface AppProps {
   readonly postCliContext?: { [key: string]: any };
 
   /**
+   * Include git source information (repository URL and commit hash) in the
+   * template metadata of all Stacks in this App.
+   *
+   * When enabled, the synthesized CloudFormation template will include an
+   * `AWS::CDK::Source` metadata entry with the repository and commit.
+   *
+   * @default false
+   */
+  readonly trackSourceCommit?: boolean;
+
+  /**
    * Include construct tree metadata as part of the Cloud Assembly.
    *
    * @default true
@@ -244,6 +256,10 @@ export class App extends Stage {
 
     if (props.stackTraces === false) {
       this.node.setContext(cxapi.DISABLE_METADATA_STACK_TRACE, true);
+    }
+
+    if (props.trackSourceCommit !== undefined) {
+      this.node.setContext(GIT_SOURCE_CONTEXT, props.trackSourceCommit);
     }
 
     if (props.defaultStackSynthesizer) {

--- a/packages/aws-cdk-lib/core/lib/git-source.ts
+++ b/packages/aws-cdk-lib/core/lib/git-source.ts
@@ -1,0 +1,150 @@
+import type { ExecSyncOptionsWithStringEncoding } from 'child_process';
+import { execSync } from 'child_process';
+import type { IConstruct } from 'constructs';
+import { Annotations } from './annotations';
+import { UnscopedValidationError } from './errors';
+import { lit } from './private/literal-string';
+
+export const GIT_SOURCE_CONTEXT = '@aws-cdk/core:trackSourceCommit';
+
+let detectAttempted = false;
+let cached: GitSource | undefined;
+
+/**
+ * Provides access to the git source information (repository URL and commit hash)
+ * for the current CDK application.
+ *
+ * The git source is detected automatically from the environment when the
+ * `@aws-cdk/core:trackSourceCommit` context flag is enabled.
+ *
+ * @example
+ *
+ * if (GitSource.isEnabledFor(this)) {
+ *   const gitSource = GitSource.of(this);
+ *   if (gitSource) {
+ *     Tags.of(this).add('git:commit', gitSource.commit);
+ *   }
+ * }
+ */
+export class GitSource {
+  /**
+   * Returns whether git source detection is enabled for the given scope.
+   *
+   * This checks the `@aws-cdk/core:trackSourceCommit` context flag.
+   */
+  public static isEnabledFor(scope: IConstruct): boolean {
+    const value = scope.node.tryGetContext(GIT_SOURCE_CONTEXT);
+    return value === true || value === 'true';
+  }
+
+  /**
+   * Returns the git source information for the current repository, or `undefined`
+   * if git information could not be detected.
+   *
+   * If detection fails (e.g., git is not installed, the directory is not a git
+   * repository, or the output fails validation), a warning is emitted on the
+   * given scope and `undefined` is returned.
+   */
+  public static of(scope: IConstruct): GitSource | undefined {
+    if (detectAttempted) {
+      // If we have already attempted to detect the git source once, there is no
+      // need to attempt again. Just return whatever we got the first time around,
+      // whether it is a proper value or undefined (if it has failed before, it will
+      // fail again now).
+      return cached;
+    }
+
+    detectAttempted = true;
+    try {
+      const result = detectGitSource();
+      cached = new GitSource(result.repository, result.commit);
+      return cached;
+    } catch (e) {
+      const message = `Failed to detect git source information: ${e instanceof Error ? e.message : String(e)}`;
+      Annotations.of(scope).addWarningV2('@aws-cdk/core:gitSourceDetectionFailed', message);
+      return undefined;
+    }
+  }
+
+  /**
+   * Clears the cached git source information. Subsequent calls to `of()` will
+   * re-detect the git source from the environment.
+   *
+   * @internal
+   */
+  public static _clearCache() {
+    detectAttempted = false;
+    cached = undefined;
+  }
+
+  private constructor(
+    /**
+     * The remote repository URL.
+     */
+    public readonly repository: string,
+    /**
+     * The commit hash (SHA-1 or SHA-256).
+     */
+    public readonly commit: string,
+  ) {}
+}
+
+function detectGitSource(): { repository: string; commit: string } {
+  const opts: ExecSyncOptionsWithStringEncoding = {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 5000,
+    cwd: process.cwd(),
+  };
+
+  const rawRepository = execSync('git config --get remote.origin.url', opts).trim();
+  const commit = execSync('git rev-parse HEAD', opts).trim();
+
+  // Validate commit hash format (40 hex chars for SHA-1, 64 for SHA-256)
+  if (!commit || !/^[a-f0-9]{40}([a-f0-9]{24})?$/i.test(commit)) {
+    throw new UnscopedValidationError(lit`InvalidCommitHash`,
+      'git rev-parse HEAD returned an unexpected value. '
+      + 'Expected a 40 or 64 character hex string. '
+      + `Got: ${JSON.stringify(commit)}`,
+    );
+  }
+
+  if (!rawRepository || /[\x00-\x1F\x7F]/.test(rawRepository)) {
+    throw new UnscopedValidationError(lit`InvalidRepositoryUrl`,
+      'git config --get remote.origin.url returned a URL with unexpected content. '
+      + `Got: ${JSON.stringify(rawRepository)}`,
+    );
+  }
+
+  const repository = sanitizeRepositoryUrl(rawRepository);
+
+  return { repository, commit };
+}
+
+/**
+ * Validates and removes embedded credentials from a repository URL.
+ *
+ * For scheme-based URLs (https://, ssh://, git://), uses the URL class to
+ * strip username/password. For SCP-like URLs (git@host:path), returns as-is
+ * since they cannot contain embedded passwords.
+ */
+function sanitizeRepositoryUrl(raw: string): string {
+  // SCP-like syntax (e.g. git@github.com:org/repo.git) — no credentials to strip
+  if (/^[^/]+@[^:]+:/.test(raw) && !raw.includes('://')) {
+    return raw;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnscopedValidationError(lit`InvalidRepositoryUrl`,
+      'git config --get remote.origin.url returned a URL with unexpected content. '
+      + `Got: ${JSON.stringify(raw)}`,
+    );
+  }
+
+  url.username = '';
+  url.password = '';
+  return url.toString();
+}

--- a/packages/aws-cdk-lib/core/lib/index.ts
+++ b/packages/aws-cdk-lib/core/lib/index.ts
@@ -68,6 +68,7 @@ export * from './cfn-capabilities';
 export * from './cloudformation.generated';
 
 export * from './feature-flags';
+export * from './git-source';
 export * from './permissions-boundary';
 
 export * from './validation';

--- a/packages/aws-cdk-lib/core/lib/stack.ts
+++ b/packages/aws-cdk-lib/core/lib/stack.ts
@@ -213,6 +213,18 @@ export interface StackProps {
   readonly suppressTemplateIndentation?: boolean;
 
   /**
+   * Include git source information (repository URL and commit hash) in the
+   * template metadata of this Stack.
+   *
+   * When enabled, the synthesized CloudFormation template will include an
+   * `AWS::CDK::Source` metadata entry with the repository and commit.
+   *
+   * @default - Value of `trackSourceCommit` on containing `App`, or
+   * value of `@aws-cdk/core:trackSourceCommit` context key
+   */
+  readonly trackSourceCommit?: boolean;
+
+  /**
    * A list of IPropertyInjector attached to this Stack.
    * @default - no PropertyInjectors
    */
@@ -591,6 +603,20 @@ export class Stack extends Construct implements ITaggable {
 
     // add the permissions boundary aspect
     this.addPermissionsBoundaryAspect();
+
+    if (props.trackSourceCommit !== undefined) {
+      this.node.setContext(GIT_SOURCE_CONTEXT, props.trackSourceCommit);
+    }
+
+    if (GitSource.isEnabledFor(this)) {
+      const gitSource = GitSource.of(this);
+      if (gitSource) {
+        this.addMetadata('AWS::CDK::Source', {
+          Repository: gitSource.repository,
+          Commit: gitSource.commit,
+        });
+      }
+    }
   }
 
   /**
@@ -1956,6 +1982,7 @@ import { AssumptionError, UnscopedValidationError, ValidationError } from './err
 import { lit } from './private/literal-string';
 import { debugModeEnabled } from './debug';
 import { captureStackTrace } from './private/stack-trace';
+import { GIT_SOURCE_CONTEXT, GitSource } from './git-source';
 /* eslint-enable import/order */
 
 function makeCustomCoupledReference(value: any, strength: ReferenceStrength): CustomCoupledReference {

--- a/packages/aws-cdk-lib/core/test/git-source.test.ts
+++ b/packages/aws-cdk-lib/core/test/git-source.test.ts
@@ -1,0 +1,173 @@
+import * as child_process from 'child_process';
+import { GitSource } from '../lib/git-source';
+import { App, Stack } from '../lib/index';
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+}));
+
+const mockExecSync = child_process.execSync as jest.Mock;
+
+beforeEach(() => {
+  GitSource._clearCache();
+  mockExecSync.mockReset();
+});
+
+test('returns git source when context is enabled and git is available', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source).toEqual({
+    repository: 'https://github.com/example/repo.git',
+    commit: 'a'.repeat(40),
+  });
+});
+
+test('returns undefined when git is not available', () => {
+  mockExecSync.mockImplementation(() => { throw new Error('not a git repo'); });
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  expect(GitSource.of(stack)).toBeUndefined();
+});
+
+test('caches result across multiple calls', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const first = GitSource.of(stack);
+  const second = GitSource.of(stack);
+
+  expect(first).toEqual(second);
+  expect(mockExecSync).toHaveBeenCalledTimes(2); // once per git command, not repeated
+});
+
+test('caches undefined result', () => {
+  mockExecSync.mockImplementation(() => { throw new Error('not a git repo'); });
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  expect(GitSource.of(stack)).toBeUndefined();
+  expect(GitSource.of(stack)).toBeUndefined();
+
+  expect(mockExecSync).toHaveBeenCalledTimes(1); // only tried once
+});
+
+test('clearCache resets the cache', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40))
+    .mockReturnValueOnce('https://github.com/example/repo2.git')
+    .mockReturnValueOnce('b'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const first = GitSource.of(stack);
+  GitSource._clearCache();
+  const second = GitSource.of(stack);
+
+  expect(first).toEqual({ repository: 'https://github.com/example/repo.git', commit: 'a'.repeat(40) });
+  expect(second).toEqual({ repository: 'https://github.com/example/repo2.git', commit: 'b'.repeat(40) });
+  expect(mockExecSync).toHaveBeenCalledTimes(4);
+});
+
+test('sanitizes credentials from repository URL', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://user:token@github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source?.repository).toBe('https://github.com/example/repo.git');
+});
+
+test('sanitizes credentials from repository URL (ssh)', () => {
+  mockExecSync
+    .mockReturnValueOnce('ssh://user:token@github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source?.repository).toBe('ssh://github.com/example/repo.git');
+});
+
+test('sanitizes credentials from repository URL (git)', () => {
+  mockExecSync
+    .mockReturnValueOnce('git://user:token@github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source?.repository).toBe('git://github.com/example/repo.git');
+});
+
+test('returns undefined for invalid commit hash', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://github.com/example/repo.git')
+    .mockReturnValueOnce('not-a-valid-hash');
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  expect(GitSource.of(stack)).toBeUndefined();
+});
+
+test('returns undefined for invalid repository URL', () => {
+  mockExecSync
+    .mockReturnValueOnce('not a valid url')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  expect(GitSource.of(stack)).toBeUndefined();
+});
+
+test('accepts SHA-256 commit hashes (64 hex chars)', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://github.com/example/repo.git')
+    .mockReturnValueOnce('a'.repeat(64));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source?.commit).toBe('a'.repeat(64));
+});
+
+test('isEnabledFor accepts string "true" from CLI context', () => {
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': 'true' } });
+  const stack = new Stack(app, 'Stack');
+
+  expect(GitSource.isEnabledFor(stack)).toBe(true);
+});
+
+test('does not corrupt URLs with @ in path segment', () => {
+  mockExecSync
+    .mockReturnValueOnce('https://git.example.com/team@org/repo.git')
+    .mockReturnValueOnce('a'.repeat(40));
+
+  const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+  const stack = new Stack(app, 'Stack');
+
+  const source = GitSource.of(stack);
+  expect(source?.repository).toBe('https://git.example.com/team@org/repo.git');
+});

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -3307,6 +3307,15 @@ describe('regionalFact', () => {
     ['context key', { context: { '@aws-cdk/core:trackSourceCommit': true } }],
     ['App props', { trackSourceCommit: true }],
   ])('git source metadata is included when trackSourceCommit is set via %s', (_label, appProps) => {
+    let gitAvailable: boolean;
+    try {
+      execSync('git --version', { stdio: 'pipe' });
+      gitAvailable = true;
+    } catch {
+      gitAvailable = false;
+    }
+    if (!gitAvailable) { return; }
+
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-git-test-'));
     try {
       execSync('git init && git remote add origin https://github.com/example/repo.git && git commit --allow-empty -m "init"', { cwd: tmpDir, stdio: 'pipe' });

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -1,4 +1,7 @@
+import { execSync } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { testDeprecated } from '@aws-cdk/cdk-build-tools';
 import { Construct, Node } from 'constructs';
 import { flattenMeta, getWarnings, toCloudFormation } from './util';
@@ -3300,41 +3303,17 @@ describe('regionalFact', () => {
     expect(template?.Metadata?.['AWS::CDK::Source']).toBeUndefined();
   });
 
-  test('git source metadata is included when trackSourceCommit context is true', () => {
-    GitSource._clearCache();
-    const spy = jest.spyOn(GitSource, 'of').mockReturnValue({
-      repository: 'https://github.com/example/repo.git',
-      commit: 'a'.repeat(40),
-    } as any);
-
+  test.each([
+    ['context key', { context: { '@aws-cdk/core:trackSourceCommit': true } }],
+    ['App props', { trackSourceCommit: true }],
+  ])('git source metadata is included when trackSourceCommit is set via %s', (_label, appProps) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-git-test-'));
     try {
-      const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
-      const stack = new Stack(app, 'Stack');
-      new CfnResource(stack, 'Resource', { type: 'MyResource' });
-
-      const assembly = app.synth();
-      const stackArtifact = assembly.getStackByName(stack.stackName);
-      const template = stackArtifact.template;
-      const source = template?.Metadata?.['AWS::CDK::Source'];
-
-      expect(source).toBeDefined();
-      expect(source.Commit).toMatch(/^[a-f0-9]{40}([a-f0-9]{24})?$/);
-      expect(source.Repository).toContain('github.com');
-    } finally {
-      spy.mockRestore();
+      execSync('git init && git remote add origin https://github.com/example/repo.git && git commit --allow-empty -m "init"', { cwd: tmpDir, stdio: 'pipe' });
+      const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
       GitSource._clearCache();
-    }
-  });
 
-  test('git source metadata is included when trackSourceCommit is set on App props', () => {
-    GitSource._clearCache();
-    const spy = jest.spyOn(GitSource, 'of').mockReturnValue({
-      repository: 'https://github.com/example/repo.git',
-      commit: 'b'.repeat(40),
-    } as any);
-
-    try {
-      const app = new App({ trackSourceCommit: true });
+      const app = new App(appProps);
       const stack = new Stack(app, 'Stack');
       new CfnResource(stack, 'Resource', { type: 'MyResource' });
 
@@ -3344,8 +3323,11 @@ describe('regionalFact', () => {
 
       expect(source).toBeDefined();
       expect(source.Commit).toMatch(/^[a-f0-9]{40}([a-f0-9]{24})?$/);
+      expect(source.Repository).toBe('https://github.com/example/repo.git');
+
+      cwdSpy.mockRestore();
     } finally {
-      spy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
       GitSource._clearCache();
     }
   });

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -3318,7 +3318,13 @@ describe('regionalFact', () => {
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-git-test-'));
     try {
-      execSync('git init && git remote add origin https://github.com/example/repo.git && git commit --allow-empty -m "init"', { cwd: tmpDir, stdio: 'pipe' });
+      execSync([
+        'git init',
+        'git config user.email "test@test.com"',
+        'git config user.name "Test"',
+        'git remote add origin https://github.com/example/repo.git',
+        'git commit --allow-empty -m "init"',
+      ].join(' && '), { cwd: tmpDir, stdio: 'pipe' });
       const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
       GitSource._clearCache();
 

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -18,6 +18,7 @@ import {
   TagManager,
   TagType,
 } from '../lib';
+import { GitSource } from '../lib/git-source';
 import { Intrinsic } from '../lib/private/intrinsic';
 import { resolveReferences } from '../lib/private/refs';
 import { PostResolveToken } from '../lib/util';
@@ -3286,6 +3287,79 @@ describe('regionalFact', () => {
         Databases: { Description: 'Information about the databases' },
       },
     });
+  });
+
+  test('git source metadata is not included by default', () => {
+    GitSource._clearCache();
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    new CfnResource(stack, 'Resource', { type: 'MyResource' });
+
+    const assembly = app.synth();
+    const template = assembly.getStackByName(stack.stackName).template;
+    expect(template?.Metadata?.['AWS::CDK::Source']).toBeUndefined();
+  });
+
+  test('git source metadata is included when trackSourceCommit context is true', () => {
+    GitSource._clearCache();
+    const spy = jest.spyOn(GitSource, 'of').mockReturnValue({
+      repository: 'https://github.com/example/repo.git',
+      commit: 'a'.repeat(40),
+    } as any);
+
+    try {
+      const app = new App({ context: { '@aws-cdk/core:trackSourceCommit': true } });
+      const stack = new Stack(app, 'Stack');
+      new CfnResource(stack, 'Resource', { type: 'MyResource' });
+
+      const assembly = app.synth();
+      const stackArtifact = assembly.getStackByName(stack.stackName);
+      const template = stackArtifact.template;
+      const source = template?.Metadata?.['AWS::CDK::Source'];
+
+      expect(source).toBeDefined();
+      expect(source.Commit).toMatch(/^[a-f0-9]{40}([a-f0-9]{24})?$/);
+      expect(source.Repository).toContain('github.com');
+    } finally {
+      spy.mockRestore();
+      GitSource._clearCache();
+    }
+  });
+
+  test('git source metadata is included when trackSourceCommit is set on App props', () => {
+    GitSource._clearCache();
+    const spy = jest.spyOn(GitSource, 'of').mockReturnValue({
+      repository: 'https://github.com/example/repo.git',
+      commit: 'b'.repeat(40),
+    } as any);
+
+    try {
+      const app = new App({ trackSourceCommit: true });
+      const stack = new Stack(app, 'Stack');
+      new CfnResource(stack, 'Resource', { type: 'MyResource' });
+
+      const assembly = app.synth();
+      const template = assembly.getStackByName(stack.stackName).template;
+      const source = template?.Metadata?.['AWS::CDK::Source'];
+
+      expect(source).toBeDefined();
+      expect(source.Commit).toMatch(/^[a-f0-9]{40}([a-f0-9]{24})?$/);
+    } finally {
+      spy.mockRestore();
+      GitSource._clearCache();
+    }
+  });
+
+  test('stack-level trackSourceCommit overrides app-level setting', () => {
+    GitSource._clearCache();
+    const app = new App({ trackSourceCommit: true });
+    const stack = new Stack(app, 'Stack', { trackSourceCommit: false });
+    new CfnResource(stack, 'Resource', { type: 'MyResource' });
+
+    const assembly = app.synth();
+    const template = assembly.getStackByName(stack.stackName).template;
+    expect(template?.Metadata?.['AWS::CDK::Source']).toBeUndefined();
+    GitSource._clearCache();
   });
 });
 

--- a/packages/aws-cdk-lib/rosetta/default.ts-fixture
+++ b/packages/aws-cdk-lib/rosetta/default.ts-fixture
@@ -45,6 +45,7 @@ import {
   ITaggable,
   PermissionsBoundary,
   CrossStackReferences,
+  GitSource,
   ReferenceStrength,
   RemovalPolicy,
   RemovalPolicies,


### PR DESCRIPTION
Re-roll of https://github.com/aws/aws-cdk/pull/37368, which had to be reverted because some unit tests were relying on the assumption that git was always available. Instead, when we need the git output for a given test, we mock the output of `GitSource.of()`.

Synthesized CloudFormation templates now include an `AWS::CDK::Source` entry in the top-level `Metadata` section containing the git remote repository URL and the latest commit hash. This helps trace deployed stacks back to their source code.

Example output:

```yaml
Metadata:
  AWS::CDK::Source:
    Repository: git@github.com:org/app.git
    Commit: 19e3e594a5512b75074526af89bf3b67a3164cc1
```

The metadata is also added to the cloud assembly.

This feature is disabled by default, and can be enabled by setting the context parameter `@aws-cdk/core:trackSourceCommit` to true.

If the current directory is not a git repository or git is not available, the metadata entry is silently omitted. Also, for security, only use the repository URL and commit hash (obtained by running `git` commands) if they match the expected format.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*