### PR TITLE
feat(ruby): add Ruby language bindings for AWS CDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The CDK is available in the following languages:
 * Java ([Java ≥ 8](https://www.oracle.com/technetwork/java/javase/downloads/index.html) and [Maven ≥ 3.5.4](https://maven.apache.org/download.cgi))
 * .NET ([.NET ≥ 8.0](https://dotnet.microsoft.com/download))
 * Go ([Go ≥ 1.16.4](https://golang.org/))
+* Ruby ([Ruby ≥ 3.3](https://www.ruby-lang.org/en/downloads/))
 
 Third-party Language Deprecation: language version is only supported until its EOL (End Of Life) shared by the vendor or community and is subject to change with prior notice.
 

--- a/packages/aws-cdk-lib/alexa-ask/.jsiirc.json
+++ b/packages/aws-cdk-lib/alexa-ask/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.alexa_ask"
+    },
+    "ruby": {
+      "module": "AWSCDK::AlexaAsk"
     }
   }
 }

--- a/packages/aws-cdk-lib/assertions/.jsiirc.json
+++ b/packages/aws-cdk-lib/assertions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.assertions"
+    },
+    "ruby": {
+      "module": "AWSCDK::Assertions"
     }
   }
 }

--- a/packages/aws-cdk-lib/assets/.jsiirc.json
+++ b/packages/aws-cdk-lib/assets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.assets"
+    },
+    "ruby": {
+      "module": "AWSCDK::Assets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-accessanalyzer/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-accessanalyzer/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_accessanalyzer"
+    },
+    "ruby": {
+      "module": "AWSCDK::AccessAnalyzer"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-acmpca/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-acmpca/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_acmpca"
+    },
+    "ruby": {
+      "module": "AWSCDK::ACMPCA"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-aiops/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-aiops/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_aiops"
+    },
+    "ruby": {
+      "module": "AWSCDK::AIOps"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-amazonmq/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-amazonmq/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_amazonmq"
+    },
+    "ruby": {
+      "module": "AWSCDK::AmazonMQ"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-amplify/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-amplify/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_amplify"
+    },
+    "ruby": {
+      "module": "AWSCDK::Amplify"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-amplifyuibuilder/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-amplifyuibuilder/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_amplifyuibuilder"
+    },
+    "ruby": {
+      "module": "AWSCDK::AmplifyUIBuilder"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apigateway/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apigateway/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apigateway"
+    },
+    "ruby": {
+      "module": "AWSCDK::APIGateway"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apigatewayv2-authorizers/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apigatewayv2-authorizers/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apigatewayv2_authorizers"
+    },
+    "ruby": {
+      "module": "AWSCDK::APIGatewayv2Authorizers"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apigatewayv2-integrations/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apigatewayv2-integrations/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apigatewayv2_integrations"
+    },
+    "ruby": {
+      "module": "AWSCDK::APIGatewayv2Integrations"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apigatewayv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apigatewayv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apigatewayv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::APIGatewayv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appconfig/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appconfig/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appconfig"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppConfig"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appflow/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appflow/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appflow"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppFlow"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appintegrations/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appintegrations/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appintegrations"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppIntegrations"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-applicationautoscaling/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-applicationautoscaling/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_applicationautoscaling"
+    },
+    "ruby": {
+      "module": "AWSCDK::ApplicationAutoScaling"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-applicationinsights/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-applicationinsights/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_applicationinsights"
+    },
+    "ruby": {
+      "module": "AWSCDK::ApplicationInsights"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-applicationsignals/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-applicationsignals/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_applicationsignals"
+    },
+    "ruby": {
+      "module": "AWSCDK::ApplicationSignals"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appmesh/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appmesh/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appmesh"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppMesh"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apprunner/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apprunner/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apprunner"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppRunner"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appstream/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appstream/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appstream"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppStream"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-appsync/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-appsync/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_appsync"
+    },
+    "ruby": {
+      "module": "AWSCDK::AppSync"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-apptest/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-apptest/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_apptest"
+    },
+    "ruby": {
+      "module": "AWSCDK::Apptest"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-aps/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-aps/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_aps"
+    },
+    "ruby": {
+      "module": "AWSCDK::APS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-arcregionswitch/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-arcregionswitch/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_arcregionswitch"
+    },
+    "ruby": {
+      "module": "AWSCDK::ARCRegionSwitch"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-arczonalshift/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-arczonalshift/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_arczonalshift"
+    },
+    "ruby": {
+      "module": "AWSCDK::ARCZonalShift"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-athena/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-athena/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_athena"
+    },
+    "ruby": {
+      "module": "AWSCDK::Athena"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-auditmanager/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-auditmanager/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_auditmanager"
+    },
+    "ruby": {
+      "module": "AWSCDK::AuditManager"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-autoscaling-common/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-autoscaling-common/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_autoscaling_common"
+    },
+    "ruby": {
+      "module": "AWSCDK::AutoScalingCommon"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-autoscaling-hooktargets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-autoscaling-hooktargets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_autoscaling_hooktargets"
+    },
+    "ruby": {
+      "module": "AWSCDK::AutoScalingHookTargets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-autoscaling/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-autoscaling/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_autoscaling"
+    },
+    "ruby": {
+      "module": "AWSCDK::Autoscaling"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-autoscalingplans/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-autoscalingplans/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_autoscalingplans"
+    },
+    "ruby": {
+      "module": "AWSCDK::AutoScalingPlans"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-awsexternalanthropic/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-awsexternalanthropic/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_awsexternalanthropic"
+    },
+    "ruby": {
+      "module": "AWSCDK::ExternalAnthropic"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-b2bi/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-b2bi/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_b2bi"
+    },
+    "ruby": {
+      "module": "AWSCDK::B2BI"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-backup/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-backup/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_backup"
+    },
+    "ruby": {
+      "module": "AWSCDK::Backup"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-backupgateway/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-backupgateway/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_backupgateway"
+    },
+    "ruby": {
+      "module": "AWSCDK::BackupGateway"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-batch/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-batch/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_batch"
+    },
+    "ruby": {
+      "module": "AWSCDK::Batch"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bcm/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bcm/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bcm"
+    },
+    "ruby": {
+      "module": "AWSCDK::BCM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bcmdataexports/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bcmdataexports/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bcmdataexports"
+    },
+    "ruby": {
+      "module": "AWSCDK::BCMDataExports"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bcmpricingcalculator/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bcmpricingcalculator/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bcmpricingcalculator"
+    },
+    "ruby": {
+      "module": "AWSCDK::BCMPricingCalculator"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bedrock/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bedrock/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bedrock"
+    },
+    "ruby": {
+      "module": "AWSCDK::Bedrock"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bedrockagentcore/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bedrockagentcore/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bedrockagentcore"
+    },
+    "ruby": {
+      "module": "AWSCDK::BedrockAgentCore"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-bedrockmantle/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-bedrockmantle/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_bedrockmantle"
+    },
+    "ruby": {
+      "module": "AWSCDK::BedrockMantle"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-billing/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-billing/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_billing"
+    },
+    "ruby": {
+      "module": "AWSCDK::Billing"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-billingconductor/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-billingconductor/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_billingconductor"
+    },
+    "ruby": {
+      "module": "AWSCDK::BillingConductor"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-braket/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-braket/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_braket"
+    },
+    "ruby": {
+      "module": "AWSCDK::Braket"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-budgets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-budgets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_budgets"
+    },
+    "ruby": {
+      "module": "AWSCDK::Budgets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cases/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cases/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cases"
+    },
+    "ruby": {
+      "module": "AWSCDK::Cases"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cassandra/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cassandra/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cassandra"
+    },
+    "ruby": {
+      "module": "AWSCDK::Cassandra"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ce/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ce/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ce"
+    },
+    "ruby": {
+      "module": "AWSCDK::CE"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-certificatemanager/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-certificatemanager/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_certificatemanager"
+    },
+    "ruby": {
+      "module": "AWSCDK::CertificateManager"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-chatbot/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-chatbot/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_chatbot"
+    },
+    "ruby": {
+      "module": "AWSCDK::Chatbot"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-chime/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-chime/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_chime"
+    },
+    "ruby": {
+      "module": "AWSCDK::Chime"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cleanrooms/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cleanrooms/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cleanrooms"
+    },
+    "ruby": {
+      "module": "AWSCDK::CleanRooms"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cleanroomsml/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cleanroomsml/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cleanroomsml"
+    },
+    "ruby": {
+      "module": "AWSCDK::CleanRoomsML"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloud9/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloud9/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloud9"
+    },
+    "ruby": {
+      "module": "AWSCDK::Cloud9"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudformation/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudformation/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudformation"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudFormation"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudfront-origins/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudfront-origins/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudfront_origins"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudFrontOrigins"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudfront/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudfront/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudfront"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudFront"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudtrail/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudtrail/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudtrail"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudTrail"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudwatch-actions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudwatch-actions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudwatch_actions"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudWatchActions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cloudwatch/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cloudwatch/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cloudwatch"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudWatch"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codeartifact/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codeartifact/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codeartifact"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeArtifact"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codebuild/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codebuild/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codebuild"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeBuild"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codecommit/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codecommit/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codecommit"
+    },
+    "ruby": {
+      "module": "AWSCDK::Codecommit"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codeconnections/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codeconnections/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codeconnections"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeConnections"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codedeploy/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codedeploy/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codedeploy"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeDeploy"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codeguruprofiler/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codeguruprofiler/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codeguruprofiler"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeGuruProfiler"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codegurureviewer/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codegurureviewer/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codegurureviewer"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeGuruReviewer"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codepipeline-actions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codepipeline-actions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codepipeline_actions"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodePipelineActions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codepipeline/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codepipeline/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codepipeline"
+    },
+    "ruby": {
+      "module": "AWSCDK::Codepipeline"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codestar/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codestar/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codestar"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeStar"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codestarconnections/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codestarconnections/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codestarconnections"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeStarConnections"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-codestarnotifications/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-codestarnotifications/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_codestarnotifications"
+    },
+    "ruby": {
+      "module": "AWSCDK::CodeStarNotifications"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cognito-identitypool/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cognito-identitypool/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cognito_identitypool"
+    },
+    "ruby": {
+      "module": "AWSCDK::CognitoIdentitypool"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cognito/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cognito/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cognito"
+    },
+    "ruby": {
+      "module": "AWSCDK::Cognito"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-comprehend/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-comprehend/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_comprehend"
+    },
+    "ruby": {
+      "module": "AWSCDK::Comprehend"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-computeoptimizer/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-computeoptimizer/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_computeoptimizer"
+    },
+    "ruby": {
+      "module": "AWSCDK::ComputeOptimizer"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-config/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-config/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_config"
+    },
+    "ruby": {
+      "module": "AWSCDK::Config"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-connect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-connect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_connect"
+    },
+    "ruby": {
+      "module": "AWSCDK::Connect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-connectcampaigns/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-connectcampaigns/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_connectcampaigns"
+    },
+    "ruby": {
+      "module": "AWSCDK::ConnectCampaigns"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-connectcampaignsv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-connectcampaignsv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_connectcampaignsv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::ConnectCampaignsv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-controltower/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-controltower/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_controltower"
+    },
+    "ruby": {
+      "module": "AWSCDK::ControlTower"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-cur/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-cur/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_cur"
+    },
+    "ruby": {
+      "module": "AWSCDK::CUR"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-customerprofiles/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-customerprofiles/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_customerprofiles"
+    },
+    "ruby": {
+      "module": "AWSCDK::CustomerProfiles"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-databrew/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-databrew/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_databrew"
+    },
+    "ruby": {
+      "module": "AWSCDK::DataBrew"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-datapipeline/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-datapipeline/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_datapipeline"
+    },
+    "ruby": {
+      "module": "AWSCDK::DataPipeline"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-datasync/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-datasync/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_datasync"
+    },
+    "ruby": {
+      "module": "AWSCDK::Datasync"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-datazone/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-datazone/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_datazone"
+    },
+    "ruby": {
+      "module": "AWSCDK::DataZone"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-dax/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-dax/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_dax"
+    },
+    "ruby": {
+      "module": "AWSCDK::DAX"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-deadline/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-deadline/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_deadline"
+    },
+    "ruby": {
+      "module": "AWSCDK::Deadline"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-detective/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-detective/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_detective"
+    },
+    "ruby": {
+      "module": "AWSCDK::Detective"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-devicefarm/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-devicefarm/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_devicefarm"
+    },
+    "ruby": {
+      "module": "AWSCDK::DeviceFarm"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-devopsagent/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-devopsagent/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_devopsagent"
+    },
+    "ruby": {
+      "module": "AWSCDK::DevOpsAgent"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-devopsguru/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-devopsguru/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_devopsguru"
+    },
+    "ruby": {
+      "module": "AWSCDK::DevOpsGuru"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-directconnect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-directconnect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_directconnect"
+    },
+    "ruby": {
+      "module": "AWSCDK::Directconnect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-directoryservice/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-directoryservice/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_directoryservice"
+    },
+    "ruby": {
+      "module": "AWSCDK::DirectoryService"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-dlm/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-dlm/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_dlm"
+    },
+    "ruby": {
+      "module": "AWSCDK::DLM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-dms/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-dms/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_dms"
+    },
+    "ruby": {
+      "module": "AWSCDK::DMS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-docdb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-docdb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_docdb"
+    },
+    "ruby": {
+      "module": "AWSCDK::DocDB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-docdbelastic/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-docdbelastic/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_docdbelastic"
+    },
+    "ruby": {
+      "module": "AWSCDK::DocDBElastic"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-dsql/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-dsql/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_dsql"
+    },
+    "ruby": {
+      "module": "AWSCDK::DSQL"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-dynamodb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-dynamodb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_dynamodb"
+    },
+    "ruby": {
+      "module": "AWSCDK::DynamoDB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ec2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ec2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ec2"
+    },
+    "ruby": {
+      "module": "AWSCDK::EC2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecr-assets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecr-assets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ecr_assets"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECRAssets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecr/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecr/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ecr"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECR"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecr/lib/mixins/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecr/lib/mixins/.jsiirc.json
@@ -11,6 +11,9 @@
     },
     "go": {
       "packageName": "awsecrmixins"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECR::Mixins"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecs-patterns/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ecs_patterns"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECSPatterns"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ecs"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ecs/lib/mixins/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ecs/lib/mixins/.jsiirc.json
@@ -11,6 +11,9 @@
     },
     "go": {
       "packageName": "awsecsmixins"
+    },
+    "ruby": {
+      "module": "AWSCDK::ECS::Mixins"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-efs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-efs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_efs"
+    },
+    "ruby": {
+      "module": "AWSCDK::EFS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-eks-v2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-eks-v2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_eks_v2"
+    },
+    "ruby": {
+      "module": "AWSCDK::EKSv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-eks/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-eks/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_eks"
+    },
+    "ruby": {
+      "module": "AWSCDK::EKS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticache/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticache/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticache"
+    },
+    "ruby": {
+      "module": "AWSCDK::Elasticache"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticbeanstalk/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticbeanstalk/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticbeanstalk"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElasticBeanstalk"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancing/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancing/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticloadbalancing"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElasticLoadBalancing"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2-actions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2-actions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticloadbalancingv2_actions"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElasticLoadBalancingv2Actions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2-targets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2-targets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticloadbalancingv2_targets"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElasticLoadBalancingv2Targets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticloadbalancingv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElasticLoadBalancingv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elasticsearch/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elasticsearch/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elasticsearch"
+    },
+    "ruby": {
+      "module": "AWSCDK::Elasticsearch"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-elementalinference/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-elementalinference/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_elementalinference"
+    },
+    "ruby": {
+      "module": "AWSCDK::ElementalInference"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-emr/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-emr/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_emr"
+    },
+    "ruby": {
+      "module": "AWSCDK::EMR"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-emrcontainers/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-emrcontainers/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_emrcontainers"
+    },
+    "ruby": {
+      "module": "AWSCDK::EMRContainers"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-emrserverless/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-emrserverless/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_emrserverless"
+    },
+    "ruby": {
+      "module": "AWSCDK::EMRServerless"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-entityresolution/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-entityresolution/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_entityresolution"
+    },
+    "ruby": {
+      "module": "AWSCDK::EntityResolution"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-events-targets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-events-targets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_events_targets"
+    },
+    "ruby": {
+      "module": "AWSCDK::EventsTargets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-events/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-events/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_events"
+    },
+    "ruby": {
+      "module": "AWSCDK::Events"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-eventschemas/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-eventschemas/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_eventschemas"
+    },
+    "ruby": {
+      "module": "AWSCDK::EventSchemas"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-evidently/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-evidently/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_evidently"
+    },
+    "ruby": {
+      "module": "AWSCDK::Evidently"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-evs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-evs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_evs"
+    },
+    "ruby": {
+      "module": "AWSCDK::EVS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-finspace/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-finspace/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_finspace"
+    },
+    "ruby": {
+      "module": "AWSCDK::FinSpace"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-fis/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-fis/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_fis"
+    },
+    "ruby": {
+      "module": "AWSCDK::FIS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-fms/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-fms/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_fms"
+    },
+    "ruby": {
+      "module": "AWSCDK::FMS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-forecast/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-forecast/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_forecast"
+    },
+    "ruby": {
+      "module": "AWSCDK::Forecast"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-frauddetector/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-frauddetector/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_frauddetector"
+    },
+    "ruby": {
+      "module": "AWSCDK::FraudDetector"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-fsx/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-fsx/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_fsx"
+    },
+    "ruby": {
+      "module": "AWSCDK::FSX"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-gamelift/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-gamelift/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_gamelift"
+    },
+    "ruby": {
+      "module": "AWSCDK::GameLift"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-gameliftstreams/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-gameliftstreams/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_gameliftstreams"
+    },
+    "ruby": {
+      "module": "AWSCDK::GameLiftStreams"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-globalaccelerator-endpoints/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-globalaccelerator-endpoints/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_globalaccelerator_endpoints"
+    },
+    "ruby": {
+      "module": "AWSCDK::GlobalAcceleratorEndpoints"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-globalaccelerator/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-globalaccelerator/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_globalaccelerator"
+    },
+    "ruby": {
+      "module": "AWSCDK::GlobalAccelerator"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-glue/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-glue/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_glue"
+    },
+    "ruby": {
+      "module": "AWSCDK::Glue"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-grafana/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-grafana/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_grafana"
+    },
+    "ruby": {
+      "module": "AWSCDK::Grafana"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-greengrass/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-greengrass/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_greengrass"
+    },
+    "ruby": {
+      "module": "AWSCDK::Greengrass"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-greengrassv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-greengrassv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_greengrassv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::Greengrassv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-groundstation/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-groundstation/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_groundstation"
+    },
+    "ruby": {
+      "module": "AWSCDK::GroundStation"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-guardduty/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-guardduty/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_guardduty"
+    },
+    "ruby": {
+      "module": "AWSCDK::GuardDuty"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-healthimaging/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-healthimaging/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_healthimaging"
+    },
+    "ruby": {
+      "module": "AWSCDK::HealthImaging"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-healthlake/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-healthlake/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_healthlake"
+    },
+    "ruby": {
+      "module": "AWSCDK::HealthLake"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iam/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iam/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iam"
+    },
+    "ruby": {
+      "module": "AWSCDK::IAM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-identitystore/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-identitystore/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_identitystore"
+    },
+    "ruby": {
+      "module": "AWSCDK::IdentityStore"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-imagebuilder/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-imagebuilder/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_imagebuilder"
+    },
+    "ruby": {
+      "module": "AWSCDK::ImageBuilder"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-inspector/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-inspector/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_inspector"
+    },
+    "ruby": {
+      "module": "AWSCDK::Inspector"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-inspectorv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-inspectorv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_inspectorv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::Inspectorv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-interconnect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-interconnect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_interconnect"
+    },
+    "ruby": {
+      "module": "AWSCDK::Interconnect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-internetmonitor/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-internetmonitor/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_internetmonitor"
+    },
+    "ruby": {
+      "module": "AWSCDK::InternetMonitor"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-invoicing/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-invoicing/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_invoicing"
+    },
+    "ruby": {
+      "module": "AWSCDK::Invoicing"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iot/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iot/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iot"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoT"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotanalytics/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotanalytics/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotanalytics"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTAnalytics"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotcoredeviceadvisor/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotcoredeviceadvisor/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotcoredeviceadvisor"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTCoreDeviceAdvisor"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotevents/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotevents/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotevents"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTEvents"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotfleethub/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotfleethub/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotfleethub"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTFleetHub"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotfleetwise/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotfleetwise/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotfleetwise"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTFleetWise"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotsitewise/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotsitewise/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotsitewise"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTSiteWise"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotthingsgraph/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotthingsgraph/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotthingsgraph"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTThingsGraph"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iottwinmaker/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iottwinmaker/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iottwinmaker"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTTwinMaker"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-iotwireless/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-iotwireless/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_iotwireless"
+    },
+    "ruby": {
+      "module": "AWSCDK::IoTWireless"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ivs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ivs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ivs"
+    },
+    "ruby": {
+      "module": "AWSCDK::IVS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ivschat/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ivschat/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ivschat"
+    },
+    "ruby": {
+      "module": "AWSCDK::IVSChat"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kafkaconnect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kafkaconnect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kafkaconnect"
+    },
+    "ruby": {
+      "module": "AWSCDK::KafkaConnect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kendra/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kendra/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kendra"
+    },
+    "ruby": {
+      "module": "AWSCDK::Kendra"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kendraranking/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kendraranking/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kendraranking"
+    },
+    "ruby": {
+      "module": "AWSCDK::KendraRanking"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kinesis/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kinesis/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kinesis"
+    },
+    "ruby": {
+      "module": "AWSCDK::Kinesis"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kinesisanalytics/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kinesisanalytics/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kinesisanalytics"
+    },
+    "ruby": {
+      "module": "AWSCDK::KinesisAnalytics"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kinesisanalyticsv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kinesisanalyticsv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kinesisanalyticsv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::KinesisAnalyticsv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kinesisfirehose/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kinesisfirehose/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kinesisfirehose"
+    },
+    "ruby": {
+      "module": "AWSCDK::KinesisFirehose"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kinesisvideo/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kinesisvideo/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kinesisvideo"
+    },
+    "ruby": {
+      "module": "AWSCDK::KinesisVideo"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-kms/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-kms/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_kms"
+    },
+    "ruby": {
+      "module": "AWSCDK::KMS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lakeformation/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lakeformation/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lakeformation"
+    },
+    "ruby": {
+      "module": "AWSCDK::LakeFormation"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lambda-destinations/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lambda-destinations/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lambda_destinations"
+    },
+    "ruby": {
+      "module": "AWSCDK::LambdaDestinations"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lambda-event-sources/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lambda-event-sources/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lambda_event_sources"
+    },
+    "ruby": {
+      "module": "AWSCDK::LambdaEventSources"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lambda_nodejs"
+    },
+    "ruby": {
+      "module": "AWSCDK::LambdaNodejs"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lambda/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lambda/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lambda"
+    },
+    "ruby": {
+      "module": "AWSCDK::Lambda"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-launchwizard/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-launchwizard/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_launchwizard"
+    },
+    "ruby": {
+      "module": "AWSCDK::LaunchWizard"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lex/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lex/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lex"
+    },
+    "ruby": {
+      "module": "AWSCDK::Lex"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-licensemanager/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-licensemanager/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_licensemanager"
+    },
+    "ruby": {
+      "module": "AWSCDK::LicenseManager"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lightsail/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lightsail/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lightsail"
+    },
+    "ruby": {
+      "module": "AWSCDK::Lightsail"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-location/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-location/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_location"
+    },
+    "ruby": {
+      "module": "AWSCDK::Location"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-logs-destinations/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-logs-destinations/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_logs_destinations"
+    },
+    "ruby": {
+      "module": "AWSCDK::LogsDestinations"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-logs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-logs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_logs"
+    },
+    "ruby": {
+      "module": "AWSCDK::Logs"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lookoutequipment/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lookoutequipment/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lookoutequipment"
+    },
+    "ruby": {
+      "module": "AWSCDK::LookoutEquipment"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lookoutmetrics/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lookoutmetrics/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lookoutmetrics"
+    },
+    "ruby": {
+      "module": "AWSCDK::LookoutMetrics"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-lookoutvision/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-lookoutvision/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_lookoutvision"
+    },
+    "ruby": {
+      "module": "AWSCDK::LookoutVision"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-m2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-m2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_m2"
+    },
+    "ruby": {
+      "module": "AWSCDK::M2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-macie/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-macie/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_macie"
+    },
+    "ruby": {
+      "module": "AWSCDK::Macie"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-managedblockchain/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-managedblockchain/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_managedblockchain"
+    },
+    "ruby": {
+      "module": "AWSCDK::ManagedBlockchain"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediaconnect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediaconnect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediaconnect"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaConnect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediaconvert/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediaconvert/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediaconvert"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaConvert"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-medialive/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-medialive/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_medialive"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaLive"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediapackage/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediapackage/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediapackage"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaPackage"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediapackagev2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediapackagev2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediapackagev2"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaPackagev2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediastore/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediastore/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediastore"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaStore"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mediatailor/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mediatailor/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mediatailor"
+    },
+    "ruby": {
+      "module": "AWSCDK::MediaTailor"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-memorydb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-memorydb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_memorydb"
+    },
+    "ruby": {
+      "module": "AWSCDK::MemoryDB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mpa/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mpa/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mpa"
+    },
+    "ruby": {
+      "module": "AWSCDK::MPA"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-msk/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-msk/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_msk"
+    },
+    "ruby": {
+      "module": "AWSCDK::MSK"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mwaa/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mwaa/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mwaa"
+    },
+    "ruby": {
+      "module": "AWSCDK::MWAA"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-mwaaserverless/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-mwaaserverless/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_mwaaserverless"
+    },
+    "ruby": {
+      "module": "AWSCDK::MWAAServerless"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-neptune/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-neptune/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_neptune"
+    },
+    "ruby": {
+      "module": "AWSCDK::Neptune"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-neptunegraph/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-neptunegraph/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_neptunegraph"
+    },
+    "ruby": {
+      "module": "AWSCDK::NeptuneGraph"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-networkfirewall/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-networkfirewall/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_networkfirewall"
+    },
+    "ruby": {
+      "module": "AWSCDK::NetworkFirewall"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-networkmanager/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-networkmanager/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_networkmanager"
+    },
+    "ruby": {
+      "module": "AWSCDK::NetworkManager"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-nimblestudio/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-nimblestudio/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_nimblestudio"
+    },
+    "ruby": {
+      "module": "AWSCDK::NimbleStudio"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-notifications/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-notifications/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_notifications"
+    },
+    "ruby": {
+      "module": "AWSCDK::Notifications"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-notificationscontacts/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-notificationscontacts/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_notificationscontacts"
+    },
+    "ruby": {
+      "module": "AWSCDK::NotificationsContacts"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-novaact/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-novaact/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_novaact"
+    },
+    "ruby": {
+      "module": "AWSCDK::NovaAct"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-oam/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-oam/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_oam"
+    },
+    "ruby": {
+      "module": "AWSCDK::OAM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-observabilityadmin/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-observabilityadmin/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_observabilityadmin"
+    },
+    "ruby": {
+      "module": "AWSCDK::ObservabilityAdmin"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-odb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-odb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_odb"
+    },
+    "ruby": {
+      "module": "AWSCDK::ODB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-omics/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-omics/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_omics"
+    },
+    "ruby": {
+      "module": "AWSCDK::Omics"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-opensearchserverless/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-opensearchserverless/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_opensearchserverless"
+    },
+    "ruby": {
+      "module": "AWSCDK::OpenSearchServerless"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-opensearchservice/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-opensearchservice/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_opensearchservice"
+    },
+    "ruby": {
+      "module": "AWSCDK::OpenSearchService"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-opsworks/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-opsworks/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_opsworks"
+    },
+    "ruby": {
+      "module": "AWSCDK::OpsWorks"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-opsworkscm/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-opsworkscm/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_opsworkscm"
+    },
+    "ruby": {
+      "module": "AWSCDK::OpsWorksCM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-organizations/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-organizations/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_organizations"
+    },
+    "ruby": {
+      "module": "AWSCDK::Organizations"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-osis/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-osis/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_osis"
+    },
+    "ruby": {
+      "module": "AWSCDK::OSIS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-panorama/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-panorama/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_panorama"
+    },
+    "ruby": {
+      "module": "AWSCDK::Panorama"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-paymentcryptography/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-paymentcryptography/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_paymentcryptography"
+    },
+    "ruby": {
+      "module": "AWSCDK::PaymentCryptography"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pcaconnectorad/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pcaconnectorad/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pcaconnectorad"
+    },
+    "ruby": {
+      "module": "AWSCDK::PCAConnectorAD"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pcaconnectorscep/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pcaconnectorscep/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pcaconnectorscep"
+    },
+    "ruby": {
+      "module": "AWSCDK::PCAConnectorSCEP"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pcs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pcs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pcs"
+    },
+    "ruby": {
+      "module": "AWSCDK::PCS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-personalize/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-personalize/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_personalize"
+    },
+    "ruby": {
+      "module": "AWSCDK::Personalize"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pinpoint/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pinpoint/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pinpoint"
+    },
+    "ruby": {
+      "module": "AWSCDK::Pinpoint"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pinpointemail/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pinpointemail/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pinpointemail"
+    },
+    "ruby": {
+      "module": "AWSCDK::PinpointEmail"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-pipes/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-pipes/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_pipes"
+    },
+    "ruby": {
+      "module": "AWSCDK::Pipes"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-proton/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-proton/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_proton"
+    },
+    "ruby": {
+      "module": "AWSCDK::Proton"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-qbusiness/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-qbusiness/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_qbusiness"
+    },
+    "ruby": {
+      "module": "AWSCDK::QBusiness"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-qldb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-qldb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_qldb"
+    },
+    "ruby": {
+      "module": "AWSCDK::QLDB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-quicksight/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-quicksight/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_quicksight"
+    },
+    "ruby": {
+      "module": "AWSCDK::QuickSight"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ram/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ram/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ram"
+    },
+    "ruby": {
+      "module": "AWSCDK::RAM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rbin/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rbin/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rbin"
+    },
+    "ruby": {
+      "module": "AWSCDK::Rbin"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rds/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rds/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rds"
+    },
+    "ruby": {
+      "module": "AWSCDK::RDS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-redshift/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-redshift/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_redshift"
+    },
+    "ruby": {
+      "module": "AWSCDK::Redshift"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-redshiftserverless/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-redshiftserverless/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_redshiftserverless"
+    },
+    "ruby": {
+      "module": "AWSCDK::RedshiftServerless"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-refactorspaces/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-refactorspaces/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_refactorspaces"
+    },
+    "ruby": {
+      "module": "AWSCDK::RefactorSpaces"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rekognition/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rekognition/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rekognition"
+    },
+    "ruby": {
+      "module": "AWSCDK::Rekognition"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-resiliencehub/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-resiliencehub/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_resiliencehub"
+    },
+    "ruby": {
+      "module": "AWSCDK::ResilienceHub"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-resiliencehubv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-resiliencehubv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_resiliencehubv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::ResilienceHubv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-resourceexplorer2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-resourceexplorer2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_resourceexplorer2"
+    },
+    "ruby": {
+      "module": "AWSCDK::ResourceExplorer2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-resourcegroups/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-resourcegroups/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_resourcegroups"
+    },
+    "ruby": {
+      "module": "AWSCDK::ResourceGroups"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-robomaker/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-robomaker/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_robomaker"
+    },
+    "ruby": {
+      "module": "AWSCDK::RoboMaker"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rolesanywhere/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rolesanywhere/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rolesanywhere"
+    },
+    "ruby": {
+      "module": "AWSCDK::RolesAnywhere"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53-patterns/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53-patterns/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53_patterns"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53Patterns"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53-targets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53-targets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53_targets"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53Targets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53globalresolver/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53globalresolver/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53globalresolver"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53GlobalResolver"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53profiles/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53profiles/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53profiles"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53Profiles"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53recoverycontrol/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53recoverycontrol/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53recoverycontrol"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53RecoveryControl"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53recoveryreadiness/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53recoveryreadiness/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53recoveryreadiness"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53RecoveryReadiness"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-route53resolver/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-route53resolver/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_route53resolver"
+    },
+    "ruby": {
+      "module": "AWSCDK::Route53Resolver"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rtbfabric/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rtbfabric/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rtbfabric"
+    },
+    "ruby": {
+      "module": "AWSCDK::RTBFabric"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-rum/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-rum/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_rum"
+    },
+    "ruby": {
+      "module": "AWSCDK::RUM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3-assets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3-assets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3_assets"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Assets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3-deployment/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3-deployment/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3_deployment"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Deployment"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3-notifications/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3-notifications/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3_notifications"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Notifications"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3/lib/mixins/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3/lib/mixins/.jsiirc.json
@@ -11,6 +11,9 @@
     },
     "go": {
       "packageName": "awss3mixins"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3::Mixins"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3express/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3express/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3express"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Express"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3files/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3files/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3files"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Files"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3objectlambda/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3objectlambda/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3objectlambda"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3ObjectLambda"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3outposts/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3outposts/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3outposts"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Outposts"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3tables/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3tables/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3tables"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Tables"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-s3vectors/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-s3vectors/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_s3vectors"
+    },
+    "ruby": {
+      "module": "AWSCDK::S3Vectors"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sagemaker/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sagemaker/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sagemaker"
+    },
+    "ruby": {
+      "module": "AWSCDK::Sagemaker"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sam/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sam/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sam"
+    },
+    "ruby": {
+      "module": "AWSCDK::SAM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-scheduler-targets/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-scheduler-targets/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_scheduler_targets"
+    },
+    "ruby": {
+      "module": "AWSCDK::SchedulerTargets"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-scheduler/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-scheduler/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_scheduler"
+    },
+    "ruby": {
+      "module": "AWSCDK::Scheduler"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sdb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sdb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sdb"
+    },
+    "ruby": {
+      "module": "AWSCDK::SDB"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-secretsmanager/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-secretsmanager/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_secretsmanager"
+    },
+    "ruby": {
+      "module": "AWSCDK::SecretsManager"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-securityagent/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-securityagent/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_securityagent"
+    },
+    "ruby": {
+      "module": "AWSCDK::SecurityAgent"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-securityhub/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-securityhub/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_securityhub"
+    },
+    "ruby": {
+      "module": "AWSCDK::SecurityHub"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-securitylake/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-securitylake/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_securitylake"
+    },
+    "ruby": {
+      "module": "AWSCDK::SecurityLake"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-servicecatalog/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-servicecatalog/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_servicecatalog"
+    },
+    "ruby": {
+      "module": "AWSCDK::ServiceCatalog"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-servicecatalogappregistry/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-servicecatalogappregistry/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_servicecatalogappregistry"
+    },
+    "ruby": {
+      "module": "AWSCDK::ServiceCatalogAppRegistry"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-servicediscovery/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-servicediscovery/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_servicediscovery"
+    },
+    "ruby": {
+      "module": "AWSCDK::ServiceDiscovery"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ses-actions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ses-actions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ses_actions"
+    },
+    "ruby": {
+      "module": "AWSCDK::SESActions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ses/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ses/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ses"
+    },
+    "ruby": {
+      "module": "AWSCDK::SES"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-shield/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-shield/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_shield"
+    },
+    "ruby": {
+      "module": "AWSCDK::Shield"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-signer/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-signer/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_signer"
+    },
+    "ruby": {
+      "module": "AWSCDK::Signer"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-simspaceweaver/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-simspaceweaver/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_simspaceweaver"
+    },
+    "ruby": {
+      "module": "AWSCDK::SimSpaceWeaver"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-smsvoice/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-smsvoice/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_smsvoice"
+    },
+    "ruby": {
+      "module": "AWSCDK::SMSVoice"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sns-subscriptions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sns-subscriptions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sns_subscriptions"
+    },
+    "ruby": {
+      "module": "AWSCDK::SNSSubscriptions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sns/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sns/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sns"
+    },
+    "ruby": {
+      "module": "AWSCDK::SNS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sqs/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sqs/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sqs"
+    },
+    "ruby": {
+      "module": "AWSCDK::SQS"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ssm/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ssm/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ssm"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSM"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ssmcontacts/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ssmcontacts/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ssmcontacts"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSMContacts"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ssmguiconnect/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ssmguiconnect/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ssmguiconnect"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSMGUIConnect"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ssmincidents/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ssmincidents/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ssmincidents"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSMIncidents"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-ssmquicksetup/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-ssmquicksetup/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_ssmquicksetup"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSMQuickSetup"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-sso/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-sso/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_sso"
+    },
+    "ruby": {
+      "module": "AWSCDK::SSO"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-stepfunctions-tasks/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-stepfunctions-tasks/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_stepfunctions_tasks"
+    },
+    "ruby": {
+      "module": "AWSCDK::StepFunctionsTasks"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-stepfunctions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-stepfunctions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_stepfunctions"
+    },
+    "ruby": {
+      "module": "AWSCDK::StepFunctions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-supportapp/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-supportapp/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_supportapp"
+    },
+    "ruby": {
+      "module": "AWSCDK::SupportApp"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-synthetics/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-synthetics/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_synthetics"
+    },
+    "ruby": {
+      "module": "AWSCDK::Synthetics"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-systemsmanagersap/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-systemsmanagersap/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_systemsmanagersap"
+    },
+    "ruby": {
+      "module": "AWSCDK::SystemsManagerSAP"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-timestream/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-timestream/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_timestream"
+    },
+    "ruby": {
+      "module": "AWSCDK::Timestream"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-transfer/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-transfer/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_transfer"
+    },
+    "ruby": {
+      "module": "AWSCDK::Transfer"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-uxc/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-uxc/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_uxc"
+    },
+    "ruby": {
+      "module": "AWSCDK::UXC"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-verifiedpermissions/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-verifiedpermissions/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_verifiedpermissions"
+    },
+    "ruby": {
+      "module": "AWSCDK::Verifiedpermissions"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-voiceid/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-voiceid/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_voiceid"
+    },
+    "ruby": {
+      "module": "AWSCDK::VoiceID"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-vpclattice/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-vpclattice/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_vpclattice"
+    },
+    "ruby": {
+      "module": "AWSCDK::VPCLattice"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-waf/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-waf/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_waf"
+    },
+    "ruby": {
+      "module": "AWSCDK::WAF"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-wafregional/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-wafregional/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_wafregional"
+    },
+    "ruby": {
+      "module": "AWSCDK::WAFRegional"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-wafv2/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-wafv2/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_wafv2"
+    },
+    "ruby": {
+      "module": "AWSCDK::WAFv2"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-wisdom/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-wisdom/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_wisdom"
+    },
+    "ruby": {
+      "module": "AWSCDK::Wisdom"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-workspaces/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-workspaces/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_workspaces"
+    },
+    "ruby": {
+      "module": "AWSCDK::Workspaces"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-workspacesinstances/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-workspacesinstances/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_workspacesinstances"
+    },
+    "ruby": {
+      "module": "AWSCDK::WorkspacesInstances"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-workspacesthinclient/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-workspacesthinclient/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_workspacesthinclient"
+    },
+    "ruby": {
+      "module": "AWSCDK::WorkspacesThinClient"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-workspacesweb/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-workspacesweb/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_workspacesweb"
+    },
+    "ruby": {
+      "module": "AWSCDK::WorkspacesWeb"
     }
   }
 }

