### PR TITLE
feat(ec2): reference the Amazon-provided IPv6 CIDR block of a dual stack VPC

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -358,6 +358,21 @@ Disabling the auto-assigning of a public IPv4 address by default can avoid the c
 
 See [Advanced Subnet Configuration](#advanced-subnet-configuration) for all IPv6 specific properties.
 
+The Amazon provided IPv6 CIDR block of a dual stack VPC can be referenced through the `vpcIpv6CidrBlock` property, for example to allow traffic from the VPC's IPv6 range in a security group:
+
+```ts
+const vpc = new ec2.Vpc(this, 'DualStackVpc', {
+  ipProtocol: ec2.IpProtocol.DUAL_STACK,
+});
+
+const securityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', { vpc });
+securityGroup.addIngressRule(
+  ec2.Peer.ipv6(vpc.vpcIpv6CidrBlock!),
+  ec2.Port.tcp(443),
+  'Allow HTTPS from the VPC IPv6 range',
+);
+```
+
 ### Reserving availability zones
 
 There are situations where the IP space for availability zones will

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -1483,6 +1483,18 @@ export class Vpc extends VpcBase {
   public readonly vpcIpv6CidrBlocks: string[];
 
   /**
+   * The IPv6 CIDR block associated with this VPC.
+   *
+   * For a dual-stack VPC, this is the Amazon-provided `/56` IPv6 CIDR block.
+   * The value can be passed to `Peer.ipv6()` to reference the VPC's IPv6 range
+   * in security group rules or used as an egress destination.
+   *
+   * This is `undefined` for VPCs that are not configured with IPv6 (i.e. the
+   * `ipProtocol` is not `DUAL_STACK`).
+   */
+  public readonly vpcIpv6CidrBlock?: string;
+
+  /**
    * List of public subnets in this VPC
    */
   public readonly publicSubnets: ISubnet[] = [];
@@ -1680,6 +1692,7 @@ export class Vpc extends VpcBase {
       });
 
       this.ipv6SelectedCidr = Fn.select(0, this.resource.attrIpv6CidrBlocks);
+      this.vpcIpv6CidrBlock = this.ipv6SelectedCidr;
     }
 
     // subnetConfiguration must be set before calling createSubnets

--- a/packages/aws-cdk-lib/aws-ec2/test/vpc.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/vpc.test.ts
@@ -25,6 +25,7 @@ import {
   Port,
   PrivateSubnet,
   RouterType,
+  SecurityGroup,
   Subnet,
   SubnetType,
   TrafficDirection,
@@ -2751,6 +2752,58 @@ describe('vpc', () => {
         Ref: Match.stringLikeRegexp('^Vpc.*'),
       },
     });
+  });
+  test('vpcIpv6CidrBlock references the Amazon-provided IPv6 CIDR block', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'DualStackStack');
+
+    // WHEN
+    const vpc = new Vpc(stack, 'Vpc', {
+      ipProtocol: IpProtocol.DUAL_STACK,
+    });
+
+    // THEN
+    const logicalId = stack.getLogicalId(vpc.node.defaultChild as CfnVPC);
+    expect(stack.resolve(vpc.vpcIpv6CidrBlock)).toEqual({
+      'Fn::Select': [0, { 'Fn::GetAtt': [logicalId, 'Ipv6CidrBlocks'] }],
+    });
+  });
+  test('vpcIpv6CidrBlock can be used to reference the VPC IPv6 range in a security group rule', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'DualStackStack');
+
+    // WHEN
+    const vpc = new Vpc(stack, 'Vpc', {
+      ipProtocol: IpProtocol.DUAL_STACK,
+    });
+    const securityGroup = new SecurityGroup(stack, 'SecurityGroup', { vpc });
+    securityGroup.addIngressRule(Peer.ipv6(vpc.vpcIpv6CidrBlock!), Port.tcp(443));
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::EC2::SecurityGroup', {
+      SecurityGroupIngress: [
+        Match.objectLike({
+          CidrIpv6: {
+            'Fn::Select': [0, { 'Fn::GetAtt': [Match.stringLikeRegexp('^Vpc.*'), 'Ipv6CidrBlocks'] }],
+          },
+          FromPort: 443,
+          ToPort: 443,
+        }),
+      ],
+    });
+  });
+  test('vpcIpv6CidrBlock is undefined for a VPC without IPv6', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Ipv4OnlyStack');
+
+    // WHEN
+    const vpc = new Vpc(stack, 'Vpc');
+
+    // THEN
+    expect(vpc.vpcIpv6CidrBlock).toBeUndefined();
   });
   test('EgressOnlyIGW is created if no private subnet configured in dual stack and feature flag EC2_REQUIRE_PRIVATE_SUBNETS_FOR_EGRESSONLYINTERNETGATEWAY is not enabled', () => {
     // GIVEN


### PR DESCRIPTION
### Issue # (if applicable)

Closes #29861.

### Reason for this change

When a VPC is configured for dual stack (`ipProtocol: ec2.IpProtocol.DUAL_STACK`), an Amazon-provided IPv6 `/56` CIDR block is associated with the VPC. There was no convenient way to reference that block from the `Vpc` construct, so it couldn't easily be used as a source/destination in security group or egress rules the way the IPv4 CIDR block (`vpcCidrBlock`) already can.

### Description of changes

Added a `vpcIpv6CidrBlock` property to the `Vpc` construct. It returns the Amazon-provided IPv6 CIDR block of a dual stack VPC, and is `undefined` for IPv4-only VPCs.

The value is `Fn.select(0, attrIpv6CidrBlocks)`, which is the reference CloudFormation recommends for the Amazon-provided block (see the `AWS::EC2::VPCCidrBlock` [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html). `VPCCidrBlock` itself does not return the CIDR as an attribute). The VPC already computed this value internally to size the subnet CIDRs; this change just exposes it. Since `Peer.ipv6()` already accepts tokens, the property can be passed straight into a rule:

```ts
const vpc = new ec2.Vpc(this, 'DualStackVpc', {
  ipProtocol: ec2.IpProtocol.DUAL_STACK,
});

const securityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', { vpc });
securityGroup.addIngressRule(
  ec2.Peer.ipv6(vpc.vpcIpv6CidrBlock!),
  ec2.Port.tcp(443),
);
```

I kept the property on the concrete `Vpc` class rather than adding it to `IVpc`. Adding a member to `IVpc` would be a breaking change for external implementers, and would require imported VPCs (`fromVpcAttributes`/`fromLookup`) to surface IPv6 information they don't have available today. This also mirrors the existing `vpcIpv6CidrBlocks` property, which lives on the concrete class only.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added unit tests in `vpc.test.ts` that assert the property resolves to `Fn::Select [0, Fn::GetAtt [VPC, Ipv6CidrBlocks]]` for a dual stack VPC, that it can be used in a security group ingress rule, and that it is `undefined` for an IPv4-only VPC. Also documented the property in the aws-ec2 README.

No new integration test was added: the property only exposes a value the VPC already synthesizes (it's used to size subnet IPv6 CIDRs), which is exercised by the existing dual stack integration tests.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
