### PR TITLE
docs(agents): forbid app.synth() and Match.anyValue() in unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,8 @@ if (FeatureFlags.of(this).isEnabled(cxapi.MY_NEW_FLAG)) { ... }
   });
   ```
 - Other `Match` helpers: `Match.objectEquals`, `Match.arrayWith`, `Match.stringLikeRegexp`, `Match.absent()`
+- Avoid `Match.anyValue()` — it weakens assertions and hides regressions; assert the specific value, using `Match.stringLikeRegexp()` for non-deterministic values (asset hashes, generated IDs)
+- Avoid `app.synth()` — `Template.fromStack()` synthesizes the stack internally, so an explicit synth is redundant
 - `test.each` for boundary conditions: `test.each([0, -1, 256])('fails for invalid value %d', (val) => { ... })`
 - Error tests: assert on specific error message, prefix test name with "fails"
 - Test utility functions separately from constructs (e.g. `util.test.ts`)


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The AGENTS.md testing conventions already forbid `app.synth()` in integration tests but did not cover unit tests, and said nothing about `Match.anyValue()`. Both are common unit-test anti-patterns.

### Description of changes

Added two bullets to the Unit Tests section of AGENTS.md:
- Avoid `Match.anyValue()` — assert the specific value, using `Match.stringLikeRegexp()` for non-deterministic values.
- Avoid `app.synth()` — `Template.fromStack()` synthesizes the stack internally.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Docs-only change. No code affected.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
