### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/agent-docs-sync-reminder.yml
+++ b/.github/workflows/agent-docs-sync-reminder.yml
@@ -26,7 +26,7 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const agentDocs = [

--- a/.github/workflows/analytics-metadata-updater.yml
+++ b/.github/workflows/analytics-metadata-updater.yml
@@ -13,12 +13,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: hmarr/auto-approve-action@v4.0.0
+    - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/check-lfs.yml
+++ b/.github/workflows/check-lfs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # We don't actually care about LFS file contents, just their integrity.
           lfs: false

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: cdklabs/close-stale-prs@main
+      - uses: cdklabs/close-stale-prs@61392ccb075b233a8887b4e19243fbbb53e2eea5 # main
         with:
           # Required
           # Must be PROJEN_GITHUB_TOKEN because the default GHA GitHub token will not have permissions to

--- a/.github/workflows/codebuild-pr-build.yml
+++ b/.github/workflows/codebuild-pr-build.yml
@@ -37,20 +37,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           cache: "yarn"
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Load Docker images
         id: docker-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar
@@ -61,7 +61,7 @@ jobs:
         run: docker image load --input ~/.docker-images.tar
 
       - name: Cache build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.s3buildcache
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache Docker images
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload PR info artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_info
           path: pr/

--- a/.github/workflows/codecov-collect.yml
+++ b/.github/workflows/codecov-collect.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
 
@@ -30,7 +30,7 @@ jobs:
         run: cd packages/aws-cdk-lib && yarn test core
 
       - name: Upload Coverage and PR Info
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-artifacts
           path: |

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-artifacts
           path: ./packages/aws-cdk-lib/core/coverage
@@ -32,7 +32,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./packages/aws-cdk-lib/core/coverage/cobertura-coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -73,6 +73,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/community-review-timeout.yml
+++ b/.github/workflows/community-review-timeout.yml
@@ -22,7 +22,7 @@ jobs:
   bump-stale-community-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DAYS_THRESHOLD: '30'
           INPUT_DAYS: ${{ inputs.days_threshold }}

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/enum-auto-updater.yml
+++ b/.github/workflows/enum-auto-updater.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:

--- a/.github/workflows/enum-static-mapping-updater.yml
+++ b/.github/workflows/enum-static-mapping-updater.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:

--- a/.github/workflows/github-merit-badger.yml
+++ b/.github/workflows/github-merit-badger.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: cdklabs/github-merit-badger@main
+      - uses: cdklabs/github-merit-badger@303de1a8953019e51957da361bcd0cbfed469d0c # main
         id: merit-badger
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -15,6 +15,6 @@ jobs:
       discussions: write
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1
+        uses: aws-github-ops/handle-stale-discussions@711a9813957be17629fc6933afcd8bd132c57254 # v1
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration-test-deployment-auto.yml
+++ b/.github/workflows/integration-test-deployment-auto.yml
@@ -26,13 +26,13 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout for path filtering
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "lts/*"
 
@@ -93,13 +93,13 @@ jobs:
 
     steps:
       - name: Checkout HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "lts/*"
           cache: "yarn"
@@ -107,11 +107,11 @@ jobs:
             yarn.lock
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Load Docker images
         id: docker-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar
@@ -122,7 +122,7 @@ jobs:
         run: docker image load --input ~/.docker-images.tar
 
       - name: Cache build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.s3buildcache

--- a/.github/workflows/integration-test-deployment.yml
+++ b/.github/workflows/integration-test-deployment.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "lts/*"
           cache: "yarn"
@@ -49,11 +49,11 @@ jobs:
             yarn.lock
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Load Docker images
         id: docker-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar
@@ -64,7 +64,7 @@ jobs:
         run: docker image load --input ~/.docker-images.tar
 
       - name: Cache build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.s3buildcache
@@ -102,7 +102,7 @@ jobs:
 
       - name: Cache Docker images
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar

--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-github-ops/aws-issue-triage-manager@main
+      - uses: aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61 # main
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: "issues"
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-github-ops/aws-issue-triage-manager@main
+      - uses: aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61 # main
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: "issues"
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: aws-github-ops/aws-issue-triage-manager@main
+      - uses: aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61 # main
         with:
           github-token: "${{ secrets.PROJEN_GITHUB_TOKEN }}"
           target: "pull-requests"

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/issue-reprioritization.yml
+++ b/.github/workflows/issue-reprioritization.yml
@@ -11,7 +11,7 @@ jobs:
       repository-projects: write
     runs-on: ubuntu-latest
     steps:
-      - uses: cdklabs/issue-reprioritization-manager@main
+      - uses: cdklabs/issue-reprioritization-manager@6fd8c5426221c769857467444d3e10c83a60328f # main
         id: reprioritization-manager
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
           new-label: p1
           reprioritization-threshold: 20
           project-column-url: https://github.com/aws/aws-cdk/projects/13#column-18002436
-      - uses: kaizencc/pr-triage-manager@main
+      - uses: kaizencc/pr-triage-manager@3a2558737a4d072feaaa4c1768b92f51abfde53b # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           on-pulls: ${{ steps.reprioritization-manager.outputs.linked-pulls }}

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'yarn'
@@ -22,7 +22,7 @@ jobs:
 
       # Cache node_modules
       - name: Cache node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         id: cache-modules
         with:
           path: |
@@ -40,7 +40,7 @@ jobs:
 
       # Cache build output
       - name: Cache build output
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         id: cache-build
         with:
           path: |

--- a/.github/workflows/lambda-runtime-tests.yml
+++ b/.github/workflows/lambda-runtime-tests.yml
@@ -11,12 +11,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:

--- a/.github/workflows/lock-issue-pr-with-message.yml
+++ b/.github/workflows/lock-issue-pr-with-message.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/closed-issue-message@v2
+      - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           message: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,20 +32,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           cache: "yarn"
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Load Docker images
         id: docker-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar
@@ -56,7 +56,7 @@ jobs:
         run: docker image load --input ~/.docker-images.tar
 
       - name: Cache build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.s3buildcache
@@ -82,7 +82,7 @@ jobs:
 
       - name: Cache Docker images
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.docker-images.tar

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -10,13 +10,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install type dependencies
         run: yarn install --frozen-lockfile
       - name: Compile TypeScript
         run: npx tsc --project scripts/tsconfig.pr-issue-check.json
       - name: Check PR description for issue reference
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: cdklabs/pr-triage-manager@main
+      - uses: cdklabs/pr-triage-manager@1afffe19c43385a323d5c6203e33f4291a154f12 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-linter-exemption-labeler.yml
+++ b/.github/workflows/pr-linter-exemption-labeler.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: cdklabs/pr-linter-exemption-labeler@main
+      - uses: cdklabs/pr-linter-exemption-labeler@9ad6c8b06f6a92a49b8529c8e493e0b1b6ba7111 # main
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/pr-linter-review-trigger.yml
+++ b/.github/workflows/pr-linter-review-trigger.yml
@@ -29,7 +29,7 @@ jobs:
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
           echo $PR_SHA > ./pr/pr_sha
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_info
           path: pr/

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: "Download workflow_run artifact"
         if: github.event_name == 'workflow_run'
-        uses: dawidd6/action-download-artifact@v21
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         continue-on-error: true
         with:
           run_id: ${{ github.event.workflow_run.id }}
@@ -72,7 +72,7 @@ jobs:
     environment: automation
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install & Build prlint
         run: yarn install --frozen-lockfile && cd tools/@aws-cdk/prlint && yarn build+test

--- a/.github/workflows/project-prioritization-added-on.yml
+++ b/.github/workflows/project-prioritization-added-on.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Update AddedOn field
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-prioritization-assignment.yml
+++ b/.github/workflows/project-prioritization-assignment.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Add PR to Project & Set Priority
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-prioritization-bug.yml
+++ b/.github/workflows/project-prioritization-bug.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Add P1 Bug to project
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-prioritization-needs-attention.yml
+++ b/.github/workflows/project-prioritization-needs-attention.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Update Needs Attention Status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-prioritization-r2-assignment.yml
+++ b/.github/workflows/project-prioritization-r2-assignment.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Check and assign R2 Priority to PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-prioritization-r5-assignment.yml
+++ b/.github/workflows/project-prioritization-r5-assignment.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Check and Assign R5 Priority to PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/request-cli-integ-test.yml
+++ b/.github/workflows/request-cli-integ-test.yml
@@ -20,7 +20,7 @@ jobs:
       any-changed-files: ${{ steps.changed-cli-files.outputs.cli_any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -49,7 +49,7 @@ jobs:
     environment: automation
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Needs to run with PROJEN_GITHUB_TOKEN because we need permissions to force push the branch
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/security-guardian.yml
+++ b/.github/workflows/security-guardian.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:      
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0  
@@ -53,7 +53,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > ./test-results/pr_sha
       
       - name: Upload Security Guardian XML Reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: security-guardian-reports

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -16,7 +16,7 @@ jobs:
       CHECK_NAME_RESOLVED: 'Security Guardian Results with resolved templates'
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: security-guardian-reports
           path: test-results/
@@ -32,7 +32,7 @@ jobs:
           echo "PR: $(cat test-results/pr_number), SHA: $(cat test-results/pr_sha)"
       - name: Publish Security Test Results 
         id: junit_static
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         if: always()
         with:
           report_paths: 'test-results/**/cfn-guard-static.xml'
@@ -51,7 +51,7 @@ jobs:
           include_empty_in_summary: false
 
       - name: Add disclaimer to static results comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: steps.junit_static.outcome == 'success'
         env:
           PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Security Test Results for resolved templates
         id: junit_resolved
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         if: always()
         with:
           report_paths: 'test-results/**/cfn-guard-resolved.xml'
@@ -104,7 +104,7 @@ jobs:
           include_empty_in_summary: false
 
       - name: Add disclaimer to resolved results comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: steps.junit_resolved.outcome == 'success'
         env:
           PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:
@@ -31,7 +31,7 @@ jobs:
 
       # Upload the current db to be used later
       - name: Upload base database
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: db.base.json.gz
           path: node_modules/@aws-cdk/aws-service-spec/db.json.gz
@@ -49,7 +49,7 @@ jobs:
 
       # Now that we have updated the database, upload the new candidate db
       - name: Upload head database
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: db.head.json.gz
           path: node_modules/@aws-cdk/aws-service-spec/db.json.gz
@@ -73,7 +73,7 @@ jobs:
           git add .
           git diff --patch --staged > ${{ runner.temp }}/update-spec.patch
       - name: Upload Patch
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: update-spec.patch
           path: ${{ runner.temp }}/update-spec.patch
@@ -89,12 +89,12 @@ jobs:
       CI: "true"
     steps:
       - name: Download base database
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: db.base.json.gz
           path: base
       - name: Download head database
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: db.head.json.gz
           path: head
@@ -114,7 +114,7 @@ jobs:
           cat DIFF >> PR.md
           echo '```' >> PR.md
       - name: Upload PR body file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: PR.md
           path: PR.md
@@ -130,10 +130,10 @@ jobs:
     environment: automation
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download patch
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: update-spec.patch
           path: ${{ runner.temp }}
@@ -142,13 +142,13 @@ jobs:
         run: '[ -s ${{ runner.temp }}/update-spec.patch ] && git apply ${{ runner.temp }}/update-spec.patch || echo "Empty patch. Skipping."'
 
       - name: Download PR body file
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: PR.md
           path: ${{ runner.temp }}
 
       - name: Make Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           # Git commit details
           branch: automation/spec-update

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -46,14 +46,14 @@ jobs:
     steps:
       - name: Checkout using User Token (+ download lfs dependencies)
         if: needs.check-secret.outputs.ok == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           lfs: true
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
 
       - name: Checkout using GitHub Actions permissions (+ download lfs dependencies)
         if: needs.check-secret.outputs.ok == 'false'
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           lfs: true
 

--- a/.github/workflows/unlock-reopened-issue-pr-with-message.yml
+++ b/.github/workflows/unlock-reopened-issue-pr-with-message.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/closed-issue-message@v2
+      - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           message: |

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     steps:
-      - uses: actions/checkout@v7
-      - uses: minicli/action-contributors@v3.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: minicli/action-contributors@20ec03af008cb51110a3137fbf77f59a4fd7ff5a # v3.3
         name: "Update a projects CONTRIBUTORS file"
         env:
           CONTRIB_REPOSITORY: "aws/aws-cdk"
           CONTRIB_OUTPUT_FILE: "CONTRIBUTORS.md"
           CONTRIB_IGNORE: "github-actions[bot],mergify[bot],dependabot[bot],dependabot-preview[bot],aws-cdk-automation"
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           # Git commit details
           branch: automation/update-contributors

--- a/.github/workflows/update-metadata-regions.yml
+++ b/.github/workflows/update-metadata-regions.yml
@@ -22,8 +22,8 @@ jobs:
 
           status=$(curl -s -o /dev/null -w "%{http_code}" $URL)
           echo "STATUS=${status}" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v7
-      - uses: actions/github-script@v9
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: ${{ steps.download.outputs.STATUS == 200 }}
         env:
           REGIONS: ${{ steps.download.outputs.REGIONS }}
@@ -36,7 +36,7 @@ jobs:
           git add .
           git diff --patch --staged > ${{ runner.temp }}/update-spec.patch
       - name: Upload Patch
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: update-spec.patch
           path: ${{ runner.temp }}/update-spec.patch
@@ -51,10 +51,10 @@ jobs:
     environment: automation
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download patch
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: update-spec.patch
           path: ${{ runner.temp }}
@@ -63,7 +63,7 @@ jobs:
         run: '[ -s ${{ runner.temp }}/update-spec.patch ] && git apply ${{ runner.temp }}/update-spec.patch || echo "Empty patch. Skipping."'
 
       - name: Make Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           # Git commit details
           branch: automation/region-update

--- a/.github/workflows/yarn-upgrade-need-manual-work.yml
+++ b/.github/workflows/yarn-upgrade-need-manual-work.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:
@@ -36,7 +36,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore Yarn cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -66,7 +66,7 @@ jobs:
           git diff --binary --patch --staged > ${{ runner.temp }}/upgrade.patch
 
       - name: Upload Patch
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: upgrade.patch
           path: ${{ runner.temp }}/upgrade.patch
@@ -81,10 +81,10 @@ jobs:
     environment: automation
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download patch
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: upgrade.patch
           path: ${{ runner.temp }}
@@ -95,7 +95,7 @@ jobs:
           }}/upgrade.patch || echo "Empty patch. Skipping."'
 
       - name: Make Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           # Git commit details
           branch: automation/yarn-upgrade-dependencies-requiring-intervention

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "*"
         env:
@@ -28,7 +28,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore Yarn cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -76,7 +76,7 @@ jobs:
           git add .
           git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
       - name: Upload Patch
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: upgrade.patch
           path: ${{ runner.temp }}/upgrade.patch
@@ -91,10 +91,10 @@ jobs:
     environment: automation
     steps:
       - name: Check Out
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download patch
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: upgrade.patch
           path: ${{ runner.temp }}
@@ -105,7 +105,7 @@ jobs:
           }}/upgrade.patch || echo "Empty patch. Skipping."'
 
       - name: Make Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           # Git commit details
           branch: automation/yarn-upgrade