--- a/packages/aws-cdk-lib/aws-xray/.jsiirc.json
+++ b/packages/aws-cdk-lib/aws-xray/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.aws_xray"
+    },
+    "ruby": {
+      "module": "AWSCDK::XRay"
     }
   }
 }

--- a/packages/aws-cdk-lib/cloudformation-include/.jsiirc.json
+++ b/packages/aws-cdk-lib/cloudformation-include/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.cloudformation_include"
+    },
+    "ruby": {
+      "module": "AWSCDK::CloudFormationInclude"
     }
   }
 }

--- a/packages/aws-cdk-lib/custom-resources/.jsiirc.json
+++ b/packages/aws-cdk-lib/custom-resources/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.custom_resources"
+    },
+    "ruby": {
+      "module": "AWSCDK::CustomResources"
     }
   }
 }

--- a/packages/aws-cdk-lib/cx-api/.jsiirc.json
+++ b/packages/aws-cdk-lib/cx-api/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.cx_api"
+    },
+    "ruby": {
+      "module": "AWSCDK::CXAPI"
     }
   }
 }

--- a/packages/aws-cdk-lib/interfaces/.jsiirc.json
+++ b/packages/aws-cdk-lib/interfaces/.jsiirc.json
@@ -11,6 +11,9 @@
     },
     "go": {
       "packageName": "interfaces"
+    },
+    "ruby": {
+      "module": "AWSCDK::Interfaces"
     }
   }
 }

