### PR TITLE
feat(ec2): add route53 interface vpc endpoint

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-global-endpoint.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-global-endpoint.ts
@@ -35,6 +35,10 @@ class Test extends cdk.Stack {
       service: ec2.InterfaceVpcEndpointAwsService.S3_MULTI_REGION_ACCESS_POINTS,
     });
 
+    vpc.addInterfaceEndpoint('Route53Endpoint', {
+      service: ec2.InterfaceVpcEndpointAwsService.ROUTE53,
+    });
+
     // Create an instance to test the endpoint
     /* const securityGroup = new ec2.SecurityGroup(this, 'MySecurityGroup', {
       vpc,

--- a/packages/aws-cdk-lib/aws-ec2/README.md
+++ b/packages/aws-cdk-lib/aws-ec2/README.md
@@ -1115,6 +1115,17 @@ new ec2.InterfaceVpcEndpoint(this, 'VPC Endpoint', {
 });
 ```
 
+A Route 53 endpoint can be created the same way:
+
+```ts
+declare const vpc: ec2.Vpc;
+
+new ec2.InterfaceVpcEndpoint(this, 'Route53 VPC Endpoint', {
+  vpc,
+  service: ec2.InterfaceVpcEndpointAwsService.ROUTE53,
+});
+```
+
 For cross-region VPC endpoints, specify the `serviceRegion` parameter:
 
 ```ts

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
@@ -726,6 +726,7 @@ export class InterfaceVpcEndpointAwsService implements IInterfaceVpcEndpointServ
   public static readonly RESOURCE_GROUPS_FIPS = new InterfaceVpcEndpointAwsService('resource-groups-fips');
   public static readonly ROBOMAKER = new InterfaceVpcEndpointAwsService('robomaker');
   public static readonly RECYCLE_BIN = new InterfaceVpcEndpointAwsService('rbin');
+  public static readonly ROUTE53 = new InterfaceVpcEndpointAwsService('route53', 'com.amazonaws', undefined, { global: true });
   public static readonly S3 = new InterfaceVpcEndpointAwsService('s3');
   public static readonly S3_OUTPOSTS = new InterfaceVpcEndpointAwsService('s3-outposts');
   public static readonly S3_MULTI_REGION_ACCESS_POINTS = new InterfaceVpcEndpointAwsService('s3-global.accesspoint', 'com.amazonaws', undefined, { global: true });

--- a/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
@@ -1143,6 +1143,9 @@ describe('vpc endpoint', () => {
       vpc.addInterfaceEndpoint('Global CodeCatalyst API Endpoint', {
         service: InterfaceVpcEndpointAwsService.CODECATALYST,
       });
+      vpc.addInterfaceEndpoint('Global Route53 API Endpoint', {
+        service: InterfaceVpcEndpointAwsService.ROUTE53,
+      });
 
       // THEN
       Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
@@ -1150,6 +1153,9 @@ describe('vpc endpoint', () => {
       });
       Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
         ServiceName: 'aws.api.global.codecatalyst',
+      });
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        ServiceName: 'com.amazonaws.route53',
       });
     });
 


### PR DESCRIPTION
### Motivation

`InterfaceVpcEndpointAwsService` catalogs the AWS services that support interface VPC endpoints (e.g. `S3_MULTI_REGION_ACCESS_POINTS`, `SAVINGS_PLANS`), but Route 53 was missing even though it supports one. This adds `InterfaceVpcEndpointAwsService.ROUTE53` so CDK apps can create a Route 53 interface VPC endpoint without hand-rolling the service name.

### Changes

- Added `ROUTE53` constant to `packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts`, placed alphabetically alongside neighboring entries (`RECYCLE_BIN`/`S3`).
- Extended the existing `global vpc interface endpoints` unit test in `packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts` with a `ROUTE53` case and a `ServiceName` assertion, following the same pattern used for `S3_MULTI_REGION_ACCESS_POINTS`/`CODECATALYST`.
- Added a Route 53 example to the `aws-ec2` README's VPC endpoints section.
- Extended `packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-global-endpoint.ts` to also create a Route 53 interface endpoint, alongside the existing S3 multi-region access point coverage.

### Verification

Verified locally: `eslint` passes clean on all touched files, and the L1 codegen step (`gen-cdk`) completes successfully so the module resolves. Confirmed via a local (non-deploying) synth that the new `ROUTE53` endpoint produces the expected `AWS::EC2::VPCEndpoint` resource with `ServiceName: com.amazonaws.route53` and no region prefix (consistent with it being a global endpoint).

I was **not** able to run a real `cdk-integ` deployment locally (no AWS credentials configured in this environment), so per CONTRIBUTING.md's guidance I have **not** attempted to regenerate the integ snapshot myself (`integ.vpc-global-endpoint.js.snapshot`) — a maintainer will need to run the integ test to produce and commit the updated snapshot. Happy to iterate further if a different approach is preferred.

Was also unable to complete a full local `jest` unit test run due to an unrelated environment issue on this machine (Node version incompatibility with this repo's pinned Jest/glob-matching stack on Windows); relying on the repository's CI to run the full test suite.

No breaking changes, no new runtime or unconventional dependencies.