### PR DESCRIPTION
## Summary

**45 workflow files** across the `aws/aws-cdk` repository reference GitHub Actions using **mutable version tags and branch references** (`@v7`, `@v8`, `@v9`, `@main`, etc.). Tags are mutable — an attacker who compromises any upstream Action repository can silently move a tag to execute malicious code in CDK's CI/CD pipelines.

## Scope

27 unique action references fixed across 45 workflow files, including workflows with access to deployment credentials and AWS integration test resources.

## Actions pinned (sample)

| Action | Mutable ref | Pinned SHA |
|--------|------------|-----------|
| `actions/checkout` | `@v7` | `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
| `actions/github-script` | `@v9` | `@3a2844b7e9c422d3c10d287c895573f7108da1b3` |
| `aws-github-ops/aws-issue-triage-manager` | `@main` ⚠️ | `@701b2b0b4ba8c03c587149c37519052c357a2a61` |
| `cdklabs/pr-triage-manager` | `@main` ⚠️ | `@1afffe19c43385a323d5c6203e33f4291a154f12` |
| `hmarr/auto-approve-action` | `@v4.0.0` | `@f0939ea97e9205ef24d872e76833fa908a770363` |
| `peter-evans/create-pull-request` | `@v8` | `@5f6978faf089d4d20b00c7766989d076bb2fc7f1` |

(All 27 unique action refs are pinned in this PR.)

## Vulnerability class

Supply-chain attack via mutable Action tag/branch references (CWE-829). See [GitHub Security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).