### PR TITLE
ci: fix pr-triage-manager team reference to aws-cdk-team

### DIFF
--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -51,7 +51,7 @@ jobs:
           target: "pull-requests"
           area-is-keyword: true
           default-area: >
-            {"reviewers":{"teamReviewers":["aws-cdk-owners"]}}
+            {"reviewers":{"teamReviewers":["aws-cdk-team"]}}
           parameters: >
             [{"area":"pullrequests","keywords":["pullrequestkeyword"]}]
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38197.

### Reason for this change

The `pr-triage-manager` job requested reviewers from team `aws-cdk-owners`, which does not exist in the `aws` org. Every PR from a beginning contributor failed with `Reviews may only be requested from collaborators`, leaving 25+ PRs with a failing check.

### Description of changes

Updated `teamReviewers` in `.github/workflows/issue-label-assign.yml` from the non-existent `aws-cdk-owners` to the existing `aws-cdk-team`.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

CI-only change; verified `aws-cdk-owners` was the sole reference in `.github/` and corrected it to a valid team.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