--- a/packages/aws-cdk-lib/lambda-layer-awscli/.jsiirc.json
+++ b/packages/aws-cdk-lib/lambda-layer-awscli/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.lambda_layer_awscli"
+    },
+    "ruby": {
+      "module": "AWSCDK::LambdaLayerAWSCLI"
     }
   }
 }

--- a/packages/aws-cdk-lib/lambda-layer-node-proxy-agent/.jsiirc.json
+++ b/packages/aws-cdk-lib/lambda-layer-node-proxy-agent/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.lambda_layer_node_proxy_agent"
+    },
+    "ruby": {
+      "module": "AWSCDK::LambdaLayerNodeProxyAgent"
     }
   }
 }

--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -85,6 +85,17 @@
       "go": {
         "moduleName": "github.com/aws/aws-cdk-go",
         "packageName": "awscdk"
+      },
+      "ruby": {
+        "module": "AWSCDK",
+        "acronyms": [
+          "AWS", "CDK", "S3", "IAM", "VPC", "SQS", "SNS", "EC2", "RDS", "KMS",
+          "ECS", "EKS", "EFS", "ELB", "WAF", "SSM", "SES", "SAM", "MSK", "MWAA",
+          "ACM", "EMR", "FSX", "QLDB", "RAM", "FMS", "DAX", "DMS", "DLM", "FIS",
+          "IVS", "CUR", "OAM", "PCS", "RUM", "CE", "APS", "DSQL", "ARN", "API",
+          "DB", "CIDR", "IP", "DNS", "URL", "URI", "SSL", "TLS", "ALB", "NLB",
+          "TCP", "UDP", "ECR"
+        ]
       }
     },
     "metadata": {

--- a/packages/aws-cdk-lib/pipelines/.jsiirc.json
+++ b/packages/aws-cdk-lib/pipelines/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.pipelines"
+    },
+    "ruby": {
+      "module": "AWSCDK::Pipelines"
     }
   }
 }

