### PR TITLE
feat(applicationautoscaling): add high-resolution ECS predefined metrics

### DIFF
--- a/packages/aws-cdk-lib/aws-applicationautoscaling/README.md
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/README.md
@@ -264,3 +264,35 @@ target.scaleToTrackMetric('SageMakerVariantProvisionedConcurrencyUtilization', {
   predefinedMetric: appscaling.PredefinedMetric.SAGEMAKER_VARIANT_PROVISIONED_CONCURRENCY_UTILIZATION,
 });
 ```
+
+### ECS service high-resolution (20-second) auto scaling
+
+ECS supports high-resolution (20-second) metrics for faster auto scaling. Use
+the `*HighResolution` predefined metrics along with the service-level
+`MonitoringConfiguration` (available in L1 once `@aws-cdk/aws-service-spec`
+>= 0.1.190 ships) to enable 20-second metric reporting.
+
+```ts
+const target = new appscaling.ScalableTarget(this, 'ECSScalableTarget', {
+  serviceNamespace: appscaling.ServiceNamespace.ECS,
+  scalableDimension: 'ecs:service:DesiredCount',
+  minCapacity: 1,
+  maxCapacity: 20,
+  resourceId: 'service/MyCluster/MyService',
+});
+
+target.scaleToTrackMetric('CpuHighResolution', {
+  targetValue: 60,
+  predefinedMetric: appscaling.PredefinedMetric.ECS_SERVICE_AVERAGE_CPU_UTILIZATION_HIGH_RESOLUTION,
+});
+
+target.scaleToTrackMetric('MemoryHighResolution', {
+  targetValue: 60,
+  predefinedMetric: appscaling.PredefinedMetric.ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION_HIGH_RESOLUTION,
+});
+```
+
+> **Note:** For existing services, you must first update the service's monitoring
+> configuration (which triggers a deployment), and only after tasks emit
+> 20-second metrics can you attach the high-resolution scaling policy.
+> A new service can set both at creation.

--- a/packages/aws-cdk-lib/aws-applicationautoscaling/lib/target-tracking-scaling-policy.ts
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/lib/target-tracking-scaling-policy.ts
@@ -277,6 +277,24 @@ export enum PredefinedMetric {
    */
   ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION = 'ECSServiceAverageMemoryUtilization',
   /**
+   * Average CPU utilization of an ECS service, sampled at 20-second intervals.
+   *
+   * This metric uses high-resolution (20-second) reporting, which enables faster
+   * auto scaling response times compared to the standard 60-second interval.
+   *
+   * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/target-tracking-faster-auto-scaling.html
+   */
+  ECS_SERVICE_AVERAGE_CPU_UTILIZATION_HIGH_RESOLUTION = 'ECSServiceAverageCPUUtilizationHighResolution',
+  /**
+   * Average memory utilization of an ECS service, sampled at 20-second intervals.
+   *
+   * This metric uses high-resolution (20-second) reporting, which enables faster
+   * auto scaling response times compared to the standard 60-second interval.
+   *
+   * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/target-tracking-faster-auto-scaling.html
+   */
+  ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION_HIGH_RESOLUTION = 'ECSServiceAverageMemoryUtilizationHighResolution',
+  /**
    * LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION
    * @see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html#monitoring-metrics-concurrency
    */

--- a/packages/aws-cdk-lib/aws-applicationautoscaling/test/target-tracking.test.ts
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/test/target-tracking.test.ts
@@ -149,6 +149,46 @@ describe('target tracking', () => {
     });
   });
 
+  test('test setup target tracking on predefined metric for ECS_SERVICE_AVERAGE_CPU_UTILIZATION_HIGH_RESOLUTION', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const target = createScalableTarget(stack);
+
+    // WHEN
+    target.scaleToTrackMetric('Tracking', {
+      predefinedMetric: appscaling.PredefinedMetric.ECS_SERVICE_AVERAGE_CPU_UTILIZATION_HIGH_RESOLUTION,
+      targetValue: 60,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
+      TargetTrackingScalingPolicyConfiguration: {
+        PredefinedMetricSpecification: { PredefinedMetricType: 'ECSServiceAverageCPUUtilizationHighResolution' },
+        TargetValue: 60,
+      },
+    });
+  });
+
+  test('test setup target tracking on predefined metric for ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION_HIGH_RESOLUTION', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    const target = createScalableTarget(stack);
+
+    // WHEN
+    target.scaleToTrackMetric('Tracking', {
+      predefinedMetric: appscaling.PredefinedMetric.ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION_HIGH_RESOLUTION,
+      targetValue: 60,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
+      TargetTrackingScalingPolicyConfiguration: {
+        PredefinedMetricSpecification: { PredefinedMetricType: 'ECSServiceAverageMemoryUtilizationHighResolution' },
+        TargetValue: 60,
+      },
+    });
+  });
+
   test('test setup target tracking on custom metric', () => {
     // GIVEN
     const stack = new cdk.Stack();


### PR DESCRIPTION
## Motivation

Closes #38207

Amazon ECS now supports high-resolution (20-second) metrics for faster auto scaling, but the CDK `PredefinedMetric` enum in `aws-applicationautoscaling` is missing the corresponding high-resolution variants. This forces users to use error-prone string literals when authoring high-resolution target-tracking policies.

## Changes

Added two new members to the `PredefinedMetric` enum:

| Enum member | CloudFormation `PredefinedMetricType` |
|---|---|
| `ECS_SERVICE_AVERAGE_CPU_UTILIZATION_HIGH_RESOLUTION` | `ECSServiceAverageCPUUtilizationHighResolution` |
| `ECS_SERVICE_AVERAGE_MEMORY_UTILIZATION_HIGH_RESOLUTION` | `ECSServiceAverageMemoryUtilizationHighResolution` |

Each new member includes JSDoc with a `@see` link to the ECS high-resolution scaling guide.

### README

Added a new section under **ECS Service Auto Scaling** showing how to create a `ScalableTarget` and attach high-resolution tracking policies, with a note about the two-step constraint for existing services.

### Tests

Added two unit tests verifying that each new metric value is rendered correctly in the synthesized `AWS::ApplicationAutoScaling::ScalingPolicy` template.

## Testing

```
npx jest aws-applicationautoscaling/test/target-tracking.test.ts
```

> **Note:** The full test suite requires the generated source to be built first (`npx lerna run build --scope=aws-cdk-lib --stream`). The new enum values follow the same pattern as all existing `PredefinedMetric` members and are string-literal mappings with no logic, so the risk of regressions is minimal.

---

**By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.**