### PR TITLE
docs(assertions): document how to stop cdk.out temp dirs leaking under Jest

### DIFF
--- a/packages/aws-cdk-lib/assertions/README.md
+++ b/packages/aws-cdk-lib/assertions/README.md
@@ -31,6 +31,38 @@ const template = Template.fromString(templateJson);
 If allowing cyclical references is desired, for example in the case of unprocessed Transform templates, supply TemplateParsingOptions and
 set skipCyclicalDependenciesCheck to true. In all other cases, will fail on detecting cyclical dependencies.
 
+**Cleaning up temporary directories in Jest**
+
+Every call to `Template.fromStack()` (and any other code path that synthesizes a
+`Stack` or `App` without an explicit `outdir`) writes a throwaway Cloud Assembly
+into a `cdk.out`-prefixed directory under the OS temp directory. The framework
+registers those directories and removes them when the Node process exits, so a
+normal `cdk synth` or a plain Node test run cleans up after itself.
+
+Jest does not fire Node's `exit` event (see
+https://github.com/jestjs/jest/issues/10927), so when assertions run under Jest
+those temporary directories are not removed and accumulate over time, which can
+fill up the disk on a busy development or CI machine.
+
+To clean them up, call `CloudAssembly.cleanupTemporaryDirectories()` once the
+suite has finished:
+
+```js
+import { CloudAssembly } from 'aws-cdk-lib/cx-api';
+
+afterAll(CloudAssembly.cleanupTemporaryDirectories);
+```
+
+Or wire it into every test file automatically with `setupFilesAfterEnv`:
+
+```js
+// jest.config.js
+module.exports = {
+  // ...
+  setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
+};
+```
+
 ## Full Template Match
 
 The simplest assertion would be to assert that the template matches a given

--- a/packages/aws-cdk-lib/core/test/app.test.ts
+++ b/packages/aws-cdk-lib/core/test/app.test.ts
@@ -422,6 +422,44 @@ describe('app', () => {
       delete process.env[cxapi.PERF_COUNTERS_FILE_ENV];
     }
   });
+
+  test('App synthesized without an outdir creates a temp dir that cleanupTemporaryDirectories removes', () => {
+    // GIVEN - an app with no outdir synthesizes into a temporary cdk.out directory
+    const app = new App();
+    new Stack(app, 'Stack1');
+    const assembly = app.synth();
+    const outdir = assembly.directory;
+
+    // the temp dir really exists and lives under the OS temp directory
+    expect(fs.existsSync(outdir)).toBe(true);
+    expect(path.dirname(outdir)).toEqual(fs.realpathSync(os.tmpdir()));
+    expect(path.basename(outdir).startsWith('cdk.out')).toBe(true);
+
+    // WHEN
+    cxapi.CloudAssembly.cleanupTemporaryDirectories();
+
+    // THEN - the temporary assembly directory has been removed
+    expect(fs.existsSync(outdir)).toBe(false);
+  });
+
+  test('App synthesized with an explicit outdir is not removed by cleanupTemporaryDirectories', () => {
+    // GIVEN - an explicit outdir is owned by the caller and must survive cleanup
+    const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-explicit-outdir'));
+    try {
+      const app = new App({ outdir });
+      new Stack(app, 'Stack1');
+      app.synth();
+      expect(fs.existsSync(outdir)).toBe(true);
+
+      // WHEN
+      cxapi.CloudAssembly.cleanupTemporaryDirectories();
+
+      // THEN - the explicit outdir is left untouched
+      expect(fs.existsSync(outdir)).toBe(true);
+    } finally {
+      fs.rmSync(outdir, { force: true, recursive: true });
+    }
+  });
 });
 
 class MyConstruct extends Construct {

--- a/packages/aws-cdk-lib/cx-api/lib/legacy-moved.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/legacy-moved.ts
@@ -189,7 +189,7 @@ export declare class CloudAssembly implements cxschema.ICloudAssembly {
    * ```js
    * module.exports = {
    *   // ...
-   *   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-cleanup'],
+   *   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
    * };
    * ```
    */


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38199.

This is a documentation and test follow-up to the framework fix merged in PR #36043. The closed-stale reports #29368, #32255, #11730 are the same disk-fill symptom.

### Reason for this change

CDK assertion tests are the standard way customers test their infrastructure code, and `Template.fromStack()` is the headline API for it. Every call synthesizes a throwaway Cloud Assembly into a `cdk.out`-prefixed directory under the OS temp directory. On a busy developer or CI machine those directories accumulate into the tens of thousands and tens of GiB, eventually filling the disk (see #29368, #11730, #32255, all closed for staleness, all the same symptom).

#36043 fixed the framework so these directories are registered and deleted on Node process exit, and shipped `aws-cdk-lib/testhelpers/jest-autoclean` plus `CloudAssembly.cleanupTemporaryDirectories()` for environments where `exit` does not fire. Node's `exit` event does not fire under Jest (jestjs/jest#10927), which is the runtime almost all CDK users run their assertions in. So for downstream Jest users the cleanup only happens if they opt in, and today there is no breadcrumb in the assertions docs telling them that. Worse, the one place it is documented (the `cleanupTemporaryDirectories` docstring) points at a module name (`jest-cleanup`) that does not exist, so copying that config line gives a "module not found" error.

### Description of changes

- Add a "Cleaning up temporary directories in Jest" note to the `assertions` README, next to the `Template.fromStack()` example, explaining the leak and the two supported remedies (`afterAll(CloudAssembly.cleanupTemporaryDirectories)` and the `setupFilesAfterEnv` helper).
- Fix the `setupFilesAfterEnv` example in the `CloudAssembly.cleanupTemporaryDirectories` docstring: `aws-cdk-lib/testhelpers/jest-cleanup` to `aws-cdk-lib/testhelpers/jest-autoclean` (the actual exported helper; the old name resolves to nothing).
- Add unit tests proving `cleanupTemporaryDirectories()` removes a no-`outdir` assembly directory and leaves an explicit `outdir` untouched (no prior coverage of this behaviour).

This is documentation plus a regression test. It does not change any runtime behaviour: the cleanup machinery and its opt-in design are from #36043 and are unchanged here. The explicit-`outdir` test guards the deliberate boundary set in #36043 (caller-owned and CLI `cdk.out` directories are intentionally not cleaned) against future regression. Alternatives considered and rejected: making aws-cdk-lib default-on auto-register an `afterAll` cleanup for Jest, which would re-open the opt-in design decision the maintainers explicitly made in #36043; and re-adding the framework-level cleanup, which already shipped.

### Describe any new or updated permissions being added

None. This change is documentation and tests only; no IAM permissions are added or changed.

### Description of how you validated changes

- Added two unit tests in `packages/aws-cdk-lib/core/test/app.test.ts`; `npx jest core/test/app.test.ts` passes all tests including the two new ones (a no-`outdir` assembly is removed by `cleanupTemporaryDirectories()`; an explicit `outdir` is left untouched).
- Reproduced the leak by hand against the published `@aws-cdk/cloud-assembly-api@2.2.5` (the version aws-cdk-lib pins): plain `node` synth and Jest with the autoclean hook both clean up; Jest without the hook leaks the temp dir, confirming the gap this PR documents.
- README snippet validity is covered by the package build's jsii-rosetta extraction; the new fences are `js` (passthrough), matching existing accepted usage in other aws-cdk-lib READMEs.

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