--- a/packages/aws-cdk-lib/region-info/.jsiirc.json
+++ b/packages/aws-cdk-lib/region-info/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.region_info"
+    },
+    "ruby": {
+      "module": "AWSCDK::RegionInfo"
     }
   }
 }

--- a/packages/aws-cdk-lib/triggers/.jsiirc.json
+++ b/packages/aws-cdk-lib/triggers/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "aws_cdk.triggers"
+    },
+    "ruby": {
+      "module": "AWSCDK::Triggers"
     }
   }
 }

--- a/tools/@aws-cdk/spec2cdk/lib/util/submodule-files.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/util/submodule-files.ts
@@ -19,6 +19,111 @@ export interface WriteJsiiRcOptions {
 }
 
 /**
+ * Ruby target configuration from the `aws-cdk-lib` package.json
+ */
+export interface RubyTargetConfig {
+  /**
+   * The root ruby module, e.g. `AWSCDK`
+   */
+  readonly module: string;
+
+  /**
+   * Words that are cased as acronyms in ruby module names, e.g. `S3`, `API`
+   */
+  readonly acronyms: string[];
+}
+
+/**
+ * Location of the `aws-cdk-lib` package.json, which is the single source of
+ * truth for the ruby root module name and acronym list.
+ */
+export const rubyTargetConfigPath = path.join(__dirname, '..', '..', '..', '..', '..', 'packages', 'aws-cdk-lib', 'package.json');
+
+/**
+ * Load the ruby target configuration (root module and acronyms) from a package.json
+ */
+export async function loadRubyTargetConfig(packageJsonPath: string = rubyTargetConfigPath): Promise<RubyTargetConfig> {
+  let pkg;
+  try {
+    pkg = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+  } catch (e: any) {
+    throw new Error(`Cannot read ruby target configuration from ${packageJsonPath}: ${e.message}`);
+  }
+
+  const ruby = pkg.jsii?.targets?.ruby;
+  if (!ruby?.module) {
+    throw new Error(`No jsii.targets.ruby.module found in ${packageJsonPath}`);
+  }
+
+  return {
+    module: ruby.module,
+    acronyms: ruby.acronyms ?? [],
+  };
+}
+
+/**
+ * Derive the ruby module name for a submodule, e.g. `AWSCDK::S3`
+ *
+ * Derivation is based on the CloudFormation namespace casing (via `moduleFamily`
+ * and `moduleBaseName`), with acronym casing applied from the given config:
+ *
+ * - `AWS::S3` -> `AWSCDK::S3`
+ * - `AWS::ApiGateway` -> `AWSCDK::APIGateway` (acronym casing from config)
+ * - `AWS::ApiGatewayV2` -> `AWSCDK::APIGatewayv2` (version suffixes are lowercased)
+ * - `Alexa::ASK` -> `AWSCDK::AlexaASK` (non-AWS module families are prefixed)
+ *
+ * Note that a handful of existing submodules deviate from these rules
+ * (e.g. `aws-autoscaling` -> `AWSCDK::Autoscaling`); their committed
+ * `.jsiirc.json` files are authoritative and preserved by `writeJsiiRc`.
+ */
+export function deriveRubyModule(definition: ModuleDefinition, config: RubyTargetConfig): string {
+  const parts = definition.moduleFamily === 'AWS'
+    ? [definition.moduleBaseName]
+    : [definition.moduleFamily, definition.moduleBaseName];
+
+  const name = parts.map((part) => rubyNamespaceFromPascalCase(part, config.acronyms)).join('');
+  return `${config.module}::${name}`;
+}
+
+/**
+ * Apply ruby casing rules to a PascalCased name (usually a CloudFormation namespace part)
+ */
+function rubyNamespaceFromPascalCase(name: string, acronyms: string[]): string {
+  const acronymSet = new Set(acronyms.map((a) => a.toUpperCase()));
+
+  // Split into words: uppercase runs (`SSM`), capitalized words (`Route53`), digit/lowercase runs (`2`)
+  const tokens = name.match(/[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+/g) ?? [name];
+
+  // Merge adjacent tokens that together form a configured acronym (`F`+`Sx` -> `FSX`, `EC`+`2` -> `EC2`)
+  // and uppercase single tokens that are configured acronyms (`Api` -> `API`).
+  const words = new Array<string>();
+  for (let i = 0; i < tokens.length; ) {
+    let merged = undefined;
+    for (let j = tokens.length; j > i; j--) {
+      const candidate = tokens.slice(i, j).join('').toUpperCase();
+      if (acronymSet.has(candidate)) {
+        merged = candidate;
+        i = j;
+        break;
+      }
+    }
+    if (merged == null) {
+      merged = tokens[i];
+      i += 1;
+    }
+    words.push(merged);
+  }
+
+  // The root module already carries the `AWS` prefix, don't repeat it (`AWSExternalAnthropic` -> `ExternalAnthropic`)
+  if (words.length > 1 && words[0] === 'AWS') {
+    words.shift();
+  }
+
+  // Version suffixes are lowercased (`ApiGatewayV2` -> `APIGatewayv2`)
+  return words.join('').replace(/(?<=[A-Za-z])V(?=\d+$)/, 'v');
+}
+
+/**
  * Write a `.jsiirc.json` file with the correct target metadata.
  *
  * @param filePath - absolute path to write the jsiirc file to
@@ -34,8 +139,8 @@ export async function writeJsiiRc(filePath: string, definition: ModuleDefinition
     try {
       const existing = JSON.parse(await fs.readFile(filePath, 'utf-8'));
       existingTargets = existing.targets || {};
-    } catch (e) {
-      // ignore JSON parse errors or other issues
+    } catch (e: any) {
+      throw new Error(`Cannot read existing jsiirc file ${filePath}: ${e.message}`);
     }
   }
 
@@ -51,8 +156,15 @@ export async function writeJsiiRc(filePath: string, definition: ModuleDefinition
     },
   };
 
+  // Existing ruby names are authoritative (a few pre-date the derivation rules);
+  // for new submodules, derive one so every submodule always has a ruby module name.
   if (existingTargets.ruby) {
     targets.ruby = existingTargets.ruby;
+  } else {
+    const rubyModule = deriveRubyModule(definition, await loadRubyTargetConfig());
+    targets.ruby = {
+      module: ns ? `${rubyModule}::${nsUc}` : rubyModule,
+    };
   }
 
   if (options.goPrefix != null) {

--- a/tools/@aws-cdk/spec2cdk/lib/util/submodule-files.ts
+++ b/tools/@aws-cdk/spec2cdk/lib/util/submodule-files.ts
@@ -29,6 +29,16 @@ export async function writeJsiiRc(filePath: string, definition: ModuleDefinition
   const ns = options.namespaceSuffix ?? '';
   const nsUc = ns.charAt(0).toUpperCase() + ns.slice(1);
 
+  let existingTargets: Record<string, Record<string, string>> = {};
+  if (existsSync(filePath)) {
+    try {
+      const existing = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+      existingTargets = existing.targets || {};
+    } catch (e) {
+      // ignore JSON parse errors or other issues
+    }
+  }
+
   const targets: Record<string, Record<string, string>> = {
     java: {
       package: ns ? `${definition.javaPackage}.${ns}` : definition.javaPackage,
@@ -40,6 +50,10 @@ export async function writeJsiiRc(filePath: string, definition: ModuleDefinition
       module: ns ? `${definition.pythonModuleName}.${ns}` : definition.pythonModuleName,
     },
   };
+
+  if (existingTargets.ruby) {
+    targets.ruby = existingTargets.ruby;
+  }
 
   if (options.goPrefix != null) {
     targets.go = {

--- a/tools/@aws-cdk/spec2cdk/test/submodule-files.test.ts
+++ b/tools/@aws-cdk/spec2cdk/test/submodule-files.test.ts
@@ -1,0 +1,185 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { moduleMapPath } from '../lib/module-topology';
+import { namespaceToModuleDefinition } from '../lib/util/jsii';
+import { deriveRubyModule, loadRubyTargetConfig, writeJsiiRc } from '../lib/util/submodule-files';
+import type { RubyTargetConfig } from '../lib/util/submodule-files';
+
+const awsCdkLibPath = path.dirname(path.dirname(moduleMapPath));
+
+/**
+ * Submodules whose committed ruby module name is a hand-chosen override.
+ *
+ * These names contradict any mechanical rule derivable from the CloudFormation
+ * namespace and the acronym config: `AWS::CodeCommit` -> `Codecommit` while
+ * `AWS::CodeBuild` -> `CodeBuild`, and `BCM`/`GUI`/`SMS` are cased as acronyms
+ * without appearing in the `aws-cdk-lib` acronym list.
+ *
+ * `writeJsiiRc` always preserves an existing ruby module name, so the committed
+ * `.jsiirc.json` files remain authoritative for these. They are listed here so
+ * that the conformance test below flags any new deviation from the rules.
+ */
+const IRREGULAR_RUBY_MODULES: Record<string, string> = {
+  'alexa-ask': 'AWSCDK::AlexaAsk',
+  'aws-apptest': 'AWSCDK::Apptest',
+  'aws-autoscaling': 'AWSCDK::Autoscaling',
+  'aws-bcmpricingcalculator': 'AWSCDK::BCMPricingCalculator',
+  'aws-codecommit': 'AWSCDK::Codecommit',
+  'aws-codepipeline': 'AWSCDK::Codepipeline',
+  'aws-datasync': 'AWSCDK::Datasync',
+  'aws-directconnect': 'AWSCDK::Directconnect',
+  'aws-elasticache': 'AWSCDK::Elasticache',
+  'aws-sagemaker': 'AWSCDK::Sagemaker',
+  'aws-smsvoice': 'AWSCDK::SMSVoice',
+  'aws-ssmguiconnect': 'AWSCDK::SSMGUIConnect',
+  'aws-verifiedpermissions': 'AWSCDK::Verifiedpermissions',
+  'aws-workspaces': 'AWSCDK::Workspaces',
+  'aws-workspacesthinclient': 'AWSCDK::WorkspacesThinClient',
+  'aws-workspacesweb': 'AWSCDK::WorkspacesWeb',
+};
+
+test('ruby module derivation matches all committed .jsiirc.json files', async () => {
+  const config = await loadRubyTargetConfig();
+  const scopeMap: Record<string, { scopes: Array<{ namespace: string }> }> = JSON.parse(
+    fs.readFileSync(moduleMapPath, 'utf-8'),
+  );
+
+  let regular = 0;
+  const mismatches: Record<string, string> = {};
+
+  for (const [name, entry] of Object.entries(scopeMap)) {
+    const namespace = entry.scopes[0]?.namespace;
+    const committed = committedRubyModule(path.join(awsCdkLibPath, name, '.jsiirc.json'));
+    if (!namespace || !committed) {
+      continue;
+    }
+
+    const derived = deriveRubyModule(namespaceToModuleDefinition(namespace), config);
+    if (derived === committed) {
+      regular += 1;
+    } else {
+      mismatches[name] = committed;
+    }
+
+    // Nested mixins submodules append `::Mixins` to the parent module. The
+    // committed parent name is authoritative here: a freshly generated mixins
+    // rc under an irregular parent will be flagged by this assertion and needs
+    // a one-time hand correction (preserved by `writeJsiiRc` afterwards).
+    const mixinsCommitted = committedRubyModule(path.join(awsCdkLibPath, name, 'lib', 'mixins', '.jsiirc.json'));
+    if (mixinsCommitted) {
+      expect(mixinsCommitted).toEqual(`${committed}::Mixins`);
+    }
+  }
+
+  // Sanity check that we are actually looking at the submodule tree
+  expect(regular).toBeGreaterThan(250);
+
+  // Any mismatch that is not a known irregular means the derivation rules
+  // no longer produce the names the existing submodules follow.
+  expect(mismatches).toEqual(IRREGULAR_RUBY_MODULES);
+});
+
+test('every committed .jsiirc.json in aws-cdk-lib declares a ruby module', () => {
+  const missing = findJsiiRcFiles(awsCdkLibPath).filter((f) => !committedRubyModule(f));
+  expect(missing).toEqual([]);
+});
+
+describe('writeJsiiRc', () => {
+  let tmpDir: string;
+  let definition: ReturnType<typeof namespaceToModuleDefinition>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'submodule-files-test'));
+    definition = namespaceToModuleDefinition('AWS::ApiGateway');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('derives a ruby module name for a new submodule', async () => {
+    const filePath = path.join(tmpDir, '.jsiirc.json');
+
+    await writeJsiiRc(filePath, definition);
+
+    expect(committedRubyModule(filePath)).toEqual('AWSCDK::APIGateway');
+  });
+
+  test('derives a ruby module name for a new mixins submodule', async () => {
+    const filePath = path.join(tmpDir, '.jsiirc.json');
+
+    await writeJsiiRc(filePath, definition, { namespaceSuffix: 'mixins', goPrefix: '' });
+
+    expect(committedRubyModule(filePath)).toEqual('AWSCDK::APIGateway::Mixins');
+  });
+
+  test('preserves an existing ruby module name', async () => {
+    const filePath = path.join(tmpDir, '.jsiirc.json');
+    fs.writeFileSync(filePath, JSON.stringify({ targets: { ruby: { module: 'AWSCDK::CustomName' } } }));
+
+    await writeJsiiRc(filePath, definition);
+
+    expect(committedRubyModule(filePath)).toEqual('AWSCDK::CustomName');
+  });
+
+  test('fails on an unparseable existing file', async () => {
+    const filePath = path.join(tmpDir, '.jsiirc.json');
+    fs.writeFileSync(filePath, '{ this is not JSON');
+
+    await expect(writeJsiiRc(filePath, definition)).rejects.toThrow(
+      `Cannot read existing jsiirc file ${filePath}`,
+    );
+  });
+});
+
+describe('deriveRubyModule', () => {
+  const config: RubyTargetConfig = {
+    module: 'AWSCDK',
+    acronyms: ['AWS', 'S3', 'API', 'EC2', 'FSX'],
+  };
+
+  test.each([
+    ['AWS::S3', 'AWSCDK::S3'],
+    ['AWS::ApiGateway', 'AWSCDK::APIGateway'],
+    ['AWS::ApiGatewayV2', 'AWSCDK::APIGatewayv2'],
+    ['AWS::EC2', 'AWSCDK::EC2'],
+    ['AWS::FSx', 'AWSCDK::FSX'],
+    ['AWS::S3Express', 'AWSCDK::S3Express'],
+    ['AWS::Route53Resolver', 'AWSCDK::Route53Resolver'],
+    ['AWS::IoTFleetHub', 'AWSCDK::IoTFleetHub'],
+    ['AWS::AWSExternalAnthropic', 'AWSCDK::ExternalAnthropic'],
+    ['Alexa::Something', 'AWSCDK::AlexaSomething'],
+  ])('%s derives to %s', (namespace, expected) => {
+    expect(deriveRubyModule(namespaceToModuleDefinition(namespace), config)).toEqual(expected);
+  });
+});
+
+/**
+ * The ruby module name a committed `.jsiirc.json` declares, if any
+ */
+function committedRubyModule(filePath: string): string | undefined {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')).targets?.ruby?.module;
+}
+
+/**
+ * All committed `.jsiirc.json` files below a directory
+ *
+ * Skips `*.generated.jsiirc.json` files, which are created at build time
+ * and intentionally have no ruby target.
+ */
+function findJsiiRcFiles(dir: string): string[] {
+  const result = new Array<string>();
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory() && entry.name !== 'node_modules') {
+      result.push(...findJsiiRcFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.jsiirc.json') && !entry.name.endsWith('.generated.jsiirc.json')) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
### Issue #38247 

> [!WARNING]
> **Draft — CI is expected to be red, by design.** Ruby code generation requires a jsii release with Ruby target support, which is not yet published (tracked in aws/jsii#5178). Until it ships, jsii-pacmak has no Ruby target on the released toolchain, so packaging/codegen checks will fail. End-to-end generation + Ruby gem publishing have already been validated against a pre-release build of the compiler. Once the compiler is released this will go green.

### Reason for this change

Add **Ruby** as a first-class supported language for AWS CDK, alongside TypeScript, Python, Java, C#/.NET and Go. Ruby-centric infrastructure teams currently maintain a parallel toolchain in another language or avoid CDK entirely. Demand has been long-standing — the original request has been open since 2018 and is one of the most-reacted language asks.

Design is captured in **RFC 0935: Ruby language bindings** — tracking issue [aws/aws-cdk-rfcs#935](https://github.com/aws/aws-cdk-rfcs/issues/935) ([full RFC text](https://github.com/omarqureshi/aws-cdk-rfcs/blob/112e8691e482c53d9de54ccd499a98d76d5eeb47/text/0935-ruby-language-bindings.md)).

### Description of changes

Strictly additive — no changes to existing languages, no breaking changes.

- **Per-module `.jsiirc.json` Ruby target configuration** across `aws-cdk-lib` (329 modules): each gains a `ruby` target with its module name (root namespace `AWSCDK`, idiomatic casing, AWS-prefix de-duplication — e.g. `aws-s3` → `AWSCDK::S3::Bucket`). Naming follows RFC 0935; version suffixes use lowercase `v` (`AWSCDK::WAFv2`, matching the `IPv4`/`IPv6` convention).
- **`tools/@aws-cdk/spec2cdk`** (`submodule-files.ts`): when regenerating a module's `.jsiirc.json`, preserve an existing hand-authored `ruby` target (java/dotnet/python remain auto-derived). Without this, `gen-cdk` would wipe the Ruby blocks.

The enabling jsii work (compiler + `jsii-pacmak` Ruby target + `@jsii/ruby-runtime`) is in aws/jsii#5178.

### Describe any new or updated permissions being added

None — this is code-generation configuration only; no runtime/IAM changes.

### Description of how you validated changes

- End-to-end Ruby generation and gem publishing validated against a pre-release build of the Ruby-capable jsii compiler (jsii-calc closure + `aws-cdk-lib`).
- Generated Ruby signatures validate under `rbs validate` in the jsii runtime test suite (see aws/jsii#5178).
- This PR's own CI is gated on the public compiler release (see warning above); fixtures will regenerate and CI will pass once it ships.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


