### PR TITLE
docs: fix awslint rule typo in design guidelines

### DIFF
--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -444,7 +444,7 @@ As a rule of thumb, most constructs should directly extend the **Construct** or
 behavior through interfaces and not through inheritance.
 
 Construct classes should extend only one of the following classes
-[_awslint:construct-inheritence_]:
+[_awslint:construct-inheritance_]:
 
 * The **Resource** class (if it represents an AWS resource)
 * The **Construct** class (if it represents an abstract component)


### PR DESCRIPTION
  Fixes #38119

  ### Issue # (if applicable)

  Closes #38119.

  ### Reason for this change

  The design guidelines contain a typo in the awslint rule reference: `construct-inheritence` should be `construct-
  inheritance`.

  ### Description of changes

  Updated `docs/DESIGN_GUIDELINES.md` to fix the misspelled awslint rule anchor from `construct-inheritence` to
  `construct-inheritance`.

  ### Describe any new or updated permissions being added

  No new or updated IAM permissions are required.

  ### Description of how you validated changes

  Validated by checking the documentation change locally. This is a documentation-only typo fix.

  ### Checklist
  - [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and
  [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)