### PR TITLE
fix(lambda): add fn.currentVersion to satisfy CloudFormation validati…

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -4087,10 +4087,12 @@ describe('function', () => {
       const stack = new cdk.Stack();
 
       // WHEN
-      new lambda.DockerImageFunction(stack, 'MyLambda', {
+      const fn = new lambda.DockerImageFunction(stack, 'MyLambda', {
         code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, 'docker-lambda-handler')),
         snapStart: lambda.SnapStartConf.ON_PUBLISHED_VERSIONS,
       });
+
+      fn.currentVersion;
 
       // THEN
       Template.fromStack(stack).hasResource('AWS::Lambda::Function', {


### PR DESCRIPTION
### Issue # (if applicable)
  
N/A — fix for CI failure on aws/aws-cdk#38XXX (SnapStart container image PR)
  
 ### Reason for this change
  
The unit test `container image function using SnapStart` fails due to CloudFormation validation check W2530, which requires a `AWS::Lambda::Version` resource when SnapStart is enabled.
  
 ### Description of changes
  
Added `fn.currentVersion` to the container image SnapStart unit test to create a Version resource and satisfy the validation.
  
### Describe any new or updated permissions being added
  
N/A
  
### Description of how you validated changes
  
- Built `aws-cdk-lib` locally from this branch
- All 215 unit tests pass (11 SnapStart tests green)
- Lint clean

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

  ----
  
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*