### PR TITLE
chore(deps): bump @aws-cdk/integ-runner to 2.200.2

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-sdk/client-acm": "3.632.0",
     "@aws-sdk/client-ec2": "3.632.0",

--- a/packages/@aws-cdk/app-staging-synthesizer-alpha/package.json
+++ b/packages/@aws-cdk/app-staging-synthesizer-alpha/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "aws-cdk-lib": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "constructs": "^10.5.0",
     "@aws-cdk/cdk-build-tools": "0.0.0",

--- a/packages/@aws-cdk/aws-amplify-alpha/package.json
+++ b/packages/@aws-cdk/aws-amplify-alpha/package.json
@@ -88,7 +88,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/custom-resource-handlers": "0.0.0",
     "@aws-sdk/client-amplify": "3.632.0",

--- a/packages/@aws-cdk/aws-applicationsignals-alpha/package.json
+++ b/packages/@aws-cdk/aws-applicationsignals-alpha/package.json
@@ -85,7 +85,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-apprunner-alpha/package.json
+++ b/packages/@aws-cdk/aws-apprunner-alpha/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
     "aws-cdk-lib": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "constructs": "^10.5.0",

--- a/packages/@aws-cdk/aws-bedrock-agentcore-alpha/package.json
+++ b/packages/@aws-cdk/aws-bedrock-agentcore-alpha/package.json
@@ -81,7 +81,7 @@
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/aws-bedrock-alpha": "0.0.0",
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-bedrock-alpha/package.json
+++ b/packages/@aws-cdk/aws-bedrock-alpha/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-cloud9-alpha/package.json
+++ b/packages/@aws-cdk/aws-cloud9-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-codestar-alpha/package.json
+++ b/packages/@aws-cdk/aws-codestar-alpha/package.json
@@ -85,7 +85,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-dsql-alpha/package.json
+++ b/packages/@aws-cdk/aws-dsql-alpha/package.json
@@ -85,7 +85,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-ec2-alpha/package.json
+++ b/packages/@aws-cdk/aws-ec2-alpha/package.json
@@ -79,7 +79,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "^0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-elasticache-alpha/package.json
+++ b/packages/@aws-cdk/aws-elasticache-alpha/package.json
@@ -86,7 +86,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-gamelift-alpha/package.json
+++ b/packages/@aws-cdk/aws-gamelift-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-glue-alpha/package.json
+++ b/packages/@aws-cdk/aws-glue-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-imagebuilder-alpha/package.json
+++ b/packages/@aws-cdk/aws-imagebuilder-alpha/package.json
@@ -78,7 +78,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-sdk/client-inspector2": "^3",

--- a/packages/@aws-cdk/aws-iot-actions-alpha/package.json
+++ b/packages/@aws-cdk/aws-iot-actions-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-iot-alpha/package.json
+++ b/packages/@aws-cdk/aws-iot-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-iotevents-actions-alpha/package.json
+++ b/packages/@aws-cdk/aws-iotevents-actions-alpha/package.json
@@ -76,7 +76,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-iotevents-alpha/package.json
+++ b/packages/@aws-cdk/aws-iotevents-alpha/package.json
@@ -85,7 +85,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-ivs-alpha/package.json
+++ b/packages/@aws-cdk/aws-ivs-alpha/package.json
@@ -86,7 +86,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/package.json
+++ b/packages/@aws-cdk/aws-kinesisanalytics-flink-alpha/package.json
@@ -79,7 +79,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-lambda-go-alpha/package.json
+++ b/packages/@aws-cdk/aws-lambda-go-alpha/package.json
@@ -77,7 +77,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-lambda-python-alpha/package.json
+++ b/packages/@aws-cdk/aws-lambda-python-alpha/package.json
@@ -78,7 +78,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-location-alpha/package.json
+++ b/packages/@aws-cdk/aws-location-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-mediapackagev2-alpha/package.json
+++ b/packages/@aws-cdk/aws-mediapackagev2-alpha/package.json
@@ -81,7 +81,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "^0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",

--- a/packages/@aws-cdk/aws-msk-alpha/package.json
+++ b/packages/@aws-cdk/aws-msk-alpha/package.json
@@ -85,7 +85,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-neptune-alpha/package.json
+++ b/packages/@aws-cdk/aws-neptune-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-pipes-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29",

--- a/packages/@aws-cdk/aws-pipes-enrichments-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-enrichments-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29",

--- a/packages/@aws-cdk/aws-pipes-sources-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-sources-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29",

--- a/packages/@aws-cdk/aws-pipes-targets-alpha/package.json
+++ b/packages/@aws-cdk/aws-pipes-targets-alpha/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29",

--- a/packages/@aws-cdk/aws-redshift-alpha/package.json
+++ b/packages/@aws-cdk/aws-redshift-alpha/package.json
@@ -86,7 +86,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/custom-resource-handlers": "0.0.0",
     "@aws-sdk/client-redshift": "3.632.0",

--- a/packages/@aws-cdk/aws-route53resolver-alpha/package.json
+++ b/packages/@aws-cdk/aws-route53resolver-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/aws-s3objectlambda-alpha/package.json
+++ b/packages/@aws-cdk/aws-s3objectlambda-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-sagemaker-alpha/package.json
+++ b/packages/@aws-cdk/aws-sagemaker-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/aws-servicecatalogappregistry-alpha/package.json
+++ b/packages/@aws-cdk/aws-servicecatalogappregistry-alpha/package.json
@@ -84,7 +84,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "aws-cdk-lib": "0.0.0",

--- a/packages/@aws-cdk/example-construct-library/package.json
+++ b/packages/@aws-cdk/example-construct-library/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "aws-cdk-lib": "0.0.0",
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0"

--- a/packages/@aws-cdk/integ-tests-alpha/package.json
+++ b/packages/@aws-cdk/integ-tests-alpha/package.json
@@ -68,7 +68,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/aws-custom-resource-sdk-adapter": "0.0.0",
     "@aws-sdk/client-ec2": "3.632.0",

--- a/packages/@aws-cdk/mixins-preview/package.json
+++ b/packages/@aws-cdk/mixins-preview/package.json
@@ -325,7 +325,7 @@
   "devDependencies": {
     "@aws-cdk/cdk-build-tools": "0.0.0",
     "@aws-cdk/custom-resource-handlers": "0.0.0",
-    "@aws-cdk/integ-runner": "^2.199.0",
+    "@aws-cdk/integ-runner": "^2.200.2",
     "@aws-cdk/integ-tests-alpha": "0.0.0",
     "@aws-cdk/pkglint": "0.0.0",
     "@aws-cdk/service-spec-types": "0.0.253",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,12 +50,12 @@
   resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz#71733894b092032309523cfcba24dc2bb3e7fd84"
   integrity sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==
 
-"@aws-cdk/aws-service-spec@0.1.184":
-  version "0.1.184"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.184.tgz#8b01e2a9d5785350584be557ebb188941258048a"
-  integrity sha512-OC/OraJ3rGqoxKleeYnveN9N8ymw9vmH8llkhLVV92VZFdUFfNcviBX6DleOvvxAbIxmsCOTaRQ8Aa7iPaPM/Q==
+"@aws-cdk/aws-service-spec@0.1.185":
+  version "0.1.185"
+  resolved "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.185.tgz#a4caa82744cde717a6a761b2a18d36a3d7a7e748"
+  integrity sha512-J1rf6m8AavVV1iFKY6s0ljTstUS94yaLYdNHCa0QwRCM5DDxK+kGaqHmj/1rBWkGsIJ15IHVLsMPQ/Q6fAvLTA==
   dependencies:
-    "@aws-cdk/service-spec-types" "^0.0.250"
+    "@aws-cdk/service-spec-types" "^0.0.251"
     "@cdklabs/tskb" "^0.0.4"
 
 "@aws-cdk/aws-service-spec@0.1.187":
@@ -82,13 +82,13 @@
     jsonschema "^1.5.0"
     semver "^7.8.1"
 
-"@aws-cdk/integ-runner@^2.199.0":
-  version "2.199.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/integ-runner/-/integ-runner-2.199.0.tgz#366af53e29c199f8ac8815c8aeef1320b31631d7"
-  integrity sha512-tK6QpC94fzvIKZiDvqZs96p4SvzKflDcGoNItPdCyUvevMSkOYqTjlzXCNl3GmfZo1rkdcaROgk9qnmQ4n28eQ==
+"@aws-cdk/integ-runner@^2.200.2":
+  version "2.200.2"
+  resolved "https://registry.npmjs.org/@aws-cdk/integ-runner/-/integ-runner-2.200.2.tgz#b3e1e83182d6281267df35a6f2eaf80f1e3c05de"
+  integrity sha512-fd/RIYrcB19eZTzYTDKpB+mRFJ5lvOwHKvEnBjN4pxbALxG2tWcyZG81uPeGkt0deYAg0Jl5MnU8ajJKkmxJ8A==
   dependencies:
-    "@aws-cdk/aws-service-spec" "0.1.184"
-    aws-cdk "2.1126.0"
+    "@aws-cdk/aws-service-spec" "0.1.185"
+    aws-cdk "2.1128.1"
 
 "@aws-cdk/lambda-layer-kubectl-v24@^2.0.242":
   version "2.0.242"
@@ -150,13 +150,6 @@
   version "0.0.253"
   resolved "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.253.tgz#6b57993c56e4c561dd5820981f319cd105641cfb"
   integrity sha512-ul3lk2azLjmwDl0sSChYlL43R4RKvpp08EhJ8CGTsSjWHIiggSmtUtUlnr18O04CjYCHunWZkJHwLr27SEwl6w==
-  dependencies:
-    "@cdklabs/tskb" "^0.0.4"
-
-"@aws-cdk/service-spec-types@^0.0.250":
-  version "0.0.250"
-  resolved "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.250.tgz#062009c756cdf9c6cd462f55914ed8123068d58b"
-  integrity sha512-jrYbgUvUPagxPKiebiXSf28up+RvGow3A1UnWltkdjO8UdAj5KZwtNazNdD/SGDfqA8FGVGKSaFeFaHztttc2w==
   dependencies:
     "@cdklabs/tskb" "^0.0.4"
 
@@ -5623,10 +5616,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk@2.1126.0:
-  version "2.1126.0"
-  resolved "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz#8468b116e41465e19095615bf1b941edf27ebf8e"
-  integrity sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==
+aws-cdk@2.1128.1:
+  version "2.1128.1"
+  resolved "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1128.1.tgz#6887a7089de63f5d79526b0dfdf045129ae82ea5"
+  integrity sha512-y9OHn5/BOcIiq409vPvpypMIr7/8M1ScFe8IkFMSCN1/GI/5c73fQ4pfzNq+VDkj86T5zxs7BQ1qU2lQQytdXA==
 
 aws-sdk-client-mock-jest@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

`@aws-cdk/integ-runner` 2.200.2 sets `aws:cdk:disable-creation-stack-traces: true` during snapshot synthesis, so integ golden snapshots no longer capture creation stack traces. The repo is pinned to ^2.199.0.

### Description of changes

Bumps `@aws-cdk/integ-runner` from `^2.199.0` to `^2.200.2` in the package.json files that declare it, and updates yarn.lock. Dependency-only change.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Ran `yarn install --frozen-lockfile` (lockfile consistent) and built the affected packages locally.

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*