### PR TITLE
fix(events): EventBus.archive() does not forward kmsKey to Archive construct

### DIFF
--- a/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
@@ -21,289 +21,289 @@ import * as cxapi from '../../cx-api';
  *  This information includes details of the event itself, as well as target details.
  */
 export enum IncludeDetail {
-    /**
-     * FULL: Include all details related to event itself and the request EventBridge sends to the target.
-     * Detailed data can be useful for troubleshooting and debugging.
-     */
-    FULL = 'FULL',
-    /**
-     * NONE: Does not include any details.
-     */
-    NONE = 'NONE',
+  /**
+   * FULL: Include all details related to event itself and the request EventBridge sends to the target.
+   * Detailed data can be useful for troubleshooting and debugging.
+   */
+  FULL = 'FULL',
+  /**
+   * NONE: Does not include any details.
+   */
+  NONE = 'NONE',
 }
 
 /**
  * The level of logging detail to include. This applies to all log destinations for the event bus.
  */
 export enum Level {
-    /**
-     * INFO: EventBridge sends any logs related to errors, as well as major steps performed during event processing
-     */
-    INFO = 'INFO',
-    /**
-     * ERROR: EventBridge sends any logs related to errors generated during event processing and target delivery.
-     */
-    ERROR = 'ERROR',
-    /**
-     * TRACE: EventBridge sends any logs generated during all steps in the event processing.
-     */
-    TRACE = 'TRACE',
-    /**
-     *  OFF: EventBridge does not send any logs. This is the default.
-     */
-    OFF = 'OFF',
+  /**
+   * INFO: EventBridge sends any logs related to errors, as well as major steps performed during event processing
+   */
+  INFO = 'INFO',
+  /**
+   * ERROR: EventBridge sends any logs related to errors generated during event processing and target delivery.
+   */
+  ERROR = 'ERROR',
+  /**
+   * TRACE: EventBridge sends any logs generated during all steps in the event processing.
+   */
+  TRACE = 'TRACE',
+  /**
+   *  OFF: EventBridge does not send any logs. This is the default.
+   */
+  OFF = 'OFF',
 }
 
 /**
  *  Interface for Logging Configuration of the Event Bus
  */
 export interface LogConfig {
-    /**
-     * Whether EventBridge include detailed event information in the records it generates.
-     * @default no details
-     */
-    readonly includeDetail?: IncludeDetail;
-    /**
-     * Logging level
-     * @default OFF
-     */
-    readonly level?: Level;
+  /**
+   * Whether EventBridge include detailed event information in the records it generates.
+   * @default no details
+   */
+  readonly includeDetail?: IncludeDetail;
+  /**
+   * Logging level
+   * @default OFF
+   */
+  readonly level?: Level;
 }
 
 /**
  * Interface which all EventBus based classes MUST implement
  */
 export interface IEventBus extends IResource, IEventBusRef {
-    /**
-     * The physical ID of this event bus resource
-     *
-     * @attribute
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-     */
-    readonly eventBusName: string;
+  /**
+   * The physical ID of this event bus resource
+   *
+   * @attribute
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+   */
+  readonly eventBusName: string;
 
-    /**
-     * The ARN of this event bus resource
-     *
-     * @attribute
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
-     */
-    readonly eventBusArn: string;
+  /**
+   * The ARN of this event bus resource
+   *
+   * @attribute
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
+   */
+  readonly eventBusArn: string;
 
-    /**
-     * The JSON policy of this event bus resource
-     *
-     * @attribute
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
-     */
-    readonly eventBusPolicy: string;
+  /**
+   * The JSON policy of this event bus resource
+   *
+   * @attribute
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
+   */
+  readonly eventBusPolicy: string;
 
-    /**
-     * The partner event source to associate with this event bus resource
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-     */
-    readonly eventSourceName?: string;
+  /**
+   * The partner event source to associate with this event bus resource
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+   */
+  readonly eventSourceName?: string;
 
-    /**
-     * Create an EventBridge archive to send events to.
-     * When you create an archive, incoming events might not immediately start being sent to the archive.
-     * Allow a short period of time for changes to take effect.
-     *
-     * @param props Properties of the archive
-     */
-    archive(id: string, props: BaseArchiveProps): Archive;
+  /**
+   * Create an EventBridge archive to send events to.
+   * When you create an archive, incoming events might not immediately start being sent to the archive.
+   * Allow a short period of time for changes to take effect.
+   *
+   * @param props Properties of the archive
+   */
+  archive(id: string, props: BaseArchiveProps): Archive;
 
-    /**
-     * Grants an IAM Principal to send custom events to the eventBus
-     * so that they can be matched to rules.
-     *
-     * @param grantee The principal (no-op if undefined)
-     * @param sid The Statement ID used if we need to add a trust policy on the event bus.
-     *
-     */
-    grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant;
+  /**
+   * Grants an IAM Principal to send custom events to the eventBus
+   * so that they can be matched to rules.
+   *
+   * @param grantee The principal (no-op if undefined)
+   * @param sid The Statement ID used if we need to add a trust policy on the event bus.
+   *
+   */
+  grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant;
 }
 
 /**
  * Properties to define an event bus
  */
 export interface EventBusProps {
-    /**
-     * The name of the event bus you are creating
-     * Note: If 'eventSourceName' is passed in, you cannot set this
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-     * @default - automatically generated name
-     */
-    readonly eventBusName?: string;
+  /**
+   * The name of the event bus you are creating
+   * Note: If 'eventSourceName' is passed in, you cannot set this
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+   * @default - automatically generated name
+   */
+  readonly eventBusName?: string;
 
-    /**
-     * The partner event source to associate with this event bus resource
-     * Note: If 'eventBusName' is passed in, you cannot set this
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-     * @default - no partner event source
-     */
-    readonly eventSourceName?: string;
+  /**
+   * The partner event source to associate with this event bus resource
+   * Note: If 'eventBusName' is passed in, you cannot set this
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+   * @default - no partner event source
+   */
+  readonly eventSourceName?: string;
 
-    /**
-     * Dead-letter queue for the event bus
-     *
-     * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-event-delivery.html#eb-rule-dlq
-     *
-     * @default - no dead-letter queue
-     */
-    readonly deadLetterQueue?: sqs.IQueue;
+  /**
+   * Dead-letter queue for the event bus
+   *
+   * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-event-delivery.html#eb-rule-dlq
+   *
+   * @default - no dead-letter queue
+   */
+  readonly deadLetterQueue?: sqs.IQueue;
 
-    /**
-     * The event bus description.
-     *
-     * The description can be up to 512 characters long.
-     *
-     * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
-     *
-     * @default - no description
-     */
-    readonly description?: string;
+  /**
+   * The event bus description.
+   *
+   * The description can be up to 512 characters long.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
+   *
+   * @default - no description
+   */
+  readonly description?: string;
 
-    /**
-     * The customer managed key that encrypt events on this event bus.
-     *
-     * @default - Use an AWS managed key
-     */
-    readonly kmsKey?: kms.IKey;
-    /**
-     * The Logging Configuration of the Èvent Bus.
-     *  @default - no logging
-     */
-    readonly logConfig?: LogConfig;
+  /**
+   * The customer managed key that encrypt events on this event bus.
+   *
+   * @default - Use an AWS managed key
+   */
+  readonly kmsKey?: kms.IKey;
+  /**
+   * The Logging Configuration of the Èvent Bus.
+   *  @default - no logging
+   */
+  readonly logConfig?: LogConfig;
 }
 
 /**
  * Interface with properties necessary to import a reusable EventBus
  */
 export interface EventBusAttributes {
-    /**
-     * The physical ID of this event bus resource
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-     */
-    readonly eventBusName: string;
+  /**
+   * The physical ID of this event bus resource
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+   */
+  readonly eventBusName: string;
 
-    /**
-     * The ARN of this event bus resource
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
-     */
-    readonly eventBusArn: string;
+  /**
+   * The ARN of this event bus resource
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
+   */
+  readonly eventBusArn: string;
 
-    /**
-     * The JSON policy of this event bus resource
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
-     */
-    readonly eventBusPolicy: string;
+  /**
+   * The JSON policy of this event bus resource
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
+   */
+  readonly eventBusPolicy: string;
 
-    /**
-     * The partner event source to associate with this event bus resource
-     *
-     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-     * @default - no partner event source
-     */
-    readonly eventSourceName?: string;
+  /**
+   * The partner event source to associate with this event bus resource
+   *
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+   * @default - no partner event source
+   */
+  readonly eventSourceName?: string;
 }
 
 abstract class EventBusBase extends Resource implements IEventBus, iam.IResourceWithPolicy {
-    /**
-     * The physical ID of this event bus resource
-     */
-    public abstract readonly eventBusName: string;
+  /**
+   * The physical ID of this event bus resource
+   */
+  public abstract readonly eventBusName: string;
 
-    /**
-     * The ARN of the event bus, such as:
-     * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
-     */
-    public abstract readonly eventBusArn: string;
+  /**
+   * The ARN of the event bus, such as:
+   * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
+   */
+  public abstract readonly eventBusArn: string;
 
-    /**
-     * The policy for the event bus in JSON form.
-     */
-    public abstract readonly eventBusPolicy: string;
+  /**
+   * The policy for the event bus in JSON form.
+   */
+  public abstract readonly eventBusPolicy: string;
 
-    /**
-     * The name of the partner event source
-     */
-    public abstract readonly eventSourceName?: string;
+  /**
+   * The name of the partner event source
+   */
+  public abstract readonly eventSourceName?: string;
 
-    /**
-     * Collection of grant methods for an EventBus
-     */
-    public readonly grants = EventBusGrants.fromEventBus(this);
+  /**
+   * Collection of grant methods for an EventBus
+   */
+  public readonly grants = EventBusGrants.fromEventBus(this);
 
-    public get eventBusRef(): EventBusReference {
-        return {
-            eventBusArn: this.eventBusArn,
-            eventBusName: this.eventBusName,
-        };
+  public get eventBusRef(): EventBusReference {
+    return {
+      eventBusArn: this.eventBusArn,
+      eventBusName: this.eventBusName,
+    };
+  }
+
+  public archive(id: string, props: BaseArchiveProps): Archive {
+    return new Archive(this, id, {
+      sourceEventBus: this,
+      description: props.description || `Event Archive for ${this.eventBusName} Event Bus`,
+      eventPattern: props.eventPattern,
+      retention: props.retention,
+      archiveName: props.archiveName,
+      kmsKey: props.kmsKey,
+    });
+  }
+
+  /**
+   * [disable-awslint:no-grants]
+   */
+  public grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant {
+    const actions = ['events:PutEvents'];
+    const resourceArns = [this.eventBusArn];
+    const options = {
+      grantee,
+      actions: actions,
+      resourceArns: [this.eventBusArn],
+    };
+    const grantResult = iam.Grant.addToPrincipal(options);
+
+    if (grantResult.success) {
+      return grantResult;
     }
 
-    public archive(id: string, props: BaseArchiveProps): Archive {
-        return new Archive(this, id, {
-            sourceEventBus: this,
-            description: props.description || `Event Archive for ${this.eventBusName} Event Bus`,
-            eventPattern: props.eventPattern,
-            retention: props.retention,
-            archiveName: props.archiveName,
-            kmsKey: props.kmsKey,
-        });
+    const requireSid = FeatureFlags.of(this).isEnabled(cxapi.EVENTBUS_POLICY_SID_REQUIRED);
+    if (requireSid) {
+      const statement = new iam.PolicyStatement({
+        actions: actions,
+        resources: resourceArns,
+        principals: [grantee!.grantPrincipal],
+        sid: sid,
+      });
+
+      return iam.Grant.addStatementToResourcePolicy({ ...options, statement, resource: this });
+    } else {
+      Annotations.of(this).addWarningV2(
+        '@aws-cdk/aws-events:eventBusServicePrincipalGrant',
+        'Unable to grant PutEvents to service principal: Statement ID is required for EventBus resource policies. Either provide a \'sid\' parameter or enable the \'@aws-cdk/aws-events:requireEventBusPolicySid\' feature flag.',
+      );
+      return iam.Grant.drop(grantee, '');
     }
+  }
 
-    /**
-     * [disable-awslint:no-grants]
-     */
-    public grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant {
-        const actions = ['events:PutEvents'];
-        const resourceArns = [this.eventBusArn];
-        const options = {
-            grantee,
-            actions: actions,
-            resourceArns: [this.eventBusArn],
-        };
-        const grantResult = iam.Grant.addToPrincipal(options);
-
-        if (grantResult.success) {
-            return grantResult;
-        }
-
-        const requireSid = FeatureFlags.of(this).isEnabled(cxapi.EVENTBUS_POLICY_SID_REQUIRED);
-        if (requireSid) {
-            const statement = new iam.PolicyStatement({
-                actions: actions,
-                resources: resourceArns,
-                principals: [grantee!.grantPrincipal],
-                sid: sid,
-            });
-
-            return iam.Grant.addStatementToResourcePolicy({ ...options, statement, resource: this });
-        } else {
-            Annotations.of(this).addWarningV2(
-                '@aws-cdk/aws-events:eventBusServicePrincipalGrant',
-                'Unable to grant PutEvents to service principal: Statement ID is required for EventBus resource policies. Either provide a \'sid\' parameter or enable the \'@aws-cdk/aws-events:requireEventBusPolicySid\' feature flag.',
-            );
-            return iam.Grant.drop(grantee, '');
-        }
-    }
-
-    /**
-     * Adds a statement to the resource policy associated with this event bus.
-     * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
-     *
-     * Note that this does not work with imported event buss.
-     *
-     * @param statement The policy statement to add
-     */
-    public abstract addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult;
+  /**
+   * Adds a statement to the resource policy associated with this event bus.
+   * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
+   *
+   * Note that this does not work with imported event buss.
+   *
+   * @param statement The policy statement to add
+   */
+  public abstract addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult;
 }
 
 /**
@@ -313,315 +313,315 @@ abstract class EventBusBase extends Resource implements IEventBus, iam.IResource
  */
 @propertyInjectable
 export class EventBus extends EventBusBase {
-    /**
-     * Uniquely identifies this class.
-     */
-    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBus';
+  /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBus';
 
-    /**
-     * Import an existing event bus resource
-     * @param scope Parent construct
-     * @param id Construct ID
-     * @param eventBusArn ARN of imported event bus
-     */
-    public static fromEventBusArn(scope: Construct, id: string, eventBusArn: string): IEventBus {
-        const parts = Stack.of(scope).splitArn(eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
+  /**
+   * Import an existing event bus resource
+   * @param scope Parent construct
+   * @param id Construct ID
+   * @param eventBusArn ARN of imported event bus
+   */
+  public static fromEventBusArn(scope: Construct, id: string, eventBusArn: string): IEventBus {
+    const parts = Stack.of(scope).splitArn(eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
 
-        return new ImportedEventBus(scope, id, {
-            eventBusArn: eventBusArn,
-            eventBusName: parts.resourceName || '',
-            eventBusPolicy: '',
-        });
+    return new ImportedEventBus(scope, id, {
+      eventBusArn: eventBusArn,
+      eventBusName: parts.resourceName || '',
+      eventBusPolicy: '',
+    });
+  }
+
+  /**
+   * Import an existing event bus resource
+   * @param scope Parent construct
+   * @param id Construct ID
+   * @param eventBusName Name of imported event bus
+   */
+  public static fromEventBusName(scope: Construct, id: string, eventBusName: string): IEventBus {
+    const eventBusArn = Stack.of(scope).formatArn({
+      resource: 'event-bus',
+      service: 'events',
+      resourceName: eventBusName,
+    });
+
+    return EventBus.fromEventBusAttributes(scope, id, {
+      eventBusName: eventBusName,
+      eventBusArn: eventBusArn,
+      eventBusPolicy: '',
+    });
+  }
+
+  /**
+   * Import an existing event bus resource
+   * @param scope Parent construct
+   * @param id Construct ID
+   * @param attrs Imported event bus properties
+   */
+  public static fromEventBusAttributes(scope: Construct, id: string, attrs: EventBusAttributes): IEventBus {
+    return new ImportedEventBus(scope, id, attrs);
+  }
+
+  /**
+   * Permits an IAM Principal to send custom events to EventBridge
+   * so that they can be matched to rules.
+   *
+   * @param grantee The principal (no-op if undefined)
+   * @deprecated use grantAllPutEvents instead
+   */
+  public static grantPutEvents(grantee: iam.IGrantable): iam.Grant {
+    // It's currently not possible to restrict PutEvents to specific resources.
+    // See https://docs.aws.amazon.com/eventbridge/latest/userguide/permissions-reference-eventbridge.html
+    return iam.Grant.addToPrincipal({
+      grantee,
+      actions: ['events:PutEvents'],
+      resourceArns: ['*'],
+    });
+  }
+
+  /**
+   * Permits an IAM Principal to send custom events to EventBridge
+   * so that they can be matched to rules.
+   *
+   * @param grantee The principal (no-op if undefined)
+   */
+  public static grantAllPutEvents(grantee: iam.IGrantable): iam.Grant {
+    // FIXME Doing this hack because this method is static, and we don't have an actual instance of
+    //  IEventBusRef to use here for the grants.
+    const eventBus = EventBus.fromEventBusName(new Stack(), 'dummy', 'dummy');
+    return EventBusGrants.fromEventBus(eventBus).allPutEvents(grantee);
+  }
+
+  private static eventBusProps(defaultEventBusName: string, props: EventBusProps = {}) {
+    const { eventBusName, eventSourceName } = props;
+    const eventBusNameRegex = /^[\/\.\-_A-Za-z0-9]{1,256}$/;
+
+    if (eventBusName !== undefined && eventSourceName !== undefined) {
+      throw new UnscopedValidationError(
+        lit`EventBusNameAndEventSourceNameCannotBothBeProvided`,
+        '\'eventBusName\' and \'eventSourceName\' cannot both be provided',
+      );
     }
 
-    /**
-     * Import an existing event bus resource
-     * @param scope Parent construct
-     * @param id Construct ID
-     * @param eventBusName Name of imported event bus
-     */
-    public static fromEventBusName(scope: Construct, id: string, eventBusName: string): IEventBus {
-        const eventBusArn = Stack.of(scope).formatArn({
-            resource: 'event-bus',
-            service: 'events',
-            resourceName: eventBusName,
-        });
-
-        return EventBus.fromEventBusAttributes(scope, id, {
-            eventBusName: eventBusName,
-            eventBusArn: eventBusArn,
-            eventBusPolicy: '',
-        });
+    if (eventBusName !== undefined) {
+      if (!Token.isUnresolved(eventBusName)) {
+        if (eventBusName === 'default') {
+          throw new UnscopedValidationError(
+            lit`EventBusNameMustNotBeDefault`,
+            '\'eventBusName\' must not be \'default\'',
+          );
+        } else if (eventBusName.indexOf('/') > -1) {
+          throw new UnscopedValidationError(
+            lit`EventBusNameMustNotContainSlash`,
+            '\'eventBusName\' must not contain \'/\'',
+          );
+        } else if (!eventBusNameRegex.test(eventBusName)) {
+          throw new UnscopedValidationError(
+            lit`EventBusNameMustSatisfyRegex`,
+            `'eventBusName' must satisfy: ${eventBusNameRegex}`,
+          );
+        }
+      }
+      return { eventBusName };
     }
 
-    /**
-     * Import an existing event bus resource
-     * @param scope Parent construct
-     * @param id Construct ID
-     * @param attrs Imported event bus properties
-     */
-    public static fromEventBusAttributes(scope: Construct, id: string, attrs: EventBusAttributes): IEventBus {
-        return new ImportedEventBus(scope, id, attrs);
+    if (eventSourceName !== undefined) {
+      if (!Token.isUnresolved(eventSourceName)) {
+        // Ex: aws.partner/PartnerName/acct1/repo1
+        const eventSourceNameRegex = /^aws\.partner(\/[\.\-_A-Za-z0-9]+){2,}$/;
+        if (!eventSourceNameRegex.test(eventSourceName)) {
+          throw new UnscopedValidationError(
+            lit`EventSourceNameMustSatisfyRegex`,
+            `'eventSourceName' must satisfy: ${eventSourceNameRegex}`,
+          );
+        } else if (!eventBusNameRegex.test(eventSourceName)) {
+          throw new UnscopedValidationError(
+            lit`EventSourceNameMustSatisfyBusNameRegex`,
+            `'eventSourceName' must satisfy: ${eventBusNameRegex}`,
+          );
+        }
+      }
+      return { eventBusName: eventSourceName, eventSourceName };
     }
 
+    return { eventBusName: defaultEventBusName };
+  }
+
+  /**
+   * The CfnEventBus resource
+   */
+  private readonly _resource: CfnEventBus;
+
+  /**
+   * The physical ID of this event bus resource
+   */
+  @memoizedGetter
+  public get eventBusName(): string {
+    return this.getResourceNameAttribute(this._resource.ref);
+  }
+
+  /**
+   * The ARN of the event bus, such as:
+   * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
+   */
+  @memoizedGetter
+  public get eventBusArn(): string {
+    return this.getResourceArnAttribute(this._resource.attrArn, {
+      service: 'events',
+      resource: 'event-bus',
+      resourceName: this._resource.name,
+    });
+  }
+
+  /**
+   * The policy for the event bus in JSON form.
+   */
+  @memoizedGetter
+  public get eventBusPolicy(): string {
+    return this._resource.attrPolicy;
+  }
+
+  /**
+   * The name of the partner event source
+   */
+  @memoizedGetter
+  public get eventSourceName(): string | undefined {
+    return this._resource.eventSourceName;
+  }
+
+  constructor(scope: Construct, id: string, props?: EventBusProps) {
+    const { eventBusName, eventSourceName } = EventBus.eventBusProps(
+      Lazy.string({ produce: () => Names.uniqueId(this) }),
+      props,
+    );
+
+    super(scope, id, { physicalName: eventBusName });
+    // Enhanced CDK Analytics Telemetry
+    addConstructMetadata(this, props);
+
+    if (props?.description && !Token.isUnresolved(props.description) && props.description.length > 512) {
+      throw new ValidationError(lit`DescriptionMustBeLessThanOrEqualTo512Characters`, `description must be less than or equal to 512 characters, got ${props.description.length}`, this);
+    }
+
+    this._resource = new CfnEventBus(this, 'Resource', {
+      name: this.physicalName,
+      eventSourceName,
+      deadLetterConfig: props?.deadLetterQueue ? {
+        arn: props.deadLetterQueue.queueArn,
+      } : undefined,
+      description: props?.description,
+      kmsKeyIdentifier: props?.kmsKey?.keyArn,
+      logConfig: props?.logConfig,
+    });
+
     /**
-     * Permits an IAM Principal to send custom events to EventBridge
-     * so that they can be matched to rules.
+     * Allow EventBridge to use customer managed key
      *
-     * @param grantee The principal (no-op if undefined)
-     * @deprecated use grantAllPutEvents instead
+     * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-key-policy.html#eb-encryption-key-policy-bus
      */
-    public static grantPutEvents(grantee: iam.IGrantable): iam.Grant {
-        // It's currently not possible to restrict PutEvents to specific resources.
-        // See https://docs.aws.amazon.com/eventbridge/latest/userguide/permissions-reference-eventbridge.html
-        return iam.Grant.addToPrincipal({
-            grantee,
-            actions: ['events:PutEvents'],
-            resourceArns: ['*'],
-        });
+    if (props?.kmsKey) {
+      props?.kmsKey.addToResourcePolicy(new iam.PolicyStatement({
+        resources: ['*'],
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:DescribeKey'],
+        principals: [new iam.ServicePrincipal('events.amazonaws.com')],
+        conditions: {
+          StringEquals: {
+            'aws:SourceAccount': this.stack.account,
+            'aws:SourceArn': Stack.of(this).formatArn({
+              service: 'events',
+              resource: 'event-bus',
+              resourceName: eventBusName,
+            }),
+            'kms:EncryptionContext:aws:events:event-bus:arn': Stack.of(this).formatArn({
+              service: 'events',
+              resource: 'event-bus',
+              resourceName: eventBusName,
+            }),
+          },
+        },
+      }));
+    }
+  }
+
+  /**
+   * Adds a statement to the IAM resource policy associated with this event bus.
+   */
+  @MethodMetadata()
+  public addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
+    // If no sid is provided, generate one based on the event bus id
+    if (statement.sid == null) {
+      throw new ValidationError(lit`EventBusPolicyStatementsMustHaveSid`, 'Event Bus policy statements must have a sid', this);
     }
 
-    /**
-     * Permits an IAM Principal to send custom events to EventBridge
-     * so that they can be matched to rules.
-     *
-     * @param grantee The principal (no-op if undefined)
-     */
-    public static grantAllPutEvents(grantee: iam.IGrantable): iam.Grant {
-        // FIXME Doing this hack because this method is static, and we don't have an actual instance of
-        //  IEventBusRef to use here for the grants.
-        const eventBus = EventBus.fromEventBusName(new Stack(), 'dummy', 'dummy');
-        return EventBusGrants.fromEventBus(eventBus).allPutEvents(grantee);
-    }
+    // In order to generate new statementIDs for the change in https://github.com/aws/aws-cdk/pull/27340
+    const statementId = `cdk-${statement.sid}`.slice(0, 64);
+    statement.sid = statementId;
+    const policy = new EventBusPolicy(this, statementId, {
+      eventBus: this,
+      statement: statement.toJSON(),
+      statementId,
+    });
 
-    private static eventBusProps(defaultEventBusName: string, props: EventBusProps = {}) {
-        const { eventBusName, eventSourceName } = props;
-        const eventBusNameRegex = /^[\/\.\-_A-Za-z0-9]{1,256}$/;
-
-        if (eventBusName !== undefined && eventSourceName !== undefined) {
-            throw new UnscopedValidationError(
-                lit`EventBusNameAndEventSourceNameCannotBothBeProvided`,
-                '\'eventBusName\' and \'eventSourceName\' cannot both be provided',
-            );
-        }
-
-        if (eventBusName !== undefined) {
-            if (!Token.isUnresolved(eventBusName)) {
-                if (eventBusName === 'default') {
-                    throw new UnscopedValidationError(
-                        lit`EventBusNameMustNotBeDefault`,
-                        '\'eventBusName\' must not be \'default\'',
-                    );
-                } else if (eventBusName.indexOf('/') > -1) {
-                    throw new UnscopedValidationError(
-                        lit`EventBusNameMustNotContainSlash`,
-                        '\'eventBusName\' must not contain \'/\'',
-                    );
-                } else if (!eventBusNameRegex.test(eventBusName)) {
-                    throw new UnscopedValidationError(
-                        lit`EventBusNameMustSatisfyRegex`,
-                        `'eventBusName' must satisfy: ${eventBusNameRegex}`,
-                    );
-                }
-            }
-            return { eventBusName };
-        }
-
-        if (eventSourceName !== undefined) {
-            if (!Token.isUnresolved(eventSourceName)) {
-                // Ex: aws.partner/PartnerName/acct1/repo1
-                const eventSourceNameRegex = /^aws\.partner(\/[\.\-_A-Za-z0-9]+){2,}$/;
-                if (!eventSourceNameRegex.test(eventSourceName)) {
-                    throw new UnscopedValidationError(
-                        lit`EventSourceNameMustSatisfyRegex`,
-                        `'eventSourceName' must satisfy: ${eventSourceNameRegex}`,
-                    );
-                } else if (!eventBusNameRegex.test(eventSourceName)) {
-                    throw new UnscopedValidationError(
-                        lit`EventSourceNameMustSatisfyBusNameRegex`,
-                        `'eventSourceName' must satisfy: ${eventBusNameRegex}`,
-                    );
-                }
-            }
-            return { eventBusName: eventSourceName, eventSourceName };
-        }
-
-        return { eventBusName: defaultEventBusName };
-    }
-
-    /**
-     * The CfnEventBus resource
-     */
-    private readonly _resource: CfnEventBus;
-
-    /**
-     * The physical ID of this event bus resource
-     */
-    @memoizedGetter
-    public get eventBusName(): string {
-        return this.getResourceNameAttribute(this._resource.ref);
-    }
-
-    /**
-     * The ARN of the event bus, such as:
-     * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
-     */
-    @memoizedGetter
-    public get eventBusArn(): string {
-        return this.getResourceArnAttribute(this._resource.attrArn, {
-            service: 'events',
-            resource: 'event-bus',
-            resourceName: this._resource.name,
-        });
-    }
-
-    /**
-     * The policy for the event bus in JSON form.
-     */
-    @memoizedGetter
-    public get eventBusPolicy(): string {
-        return this._resource.attrPolicy;
-    }
-
-    /**
-     * The name of the partner event source
-     */
-    @memoizedGetter
-    public get eventSourceName(): string | undefined {
-        return this._resource.eventSourceName;
-    }
-
-    constructor(scope: Construct, id: string, props?: EventBusProps) {
-        const { eventBusName, eventSourceName } = EventBus.eventBusProps(
-            Lazy.string({ produce: () => Names.uniqueId(this) }),
-            props,
-        );
-
-        super(scope, id, { physicalName: eventBusName });
-        // Enhanced CDK Analytics Telemetry
-        addConstructMetadata(this, props);
-
-        if (props?.description && !Token.isUnresolved(props.description) && props.description.length > 512) {
-            throw new ValidationError(lit`DescriptionMustBeLessThanOrEqualTo512Characters`, `description must be less than or equal to 512 characters, got ${props.description.length}`, this);
-        }
-
-        this._resource = new CfnEventBus(this, 'Resource', {
-            name: this.physicalName,
-            eventSourceName,
-            deadLetterConfig: props?.deadLetterQueue ? {
-                arn: props.deadLetterQueue.queueArn,
-            } : undefined,
-            description: props?.description,
-            kmsKeyIdentifier: props?.kmsKey?.keyArn,
-            logConfig: props?.logConfig,
-        });
-
-        /**
-         * Allow EventBridge to use customer managed key
-         *
-         * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-key-policy.html#eb-encryption-key-policy-bus
-         */
-        if (props?.kmsKey) {
-            props?.kmsKey.addToResourcePolicy(new iam.PolicyStatement({
-                resources: ['*'],
-                actions: ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:DescribeKey'],
-                principals: [new iam.ServicePrincipal('events.amazonaws.com')],
-                conditions: {
-                    StringEquals: {
-                        'aws:SourceAccount': this.stack.account,
-                        'aws:SourceArn': Stack.of(this).formatArn({
-                            service: 'events',
-                            resource: 'event-bus',
-                            resourceName: eventBusName,
-                        }),
-                        'kms:EncryptionContext:aws:events:event-bus:arn': Stack.of(this).formatArn({
-                            service: 'events',
-                            resource: 'event-bus',
-                            resourceName: eventBusName,
-                        }),
-                    },
-                },
-            }));
-        }
-    }
-
-    /**
-     * Adds a statement to the IAM resource policy associated with this event bus.
-     */
-    @MethodMetadata()
-    public addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
-        // If no sid is provided, generate one based on the event bus id
-        if (statement.sid == null) {
-            throw new ValidationError(lit`EventBusPolicyStatementsMustHaveSid`, 'Event Bus policy statements must have a sid', this);
-        }
-
-        // In order to generate new statementIDs for the change in https://github.com/aws/aws-cdk/pull/27340
-        const statementId = `cdk-${statement.sid}`.slice(0, 64);
-        statement.sid = statementId;
-        const policy = new EventBusPolicy(this, statementId, {
-            eventBus: this,
-            statement: statement.toJSON(),
-            statementId,
-        });
-
-        return { statementAdded: true, policyDependable: policy };
-    }
+    return { statementAdded: true, policyDependable: policy };
+  }
 }
 
 @propertyInjectable
 class ImportedEventBus extends EventBusBase {
-    /** Uniquely identifies this class. */
-    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.ImportedEventBus';
-    public readonly eventBusArn: string;
-    public readonly eventBusName: string;
-    public readonly eventBusPolicy: string;
-    public readonly eventSourceName?: string;
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.ImportedEventBus';
+  public readonly eventBusArn: string;
+  public readonly eventBusName: string;
+  public readonly eventBusPolicy: string;
+  public readonly eventSourceName?: string;
 
-    constructor(scope: Construct, id: string, attrs: EventBusAttributes) {
-        const arnParts = Stack.of(scope).splitArn(attrs.eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
-        super(scope, id, {
-            account: arnParts.account,
-            region: arnParts.region,
-        });
-        // Enhanced CDK Analytics Telemetry
-        addConstructMetadata(this, attrs);
+  constructor(scope: Construct, id: string, attrs: EventBusAttributes) {
+    const arnParts = Stack.of(scope).splitArn(attrs.eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
+    super(scope, id, {
+      account: arnParts.account,
+      region: arnParts.region,
+    });
+    // Enhanced CDK Analytics Telemetry
+    addConstructMetadata(this, attrs);
 
-        this.eventBusArn = attrs.eventBusArn;
-        this.eventBusName = attrs.eventBusName;
-        this.eventBusPolicy = attrs.eventBusPolicy;
-        this.eventSourceName = attrs.eventSourceName;
-    }
+    this.eventBusArn = attrs.eventBusArn;
+    this.eventBusName = attrs.eventBusName;
+    this.eventBusPolicy = attrs.eventBusPolicy;
+    this.eventSourceName = attrs.eventSourceName;
+  }
 
-    @MethodMetadata()
-    public addToResourcePolicy(_statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
-        // Warn the user
-        Annotations.of(this).addWarningV2(
-            '@aws-cdk/aws-events:eventBusAddToResourcePolicy',
-            `Unable to add necessary permissions to imported target event bus: ${this.eventBusArn}`,
-        );
-        return { statementAdded: false };
-    }
+  @MethodMetadata()
+  public addToResourcePolicy(_statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
+    // Warn the user
+    Annotations.of(this).addWarningV2(
+      '@aws-cdk/aws-events:eventBusAddToResourcePolicy',
+      `Unable to add necessary permissions to imported target event bus: ${this.eventBusArn}`,
+    );
+    return { statementAdded: false };
+  }
 }
 
 /**
  * Properties to associate Event Buses with a policy
  */
 export interface EventBusPolicyProps {
-    /**
-     * The event bus to which the policy applies
-     */
-    readonly eventBus: IEventBus;
+  /**
+   * The event bus to which the policy applies
+   */
+  readonly eventBus: IEventBus;
 
-    /**
-     * An IAM Policy Statement to apply to the Event Bus
-     */
-    readonly statement: iam.PolicyStatement;
+  /**
+   * An IAM Policy Statement to apply to the Event Bus
+   */
+  readonly statement: iam.PolicyStatement;
 
-    /**
-     * An identifier string for the external account that
-     * you are granting permissions to.
-     */
-    readonly statementId: string;
+  /**
+   * An identifier string for the external account that
+   * you are granting permissions to.
+   */
+  readonly statementId: string;
 }
 
 /**
@@ -640,18 +640,18 @@ export interface EventBusPolicyProps {
  */
 @propertyInjectable
 export class EventBusPolicy extends Resource {
-    /** Uniquely identifies this class. */
-    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBusPolicy';
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBusPolicy';
 
-    constructor(scope: Construct, id: string, props: EventBusPolicyProps) {
-        super(scope, id);
-        // Enhanced CDK Analytics Telemetry
-        addConstructMetadata(this, props);
+  constructor(scope: Construct, id: string, props: EventBusPolicyProps) {
+    super(scope, id);
+    // Enhanced CDK Analytics Telemetry
+    addConstructMetadata(this, props);
 
-        new CfnEventBusPolicy(this, 'Resource', {
-            statementId: props.statementId!,
-            statement: props.statement,
-            eventBusName: props.eventBus.eventBusName,
-        });
-    }
+    new CfnEventBusPolicy(this, 'Resource', {
+      statementId: props.statementId!,
+      statement: props.statement,
+      eventBusName: props.eventBus.eventBusName,
+    });
+  }
 }

--- a/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
+++ b/packages/aws-cdk-lib/aws-events/lib/event-bus.ts
@@ -21,288 +21,289 @@ import * as cxapi from '../../cx-api';
  *  This information includes details of the event itself, as well as target details.
  */
 export enum IncludeDetail {
-  /**
-   * FULL: Include all details related to event itself and the request EventBridge sends to the target.
-   * Detailed data can be useful for troubleshooting and debugging.
-   */
-  FULL = 'FULL',
-  /**
-   * NONE: Does not include any details.
-   */
-  NONE = 'NONE',
+    /**
+     * FULL: Include all details related to event itself and the request EventBridge sends to the target.
+     * Detailed data can be useful for troubleshooting and debugging.
+     */
+    FULL = 'FULL',
+    /**
+     * NONE: Does not include any details.
+     */
+    NONE = 'NONE',
 }
 
 /**
  * The level of logging detail to include. This applies to all log destinations for the event bus.
  */
 export enum Level {
-  /**
-   * INFO: EventBridge sends any logs related to errors, as well as major steps performed during event processing
-   */
-  INFO = 'INFO',
-  /**
-   * ERROR: EventBridge sends any logs related to errors generated during event processing and target delivery.
-   */
-  ERROR = 'ERROR',
-  /**
-   * TRACE: EventBridge sends any logs generated during all steps in the event processing.
-   */
-  TRACE = 'TRACE',
-  /**
-   *  OFF: EventBridge does not send any logs. This is the default.
-   */
-  OFF = 'OFF',
+    /**
+     * INFO: EventBridge sends any logs related to errors, as well as major steps performed during event processing
+     */
+    INFO = 'INFO',
+    /**
+     * ERROR: EventBridge sends any logs related to errors generated during event processing and target delivery.
+     */
+    ERROR = 'ERROR',
+    /**
+     * TRACE: EventBridge sends any logs generated during all steps in the event processing.
+     */
+    TRACE = 'TRACE',
+    /**
+     *  OFF: EventBridge does not send any logs. This is the default.
+     */
+    OFF = 'OFF',
 }
 
 /**
  *  Interface for Logging Configuration of the Event Bus
  */
 export interface LogConfig {
-  /**
-   * Whether EventBridge include detailed event information in the records it generates.
-   * @default no details
-   */
-  readonly includeDetail?: IncludeDetail;
-  /**
-   * Logging level
-   * @default OFF
-   */
-  readonly level?: Level;
+    /**
+     * Whether EventBridge include detailed event information in the records it generates.
+     * @default no details
+     */
+    readonly includeDetail?: IncludeDetail;
+    /**
+     * Logging level
+     * @default OFF
+     */
+    readonly level?: Level;
 }
 
 /**
  * Interface which all EventBus based classes MUST implement
  */
 export interface IEventBus extends IResource, IEventBusRef {
-  /**
-   * The physical ID of this event bus resource
-   *
-   * @attribute
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-   */
-  readonly eventBusName: string;
+    /**
+     * The physical ID of this event bus resource
+     *
+     * @attribute
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+     */
+    readonly eventBusName: string;
 
-  /**
-   * The ARN of this event bus resource
-   *
-   * @attribute
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
-   */
-  readonly eventBusArn: string;
+    /**
+     * The ARN of this event bus resource
+     *
+     * @attribute
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
+     */
+    readonly eventBusArn: string;
 
-  /**
-   * The JSON policy of this event bus resource
-   *
-   * @attribute
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
-   */
-  readonly eventBusPolicy: string;
+    /**
+     * The JSON policy of this event bus resource
+     *
+     * @attribute
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
+     */
+    readonly eventBusPolicy: string;
 
-  /**
-   * The partner event source to associate with this event bus resource
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-   */
-  readonly eventSourceName?: string;
+    /**
+     * The partner event source to associate with this event bus resource
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+     */
+    readonly eventSourceName?: string;
 
-  /**
-   * Create an EventBridge archive to send events to.
-   * When you create an archive, incoming events might not immediately start being sent to the archive.
-   * Allow a short period of time for changes to take effect.
-   *
-   * @param props Properties of the archive
-   */
-  archive(id: string, props: BaseArchiveProps): Archive;
+    /**
+     * Create an EventBridge archive to send events to.
+     * When you create an archive, incoming events might not immediately start being sent to the archive.
+     * Allow a short period of time for changes to take effect.
+     *
+     * @param props Properties of the archive
+     */
+    archive(id: string, props: BaseArchiveProps): Archive;
 
-  /**
-   * Grants an IAM Principal to send custom events to the eventBus
-   * so that they can be matched to rules.
-   *
-   * @param grantee The principal (no-op if undefined)
-   * @param sid The Statement ID used if we need to add a trust policy on the event bus.
-   *
-   */
-  grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant;
+    /**
+     * Grants an IAM Principal to send custom events to the eventBus
+     * so that they can be matched to rules.
+     *
+     * @param grantee The principal (no-op if undefined)
+     * @param sid The Statement ID used if we need to add a trust policy on the event bus.
+     *
+     */
+    grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant;
 }
 
 /**
  * Properties to define an event bus
  */
 export interface EventBusProps {
-  /**
-   * The name of the event bus you are creating
-   * Note: If 'eventSourceName' is passed in, you cannot set this
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-   * @default - automatically generated name
-   */
-  readonly eventBusName?: string;
+    /**
+     * The name of the event bus you are creating
+     * Note: If 'eventSourceName' is passed in, you cannot set this
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+     * @default - automatically generated name
+     */
+    readonly eventBusName?: string;
 
-  /**
-   * The partner event source to associate with this event bus resource
-   * Note: If 'eventBusName' is passed in, you cannot set this
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-   * @default - no partner event source
-   */
-  readonly eventSourceName?: string;
+    /**
+     * The partner event source to associate with this event bus resource
+     * Note: If 'eventBusName' is passed in, you cannot set this
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+     * @default - no partner event source
+     */
+    readonly eventSourceName?: string;
 
-  /**
-   * Dead-letter queue for the event bus
-   *
-   * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-event-delivery.html#eb-rule-dlq
-   *
-   * @default - no dead-letter queue
-   */
-  readonly deadLetterQueue?: sqs.IQueue;
+    /**
+     * Dead-letter queue for the event bus
+     *
+     * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-event-delivery.html#eb-rule-dlq
+     *
+     * @default - no dead-letter queue
+     */
+    readonly deadLetterQueue?: sqs.IQueue;
 
-  /**
-   * The event bus description.
-   *
-   * The description can be up to 512 characters long.
-   *
-   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
-   *
-   * @default - no description
-   */
-  readonly description?: string;
+    /**
+     * The event bus description.
+     *
+     * The description can be up to 512 characters long.
+     *
+     * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-description
+     *
+     * @default - no description
+     */
+    readonly description?: string;
 
-  /**
-   * The customer managed key that encrypt events on this event bus.
-   *
-   * @default - Use an AWS managed key
-   */
-  readonly kmsKey?: kms.IKey;
-  /**
-   * The Logging Configuration of the Èvent Bus.
-   *  @default - no logging
-   */
-  readonly logConfig?: LogConfig;
+    /**
+     * The customer managed key that encrypt events on this event bus.
+     *
+     * @default - Use an AWS managed key
+     */
+    readonly kmsKey?: kms.IKey;
+    /**
+     * The Logging Configuration of the Èvent Bus.
+     *  @default - no logging
+     */
+    readonly logConfig?: LogConfig;
 }
 
 /**
  * Interface with properties necessary to import a reusable EventBus
  */
 export interface EventBusAttributes {
-  /**
-   * The physical ID of this event bus resource
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
-   */
-  readonly eventBusName: string;
+    /**
+     * The physical ID of this event bus resource
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-name
+     */
+    readonly eventBusName: string;
 
-  /**
-   * The ARN of this event bus resource
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
-   */
-  readonly eventBusArn: string;
+    /**
+     * The ARN of this event bus resource
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Arn-fn::getatt
+     */
+    readonly eventBusArn: string;
 
-  /**
-   * The JSON policy of this event bus resource
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
-   */
-  readonly eventBusPolicy: string;
+    /**
+     * The JSON policy of this event bus resource
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#Policy-fn::getatt
+     */
+    readonly eventBusPolicy: string;
 
-  /**
-   * The partner event source to associate with this event bus resource
-   *
-   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
-   * @default - no partner event source
-   */
-  readonly eventSourceName?: string;
+    /**
+     * The partner event source to associate with this event bus resource
+     *
+     * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html#cfn-events-eventbus-eventsourcename
+     * @default - no partner event source
+     */
+    readonly eventSourceName?: string;
 }
 
 abstract class EventBusBase extends Resource implements IEventBus, iam.IResourceWithPolicy {
-  /**
-   * The physical ID of this event bus resource
-   */
-  public abstract readonly eventBusName: string;
+    /**
+     * The physical ID of this event bus resource
+     */
+    public abstract readonly eventBusName: string;
 
-  /**
-   * The ARN of the event bus, such as:
-   * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
-   */
-  public abstract readonly eventBusArn: string;
+    /**
+     * The ARN of the event bus, such as:
+     * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
+     */
+    public abstract readonly eventBusArn: string;
 
-  /**
-   * The policy for the event bus in JSON form.
-   */
-  public abstract readonly eventBusPolicy: string;
+    /**
+     * The policy for the event bus in JSON form.
+     */
+    public abstract readonly eventBusPolicy: string;
 
-  /**
-   * The name of the partner event source
-   */
-  public abstract readonly eventSourceName?: string;
+    /**
+     * The name of the partner event source
+     */
+    public abstract readonly eventSourceName?: string;
 
-  /**
-   * Collection of grant methods for an EventBus
-   */
-  public readonly grants = EventBusGrants.fromEventBus(this);
+    /**
+     * Collection of grant methods for an EventBus
+     */
+    public readonly grants = EventBusGrants.fromEventBus(this);
 
-  public get eventBusRef(): EventBusReference {
-    return {
-      eventBusArn: this.eventBusArn,
-      eventBusName: this.eventBusName,
-    };
-  }
-
-  public archive(id: string, props: BaseArchiveProps): Archive {
-    return new Archive(this, id, {
-      sourceEventBus: this,
-      description: props.description || `Event Archive for ${this.eventBusName} Event Bus`,
-      eventPattern: props.eventPattern,
-      retention: props.retention,
-      archiveName: props.archiveName,
-    });
-  }
-
-  /**
-   * [disable-awslint:no-grants]
-   */
-  public grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant {
-    const actions = ['events:PutEvents'];
-    const resourceArns = [this.eventBusArn];
-    const options = {
-      grantee,
-      actions: actions,
-      resourceArns: [this.eventBusArn],
-    };
-    const grantResult = iam.Grant.addToPrincipal(options);
-
-    if (grantResult.success) {
-      return grantResult;
+    public get eventBusRef(): EventBusReference {
+        return {
+            eventBusArn: this.eventBusArn,
+            eventBusName: this.eventBusName,
+        };
     }
 
-    const requireSid = FeatureFlags.of(this).isEnabled(cxapi.EVENTBUS_POLICY_SID_REQUIRED);
-    if (requireSid) {
-      const statement = new iam.PolicyStatement({
-        actions: actions,
-        resources: resourceArns,
-        principals: [grantee!.grantPrincipal],
-        sid: sid,
-      });
-
-      return iam.Grant.addStatementToResourcePolicy({ ...options, statement, resource: this });
-    } else {
-      Annotations.of(this).addWarningV2(
-        '@aws-cdk/aws-events:eventBusServicePrincipalGrant',
-        'Unable to grant PutEvents to service principal: Statement ID is required for EventBus resource policies. Either provide a \'sid\' parameter or enable the \'@aws-cdk/aws-events:requireEventBusPolicySid\' feature flag.',
-      );
-      return iam.Grant.drop(grantee, '');
+    public archive(id: string, props: BaseArchiveProps): Archive {
+        return new Archive(this, id, {
+            sourceEventBus: this,
+            description: props.description || `Event Archive for ${this.eventBusName} Event Bus`,
+            eventPattern: props.eventPattern,
+            retention: props.retention,
+            archiveName: props.archiveName,
+            kmsKey: props.kmsKey,
+        });
     }
-  }
 
-  /**
-   * Adds a statement to the resource policy associated with this event bus.
-   * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
-   *
-   * Note that this does not work with imported event buss.
-   *
-   * @param statement The policy statement to add
-   */
-  public abstract addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult;
+    /**
+     * [disable-awslint:no-grants]
+     */
+    public grantPutEventsTo(grantee: iam.IGrantable, sid?: string): iam.Grant {
+        const actions = ['events:PutEvents'];
+        const resourceArns = [this.eventBusArn];
+        const options = {
+            grantee,
+            actions: actions,
+            resourceArns: [this.eventBusArn],
+        };
+        const grantResult = iam.Grant.addToPrincipal(options);
+
+        if (grantResult.success) {
+            return grantResult;
+        }
+
+        const requireSid = FeatureFlags.of(this).isEnabled(cxapi.EVENTBUS_POLICY_SID_REQUIRED);
+        if (requireSid) {
+            const statement = new iam.PolicyStatement({
+                actions: actions,
+                resources: resourceArns,
+                principals: [grantee!.grantPrincipal],
+                sid: sid,
+            });
+
+            return iam.Grant.addStatementToResourcePolicy({ ...options, statement, resource: this });
+        } else {
+            Annotations.of(this).addWarningV2(
+                '@aws-cdk/aws-events:eventBusServicePrincipalGrant',
+                'Unable to grant PutEvents to service principal: Statement ID is required for EventBus resource policies. Either provide a \'sid\' parameter or enable the \'@aws-cdk/aws-events:requireEventBusPolicySid\' feature flag.',
+            );
+            return iam.Grant.drop(grantee, '');
+        }
+    }
+
+    /**
+     * Adds a statement to the resource policy associated with this event bus.
+     * A resource policy will be automatically created upon the first call to `addToResourcePolicy`.
+     *
+     * Note that this does not work with imported event buss.
+     *
+     * @param statement The policy statement to add
+     */
+    public abstract addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult;
 }
 
 /**
@@ -312,315 +313,315 @@ abstract class EventBusBase extends Resource implements IEventBus, iam.IResource
  */
 @propertyInjectable
 export class EventBus extends EventBusBase {
-  /**
-   * Uniquely identifies this class.
-   */
-  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBus';
-
-  /**
-   * Import an existing event bus resource
-   * @param scope Parent construct
-   * @param id Construct ID
-   * @param eventBusArn ARN of imported event bus
-   */
-  public static fromEventBusArn(scope: Construct, id: string, eventBusArn: string): IEventBus {
-    const parts = Stack.of(scope).splitArn(eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
-
-    return new ImportedEventBus(scope, id, {
-      eventBusArn: eventBusArn,
-      eventBusName: parts.resourceName || '',
-      eventBusPolicy: '',
-    });
-  }
-
-  /**
-   * Import an existing event bus resource
-   * @param scope Parent construct
-   * @param id Construct ID
-   * @param eventBusName Name of imported event bus
-   */
-  public static fromEventBusName(scope: Construct, id: string, eventBusName: string): IEventBus {
-    const eventBusArn = Stack.of(scope).formatArn({
-      resource: 'event-bus',
-      service: 'events',
-      resourceName: eventBusName,
-    });
-
-    return EventBus.fromEventBusAttributes(scope, id, {
-      eventBusName: eventBusName,
-      eventBusArn: eventBusArn,
-      eventBusPolicy: '',
-    });
-  }
-
-  /**
-   * Import an existing event bus resource
-   * @param scope Parent construct
-   * @param id Construct ID
-   * @param attrs Imported event bus properties
-   */
-  public static fromEventBusAttributes(scope: Construct, id: string, attrs: EventBusAttributes): IEventBus {
-    return new ImportedEventBus(scope, id, attrs);
-  }
-
-  /**
-   * Permits an IAM Principal to send custom events to EventBridge
-   * so that they can be matched to rules.
-   *
-   * @param grantee The principal (no-op if undefined)
-   * @deprecated use grantAllPutEvents instead
-   */
-  public static grantPutEvents(grantee: iam.IGrantable): iam.Grant {
-    // It's currently not possible to restrict PutEvents to specific resources.
-    // See https://docs.aws.amazon.com/eventbridge/latest/userguide/permissions-reference-eventbridge.html
-    return iam.Grant.addToPrincipal({
-      grantee,
-      actions: ['events:PutEvents'],
-      resourceArns: ['*'],
-    });
-  }
-
-  /**
-   * Permits an IAM Principal to send custom events to EventBridge
-   * so that they can be matched to rules.
-   *
-   * @param grantee The principal (no-op if undefined)
-   */
-  public static grantAllPutEvents(grantee: iam.IGrantable): iam.Grant {
-    // FIXME Doing this hack because this method is static, and we don't have an actual instance of
-    //  IEventBusRef to use here for the grants.
-    const eventBus = EventBus.fromEventBusName(new Stack(), 'dummy', 'dummy');
-    return EventBusGrants.fromEventBus(eventBus).allPutEvents(grantee);
-  }
-
-  private static eventBusProps(defaultEventBusName: string, props: EventBusProps = {}) {
-    const { eventBusName, eventSourceName } = props;
-    const eventBusNameRegex = /^[\/\.\-_A-Za-z0-9]{1,256}$/;
-
-    if (eventBusName !== undefined && eventSourceName !== undefined) {
-      throw new UnscopedValidationError(
-        lit`EventBusNameAndEventSourceNameCannotBothBeProvided`,
-        '\'eventBusName\' and \'eventSourceName\' cannot both be provided',
-      );
-    }
-
-    if (eventBusName !== undefined) {
-      if (!Token.isUnresolved(eventBusName)) {
-        if (eventBusName === 'default') {
-          throw new UnscopedValidationError(
-            lit`EventBusNameMustNotBeDefault`,
-            '\'eventBusName\' must not be \'default\'',
-          );
-        } else if (eventBusName.indexOf('/') > -1) {
-          throw new UnscopedValidationError(
-            lit`EventBusNameMustNotContainSlash`,
-            '\'eventBusName\' must not contain \'/\'',
-          );
-        } else if (!eventBusNameRegex.test(eventBusName)) {
-          throw new UnscopedValidationError(
-            lit`EventBusNameMustSatisfyRegex`,
-            `'eventBusName' must satisfy: ${eventBusNameRegex}`,
-          );
-        }
-      }
-      return { eventBusName };
-    }
-
-    if (eventSourceName !== undefined) {
-      if (!Token.isUnresolved(eventSourceName)) {
-        // Ex: aws.partner/PartnerName/acct1/repo1
-        const eventSourceNameRegex = /^aws\.partner(\/[\.\-_A-Za-z0-9]+){2,}$/;
-        if (!eventSourceNameRegex.test(eventSourceName)) {
-          throw new UnscopedValidationError(
-            lit`EventSourceNameMustSatisfyRegex`,
-            `'eventSourceName' must satisfy: ${eventSourceNameRegex}`,
-          );
-        } else if (!eventBusNameRegex.test(eventSourceName)) {
-          throw new UnscopedValidationError(
-            lit`EventSourceNameMustSatisfyBusNameRegex`,
-            `'eventSourceName' must satisfy: ${eventBusNameRegex}`,
-          );
-        }
-      }
-      return { eventBusName: eventSourceName, eventSourceName };
-    }
-
-    return { eventBusName: defaultEventBusName };
-  }
-
-  /**
-   * The CfnEventBus resource
-   */
-  private readonly _resource: CfnEventBus;
-
-  /**
-   * The physical ID of this event bus resource
-   */
-  @memoizedGetter
-  public get eventBusName(): string {
-    return this.getResourceNameAttribute(this._resource.ref);
-  }
-
-  /**
-   * The ARN of the event bus, such as:
-   * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
-   */
-  @memoizedGetter
-  public get eventBusArn(): string {
-    return this.getResourceArnAttribute(this._resource.attrArn, {
-      service: 'events',
-      resource: 'event-bus',
-      resourceName: this._resource.name,
-    });
-  }
-
-  /**
-   * The policy for the event bus in JSON form.
-   */
-  @memoizedGetter
-  public get eventBusPolicy(): string {
-    return this._resource.attrPolicy;
-  }
-
-  /**
-   * The name of the partner event source
-   */
-  @memoizedGetter
-  public get eventSourceName(): string | undefined {
-    return this._resource.eventSourceName;
-  }
-
-  constructor(scope: Construct, id: string, props?: EventBusProps) {
-    const { eventBusName, eventSourceName } = EventBus.eventBusProps(
-      Lazy.string({ produce: () => Names.uniqueId(this) }),
-      props,
-    );
-
-    super(scope, id, { physicalName: eventBusName });
-    // Enhanced CDK Analytics Telemetry
-    addConstructMetadata(this, props);
-
-    if (props?.description && !Token.isUnresolved(props.description) && props.description.length > 512) {
-      throw new ValidationError(lit`DescriptionMustBeLessThanOrEqualTo512Characters`, `description must be less than or equal to 512 characters, got ${props.description.length}`, this);
-    }
-
-    this._resource = new CfnEventBus(this, 'Resource', {
-      name: this.physicalName,
-      eventSourceName,
-      deadLetterConfig: props?.deadLetterQueue ? {
-        arn: props.deadLetterQueue.queueArn,
-      } : undefined,
-      description: props?.description,
-      kmsKeyIdentifier: props?.kmsKey?.keyArn,
-      logConfig: props?.logConfig,
-    });
+    /**
+     * Uniquely identifies this class.
+     */
+    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBus';
 
     /**
-     * Allow EventBridge to use customer managed key
-     *
-     * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-key-policy.html#eb-encryption-key-policy-bus
+     * Import an existing event bus resource
+     * @param scope Parent construct
+     * @param id Construct ID
+     * @param eventBusArn ARN of imported event bus
      */
-    if (props?.kmsKey) {
-      props?.kmsKey.addToResourcePolicy(new iam.PolicyStatement({
-        resources: ['*'],
-        actions: ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:DescribeKey'],
-        principals: [new iam.ServicePrincipal('events.amazonaws.com')],
-        conditions: {
-          StringEquals: {
-            'aws:SourceAccount': this.stack.account,
-            'aws:SourceArn': Stack.of(this).formatArn({
-              service: 'events',
-              resource: 'event-bus',
-              resourceName: eventBusName,
-            }),
-            'kms:EncryptionContext:aws:events:event-bus:arn': Stack.of(this).formatArn({
-              service: 'events',
-              resource: 'event-bus',
-              resourceName: eventBusName,
-            }),
-          },
-        },
-      }));
-    }
-  }
+    public static fromEventBusArn(scope: Construct, id: string, eventBusArn: string): IEventBus {
+        const parts = Stack.of(scope).splitArn(eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
 
-  /**
-   * Adds a statement to the IAM resource policy associated with this event bus.
-   */
-  @MethodMetadata()
-  public addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
-    // If no sid is provided, generate one based on the event bus id
-    if (statement.sid == null) {
-      throw new ValidationError(lit`EventBusPolicyStatementsMustHaveSid`, 'Event Bus policy statements must have a sid', this);
+        return new ImportedEventBus(scope, id, {
+            eventBusArn: eventBusArn,
+            eventBusName: parts.resourceName || '',
+            eventBusPolicy: '',
+        });
     }
 
-    // In order to generate new statementIDs for the change in https://github.com/aws/aws-cdk/pull/27340
-    const statementId = `cdk-${statement.sid}`.slice(0, 64);
-    statement.sid = statementId;
-    const policy = new EventBusPolicy(this, statementId, {
-      eventBus: this,
-      statement: statement.toJSON(),
-      statementId,
-    });
+    /**
+     * Import an existing event bus resource
+     * @param scope Parent construct
+     * @param id Construct ID
+     * @param eventBusName Name of imported event bus
+     */
+    public static fromEventBusName(scope: Construct, id: string, eventBusName: string): IEventBus {
+        const eventBusArn = Stack.of(scope).formatArn({
+            resource: 'event-bus',
+            service: 'events',
+            resourceName: eventBusName,
+        });
 
-    return { statementAdded: true, policyDependable: policy };
-  }
+        return EventBus.fromEventBusAttributes(scope, id, {
+            eventBusName: eventBusName,
+            eventBusArn: eventBusArn,
+            eventBusPolicy: '',
+        });
+    }
+
+    /**
+     * Import an existing event bus resource
+     * @param scope Parent construct
+     * @param id Construct ID
+     * @param attrs Imported event bus properties
+     */
+    public static fromEventBusAttributes(scope: Construct, id: string, attrs: EventBusAttributes): IEventBus {
+        return new ImportedEventBus(scope, id, attrs);
+    }
+
+    /**
+     * Permits an IAM Principal to send custom events to EventBridge
+     * so that they can be matched to rules.
+     *
+     * @param grantee The principal (no-op if undefined)
+     * @deprecated use grantAllPutEvents instead
+     */
+    public static grantPutEvents(grantee: iam.IGrantable): iam.Grant {
+        // It's currently not possible to restrict PutEvents to specific resources.
+        // See https://docs.aws.amazon.com/eventbridge/latest/userguide/permissions-reference-eventbridge.html
+        return iam.Grant.addToPrincipal({
+            grantee,
+            actions: ['events:PutEvents'],
+            resourceArns: ['*'],
+        });
+    }
+
+    /**
+     * Permits an IAM Principal to send custom events to EventBridge
+     * so that they can be matched to rules.
+     *
+     * @param grantee The principal (no-op if undefined)
+     */
+    public static grantAllPutEvents(grantee: iam.IGrantable): iam.Grant {
+        // FIXME Doing this hack because this method is static, and we don't have an actual instance of
+        //  IEventBusRef to use here for the grants.
+        const eventBus = EventBus.fromEventBusName(new Stack(), 'dummy', 'dummy');
+        return EventBusGrants.fromEventBus(eventBus).allPutEvents(grantee);
+    }
+
+    private static eventBusProps(defaultEventBusName: string, props: EventBusProps = {}) {
+        const { eventBusName, eventSourceName } = props;
+        const eventBusNameRegex = /^[\/\.\-_A-Za-z0-9]{1,256}$/;
+
+        if (eventBusName !== undefined && eventSourceName !== undefined) {
+            throw new UnscopedValidationError(
+                lit`EventBusNameAndEventSourceNameCannotBothBeProvided`,
+                '\'eventBusName\' and \'eventSourceName\' cannot both be provided',
+            );
+        }
+
+        if (eventBusName !== undefined) {
+            if (!Token.isUnresolved(eventBusName)) {
+                if (eventBusName === 'default') {
+                    throw new UnscopedValidationError(
+                        lit`EventBusNameMustNotBeDefault`,
+                        '\'eventBusName\' must not be \'default\'',
+                    );
+                } else if (eventBusName.indexOf('/') > -1) {
+                    throw new UnscopedValidationError(
+                        lit`EventBusNameMustNotContainSlash`,
+                        '\'eventBusName\' must not contain \'/\'',
+                    );
+                } else if (!eventBusNameRegex.test(eventBusName)) {
+                    throw new UnscopedValidationError(
+                        lit`EventBusNameMustSatisfyRegex`,
+                        `'eventBusName' must satisfy: ${eventBusNameRegex}`,
+                    );
+                }
+            }
+            return { eventBusName };
+        }
+
+        if (eventSourceName !== undefined) {
+            if (!Token.isUnresolved(eventSourceName)) {
+                // Ex: aws.partner/PartnerName/acct1/repo1
+                const eventSourceNameRegex = /^aws\.partner(\/[\.\-_A-Za-z0-9]+){2,}$/;
+                if (!eventSourceNameRegex.test(eventSourceName)) {
+                    throw new UnscopedValidationError(
+                        lit`EventSourceNameMustSatisfyRegex`,
+                        `'eventSourceName' must satisfy: ${eventSourceNameRegex}`,
+                    );
+                } else if (!eventBusNameRegex.test(eventSourceName)) {
+                    throw new UnscopedValidationError(
+                        lit`EventSourceNameMustSatisfyBusNameRegex`,
+                        `'eventSourceName' must satisfy: ${eventBusNameRegex}`,
+                    );
+                }
+            }
+            return { eventBusName: eventSourceName, eventSourceName };
+        }
+
+        return { eventBusName: defaultEventBusName };
+    }
+
+    /**
+     * The CfnEventBus resource
+     */
+    private readonly _resource: CfnEventBus;
+
+    /**
+     * The physical ID of this event bus resource
+     */
+    @memoizedGetter
+    public get eventBusName(): string {
+        return this.getResourceNameAttribute(this._resource.ref);
+    }
+
+    /**
+     * The ARN of the event bus, such as:
+     * arn:aws:events:us-east-2:123456789012:event-bus/aws.partner/PartnerName/acct1/repo1.
+     */
+    @memoizedGetter
+    public get eventBusArn(): string {
+        return this.getResourceArnAttribute(this._resource.attrArn, {
+            service: 'events',
+            resource: 'event-bus',
+            resourceName: this._resource.name,
+        });
+    }
+
+    /**
+     * The policy for the event bus in JSON form.
+     */
+    @memoizedGetter
+    public get eventBusPolicy(): string {
+        return this._resource.attrPolicy;
+    }
+
+    /**
+     * The name of the partner event source
+     */
+    @memoizedGetter
+    public get eventSourceName(): string | undefined {
+        return this._resource.eventSourceName;
+    }
+
+    constructor(scope: Construct, id: string, props?: EventBusProps) {
+        const { eventBusName, eventSourceName } = EventBus.eventBusProps(
+            Lazy.string({ produce: () => Names.uniqueId(this) }),
+            props,
+        );
+
+        super(scope, id, { physicalName: eventBusName });
+        // Enhanced CDK Analytics Telemetry
+        addConstructMetadata(this, props);
+
+        if (props?.description && !Token.isUnresolved(props.description) && props.description.length > 512) {
+            throw new ValidationError(lit`DescriptionMustBeLessThanOrEqualTo512Characters`, `description must be less than or equal to 512 characters, got ${props.description.length}`, this);
+        }
+
+        this._resource = new CfnEventBus(this, 'Resource', {
+            name: this.physicalName,
+            eventSourceName,
+            deadLetterConfig: props?.deadLetterQueue ? {
+                arn: props.deadLetterQueue.queueArn,
+            } : undefined,
+            description: props?.description,
+            kmsKeyIdentifier: props?.kmsKey?.keyArn,
+            logConfig: props?.logConfig,
+        });
+
+        /**
+         * Allow EventBridge to use customer managed key
+         *
+         * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-encryption-key-policy.html#eb-encryption-key-policy-bus
+         */
+        if (props?.kmsKey) {
+            props?.kmsKey.addToResourcePolicy(new iam.PolicyStatement({
+                resources: ['*'],
+                actions: ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:DescribeKey'],
+                principals: [new iam.ServicePrincipal('events.amazonaws.com')],
+                conditions: {
+                    StringEquals: {
+                        'aws:SourceAccount': this.stack.account,
+                        'aws:SourceArn': Stack.of(this).formatArn({
+                            service: 'events',
+                            resource: 'event-bus',
+                            resourceName: eventBusName,
+                        }),
+                        'kms:EncryptionContext:aws:events:event-bus:arn': Stack.of(this).formatArn({
+                            service: 'events',
+                            resource: 'event-bus',
+                            resourceName: eventBusName,
+                        }),
+                    },
+                },
+            }));
+        }
+    }
+
+    /**
+     * Adds a statement to the IAM resource policy associated with this event bus.
+     */
+    @MethodMetadata()
+    public addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
+        // If no sid is provided, generate one based on the event bus id
+        if (statement.sid == null) {
+            throw new ValidationError(lit`EventBusPolicyStatementsMustHaveSid`, 'Event Bus policy statements must have a sid', this);
+        }
+
+        // In order to generate new statementIDs for the change in https://github.com/aws/aws-cdk/pull/27340
+        const statementId = `cdk-${statement.sid}`.slice(0, 64);
+        statement.sid = statementId;
+        const policy = new EventBusPolicy(this, statementId, {
+            eventBus: this,
+            statement: statement.toJSON(),
+            statementId,
+        });
+
+        return { statementAdded: true, policyDependable: policy };
+    }
 }
 
 @propertyInjectable
 class ImportedEventBus extends EventBusBase {
-  /** Uniquely identifies this class. */
-  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.ImportedEventBus';
-  public readonly eventBusArn: string;
-  public readonly eventBusName: string;
-  public readonly eventBusPolicy: string;
-  public readonly eventSourceName?: string;
+    /** Uniquely identifies this class. */
+    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.ImportedEventBus';
+    public readonly eventBusArn: string;
+    public readonly eventBusName: string;
+    public readonly eventBusPolicy: string;
+    public readonly eventSourceName?: string;
 
-  constructor(scope: Construct, id: string, attrs: EventBusAttributes) {
-    const arnParts = Stack.of(scope).splitArn(attrs.eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
-    super(scope, id, {
-      account: arnParts.account,
-      region: arnParts.region,
-    });
-    // Enhanced CDK Analytics Telemetry
-    addConstructMetadata(this, attrs);
+    constructor(scope: Construct, id: string, attrs: EventBusAttributes) {
+        const arnParts = Stack.of(scope).splitArn(attrs.eventBusArn, ArnFormat.SLASH_RESOURCE_NAME);
+        super(scope, id, {
+            account: arnParts.account,
+            region: arnParts.region,
+        });
+        // Enhanced CDK Analytics Telemetry
+        addConstructMetadata(this, attrs);
 
-    this.eventBusArn = attrs.eventBusArn;
-    this.eventBusName = attrs.eventBusName;
-    this.eventBusPolicy = attrs.eventBusPolicy;
-    this.eventSourceName = attrs.eventSourceName;
-  }
+        this.eventBusArn = attrs.eventBusArn;
+        this.eventBusName = attrs.eventBusName;
+        this.eventBusPolicy = attrs.eventBusPolicy;
+        this.eventSourceName = attrs.eventSourceName;
+    }
 
-  @MethodMetadata()
-  public addToResourcePolicy(_statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
-    // Warn the user
-    Annotations.of(this).addWarningV2(
-      '@aws-cdk/aws-events:eventBusAddToResourcePolicy',
-      `Unable to add necessary permissions to imported target event bus: ${this.eventBusArn}`,
-    );
-    return { statementAdded: false };
-  }
+    @MethodMetadata()
+    public addToResourcePolicy(_statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
+        // Warn the user
+        Annotations.of(this).addWarningV2(
+            '@aws-cdk/aws-events:eventBusAddToResourcePolicy',
+            `Unable to add necessary permissions to imported target event bus: ${this.eventBusArn}`,
+        );
+        return { statementAdded: false };
+    }
 }
 
 /**
  * Properties to associate Event Buses with a policy
  */
 export interface EventBusPolicyProps {
-  /**
-   * The event bus to which the policy applies
-   */
-  readonly eventBus: IEventBus;
+    /**
+     * The event bus to which the policy applies
+     */
+    readonly eventBus: IEventBus;
 
-  /**
-   * An IAM Policy Statement to apply to the Event Bus
-   */
-  readonly statement: iam.PolicyStatement;
+    /**
+     * An IAM Policy Statement to apply to the Event Bus
+     */
+    readonly statement: iam.PolicyStatement;
 
-  /**
-   * An identifier string for the external account that
-   * you are granting permissions to.
-   */
-  readonly statementId: string;
+    /**
+     * An identifier string for the external account that
+     * you are granting permissions to.
+     */
+    readonly statementId: string;
 }
 
 /**
@@ -639,18 +640,18 @@ export interface EventBusPolicyProps {
  */
 @propertyInjectable
 export class EventBusPolicy extends Resource {
-  /** Uniquely identifies this class. */
-  public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBusPolicy';
+    /** Uniquely identifies this class. */
+    public static readonly PROPERTY_INJECTION_ID: string = 'aws-cdk-lib.aws-events.EventBusPolicy';
 
-  constructor(scope: Construct, id: string, props: EventBusPolicyProps) {
-    super(scope, id);
-    // Enhanced CDK Analytics Telemetry
-    addConstructMetadata(this, props);
+    constructor(scope: Construct, id: string, props: EventBusPolicyProps) {
+        super(scope, id);
+        // Enhanced CDK Analytics Telemetry
+        addConstructMetadata(this, props);
 
-    new CfnEventBusPolicy(this, 'Resource', {
-      statementId: props.statementId!,
-      statement: props.statement,
-      eventBusName: props.eventBus.eventBusName,
-    });
-  }
+        new CfnEventBusPolicy(this, 'Resource', {
+            statementId: props.statementId!,
+            statement: props.statement,
+            eventBusName: props.eventBus.eventBusName,
+        });
+    }
 }

--- a/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
@@ -7,796 +7,818 @@ import { Aws, CfnResource, Stack, Arn, App, PhysicalName, CfnOutput } from '../.
 import { EventBus, IncludeDetail, Level } from '../lib';
 
 describe('event bus', () => {
-  test('default event bus', () => {
-    // GIVEN
-    const stack = new Stack();
+    test('default event bus', () => {
+        // GIVEN
+        const stack = new Stack();
 
-    // WHEN
-    new EventBus(stack, 'Bus');
+        // WHEN
+        new EventBus(stack, 'Bus');
 
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'Bus',
-    });
-  });
-
-  test('default event bus with logConfig', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    new EventBus(stack, 'Bus', {
-      logConfig: {
-        includeDetail: IncludeDetail.FULL,
-        level: Level.TRACE,
-      },
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'Bus',
+        });
     });
 
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'Bus',
-      LogConfig: {
-        IncludeDetail: 'FULL',
-        Level: 'TRACE',
-      },
-    });
-  });
-
-  test('default event bus with empty props object', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    new EventBus(stack, 'Bus', {});
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'Bus',
-    });
-  });
-
-  test('named event bus', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    new EventBus(stack, 'Bus', {
-      eventBusName: 'myEventBus',
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'myEventBus',
-    });
-  });
-
-  test('event bus with description', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    new EventBus(stack, 'myEventBus', {
-      description: 'myEventBusDescription',
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Description: 'myEventBusDescription',
-    });
-  });
-
-  test('partner event bus', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    new EventBus(stack, 'Bus', {
-      eventSourceName: 'aws.partner/PartnerName/acct1/repo1',
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'aws.partner/PartnerName/acct1/repo1',
-      EventSourceName: 'aws.partner/PartnerName/acct1/repo1',
-    });
-  });
-
-  test('imported event bus', () => {
-    const stack = new Stack();
-
-    const eventBus = new EventBus(stack, 'Bus');
-
-    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
-
-    // WHEN
-    new CfnResource(stack, 'Res', {
-      type: 'Test::Resource',
-      properties: {
-        EventBusArn1: eventBus.eventBusArn,
-        EventBusArn2: importEB.eventBusArn,
-      },
-    });
-
-    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-      EventBusArn1: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-      EventBusArn2: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-    });
-  });
-
-  test('imported event bus from name', () => {
-    const stack = new Stack();
-
-    const eventBus = new EventBus(stack, 'Bus', { eventBusName: 'test-bus-to-import-by-name' });
-
-    const importEB = EventBus.fromEventBusName(stack, 'ImportBus', eventBus.eventBusName);
-
-    // WHEN
-    expect(stack.resolve(eventBus.eventBusName)).toEqual(stack.resolve(importEB.eventBusName));
-  });
-
-  test('same account imported event bus has right resource env', () => {
-    const stack = new Stack();
-
-    const eventBus = new EventBus(stack, 'Bus');
-
-    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
-
-    // WHEN
-    expect(stack.resolve(importEB.env.account)).toEqual({ 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
-    expect(stack.resolve(importEB.env.region)).toEqual({ 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
-  });
-
-  test('cross account imported event bus has right resource env', () => {
-    const stack = new Stack();
-
-    const arnParts = {
-      resource: 'bus',
-      service: 'events',
-      account: 'myAccount',
-      region: 'us-west-1',
-    };
-
-    const arn = Arn.format(arnParts, stack);
-
-    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', arn);
-
-    // WHEN
-    expect(importEB.env.account).toEqual(arnParts.account);
-    expect(importEB.env.region).toEqual(arnParts.region);
-  });
-
-  test('can get bus name', () => {
-    // GIVEN
-    const stack = new Stack();
-    const bus = new EventBus(stack, 'Bus', {
-      eventBusName: 'myEventBus',
-    });
-
-    // WHEN
-    new CfnResource(stack, 'Res', {
-      type: 'Test::Resource',
-      properties: {
-        EventBusName: bus.eventBusName,
-      },
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-      EventBusName: { Ref: 'BusEA82B648' },
-    });
-  });
-
-  test('can get bus arn', () => {
-    // GIVEN
-    const stack = new Stack();
-    const bus = new EventBus(stack, 'Bus', {
-      eventBusName: 'myEventBus',
-    });
-
-    // WHEN
-    new CfnResource(stack, 'Res', {
-      type: 'Test::Resource',
-      properties: {
-        EventBusArn: bus.eventBusArn,
-      },
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-      EventBusArn: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-    });
-  });
-
-  test('event bus name cannot be default', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventBusName: 'default',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventBusName' must not be 'default'/);
-  });
-
-  test('event bus name cannot contain slash', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventBusName: 'my/bus',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventBusName' must not contain '\/'/);
-  });
-
-  test('event bus cannot have name and source name', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventBusName: 'myBus',
-      eventSourceName: 'myBus',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventBusName' and 'eventSourceName' cannot both be provided/);
-  });
-
-  test('event bus name cannot be empty string', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventBusName: '',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventBusName' must satisfy: /);
-  });
-
-  test('does not throw if eventBusName is a token', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN / THEN
-    expect(() => new EventBus(stack, 'EventBus', {
-      eventBusName: Aws.STACK_NAME,
-    })).not.toThrow();
-  });
-
-  test('event bus source name must follow pattern', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventSourceName: 'invalid-partner',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventSourceName' must satisfy: \/\^aws/);
-  });
-
-  test('does not throw if eventSourceName is a token', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN / THEN
-    expect(() => new EventBus(stack, 'EventBus', {
-      eventSourceName: Aws.STACK_NAME,
-    })).not.toThrow();
-  });
-
-  test('event bus source name cannot be empty string', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const createInvalidBus = () => new EventBus(stack, 'Bus', {
-      eventSourceName: '',
-    });
-
-    // THEN
-    expect(() => {
-      createInvalidBus();
-    }).toThrow(/'eventSourceName' must satisfy: /);
-  });
-
-  test('event bus description cannot be too long', () => {
-    // GIVEN
-    const stack = new Stack();
-    const tooLongDescription = 'a'.repeat(513);
-
-    // WHEN / THEN
-    expect(() => {
-      new EventBus(stack, 'EventBusWithTooLongDescription', {
-        description: tooLongDescription,
-      });
-    }).toThrow('description must be less than or equal to 512 characters, got 513');
-  });
-
-  testDeprecated('can grant PutEvents', () => {
-    // GIVEN
-    const stack = new Stack();
-    const role = new iam.Role(stack, 'Role', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-    });
-
-    // WHEN
-    EventBus.grantPutEvents(role);
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-      PolicyDocument: {
-        Statement: [
-          {
-            Action: 'events:PutEvents',
-            Effect: 'Allow',
-            Resource: '*',
-          },
-        ],
-        Version: '2012-10-17',
-      },
-      Roles: [
-        {
-          Ref: 'Role1ABCC5F0',
-        },
-      ],
-    });
-  });
-
-  test('can grant PutEvents using grantAllPutEvents', () => {
-    // GIVEN
-    const stack = new Stack();
-    const role = new iam.Role(stack, 'Role', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-    });
-
-    // WHEN
-    EventBus.grantAllPutEvents(role);
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-      PolicyDocument: {
-        Statement: [
-          {
-            Action: 'events:PutEvents',
-            Effect: 'Allow',
-            Resource: '*',
-          },
-        ],
-        Version: '2012-10-17',
-      },
-      Roles: [
-        {
-          Ref: 'Role1ABCC5F0',
-        },
-      ],
-    });
-  });
-
-  test('can grant PutEvents to a specific event bus', () => {
-    // GIVEN
-    const stack = new Stack();
-    const role = new iam.Role(stack, 'Role', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-    });
-
-    const eventBus = new EventBus(stack, 'EventBus');
-
-    // WHEN
-    eventBus.grantPutEventsTo(role);
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-      PolicyDocument: {
-        Statement: [
-          {
-            Action: 'events:PutEvents',
-            Effect: 'Allow',
-            Resource: {
-              'Fn::GetAtt': [
-                'EventBus7B8748AA',
-                'Arn',
-              ],
+    test('default event bus with logConfig', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        new EventBus(stack, 'Bus', {
+            logConfig: {
+                includeDetail: IncludeDetail.FULL,
+                level: Level.TRACE,
             },
-          },
-        ],
-        Version: '2012-10-17',
-      },
-      Roles: [
-        {
-          Ref: 'Role1ABCC5F0',
-        },
-      ],
-    });
-  });
+        });
 
-  test('can archive events', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const event = new EventBus(stack, 'Bus');
-
-    event.archive('MyArchive', {
-      eventPattern: {
-        account: [stack.account],
-      },
-      archiveName: 'MyArchive',
-    });
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'Bus',
-    });
-
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
-      SourceArn: {
-        'Fn::GetAtt': [
-          'BusEA82B648',
-          'Arn',
-        ],
-      },
-      Description: {
-        'Fn::Join': [
-          '',
-          [
-            'Event Archive for ',
-            {
-              Ref: 'BusEA82B648',
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'Bus',
+            LogConfig: {
+                IncludeDetail: 'FULL',
+                Level: 'TRACE',
             },
-            ' Event Bus',
-          ],
-        ],
-      },
-      EventPattern: {
-        account: [
-          {
-            Ref: 'AWS::AccountId',
-          },
-        ],
-      },
-      RetentionDays: 0,
-      ArchiveName: 'MyArchive',
-    });
-  });
-
-  test('can archive events from an imported EventBus', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    const bus = new EventBus(stack, 'Bus');
-
-    const importedBus = EventBus.fromEventBusArn(stack, 'ImportedBus', bus.eventBusArn);
-
-    importedBus.archive('MyArchive', {
-      eventPattern: {
-        account: [stack.account],
-      },
-      archiveName: 'MyArchive',
+        });
     });
 
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'Bus',
+    test('default event bus with empty props object', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        new EventBus(stack, 'Bus', {});
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'Bus',
+        });
     });
 
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
-      SourceArn: {
-        'Fn::GetAtt': [
-          'BusEA82B648',
-          'Arn',
-        ],
-      },
-      Description: {
-        'Fn::Join': [
-          '',
-          [
-            'Event Archive for ',
-            {
-              'Fn::Select': [
-                1,
-                {
-                  'Fn::Split': [
-                    '/',
-                    {
-                      'Fn::Select': [
-                        5,
-                        {
-                          'Fn::Split': [
-                            ':',
-                            {
-                              'Fn::GetAtt': [
-                                'BusEA82B648',
-                                'Arn',
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
+    test('named event bus', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        new EventBus(stack, 'Bus', {
+            eventBusName: 'myEventBus',
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'myEventBus',
+        });
+    });
+
+    test('event bus with description', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        new EventBus(stack, 'myEventBus', {
+            description: 'myEventBusDescription',
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Description: 'myEventBusDescription',
+        });
+    });
+
+    test('partner event bus', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        new EventBus(stack, 'Bus', {
+            eventSourceName: 'aws.partner/PartnerName/acct1/repo1',
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'aws.partner/PartnerName/acct1/repo1',
+            EventSourceName: 'aws.partner/PartnerName/acct1/repo1',
+        });
+    });
+
+    test('imported event bus', () => {
+        const stack = new Stack();
+
+        const eventBus = new EventBus(stack, 'Bus');
+
+        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
+
+        // WHEN
+        new CfnResource(stack, 'Res', {
+            type: 'Test::Resource',
+            properties: {
+                EventBusArn1: eventBus.eventBusArn,
+                EventBusArn2: importEB.eventBusArn,
             },
-            ' Event Bus',
-          ],
-        ],
-      },
-      EventPattern: {
-        account: [
-          {
-            Ref: 'AWS::AccountId',
-          },
-        ],
-      },
-      RetentionDays: 0,
-      ArchiveName: 'MyArchive',
-    });
-  });
+        });
 
-  test('cross account event bus uses generated physical name', () => {
-    // GIVEN
-    const app = new App();
-    const stack1 = new Stack(app, 'Stack1', {
-      env: {
-        account: '11111111111',
-        region: 'us-east-1',
-      },
-    });
-    const stack2 = new Stack(app, 'Stack2', {
-      env: {
-        account: '22222222222',
-        region: 'us-east-1',
-      },
+        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+            EventBusArn1: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+            EventBusArn2: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+        });
     });
 
-    // WHEN
-    const bus1 = new EventBus(stack1, 'Bus', {
-      eventBusName: PhysicalName.GENERATE_IF_NEEDED,
+    test('imported event bus from name', () => {
+        const stack = new Stack();
+
+        const eventBus = new EventBus(stack, 'Bus', { eventBusName: 'test-bus-to-import-by-name' });
+
+        const importEB = EventBus.fromEventBusName(stack, 'ImportBus', eventBus.eventBusName);
+
+        // WHEN
+        expect(stack.resolve(eventBus.eventBusName)).toEqual(stack.resolve(importEB.eventBusName));
     });
 
-    new CfnOutput(stack2, 'BusName', { value: bus1.eventBusName });
+    test('same account imported event bus has right resource env', () => {
+        const stack = new Stack();
 
-    // THEN
-    Template.fromStack(stack1).hasResourceProperties('AWS::Events::EventBus', {
-      Name: 'stack1stack1busca19bdf8ab2e51b62a5a',
-    });
-  });
+        const eventBus = new EventBus(stack, 'Bus');
 
-  test('can add one event bus policy', () => {
-    // GIVEN
-    const app = new App();
-    const stack = new Stack(app, 'Stack');
-    const bus = new EventBus(stack, 'Bus');
+        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
 
-    // WHEN
-    bus.addToResourcePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.AccountPrincipal('111111111111111')],
-      actions: ['events:PutEvents'],
-      sid: '123',
-      resources: [bus.eventBusArn],
-    }));
-
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBusPolicy', {
-      StatementId: 'cdk-123',
-      EventBusName: {
-        Ref: 'BusEA82B648',
-      },
-      Statement: {
-        Action: 'events:PutEvents',
-        Effect: 'Allow',
-        Principal: {
-          AWS: {
-            'Fn::Join': [
-              '',
-              [
-                'arn:',
-                {
-                  Ref: 'AWS::Partition',
-                },
-                ':iam::111111111111111:root',
-              ],
-            ],
-          },
-        },
-        Sid: 'cdk-123',
-        Resource: {
-          'Fn::GetAtt': [
-            'BusEA82B648',
-            'Arn',
-          ],
-        },
-      },
-    });
-  });
-
-  test('can add more than one event bus policy', () => {
-    // GIVEN
-    const app = new App();
-    const stack = new Stack(app, 'Stack');
-    const bus = new EventBus(stack, 'Bus');
-
-    const statement1 = new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ArnPrincipal('arn')],
-      actions: ['events:PutEvents'],
-      sid: 'statement1',
-      resources: [bus.eventBusArn],
+        // WHEN
+        expect(stack.resolve(importEB.env.account)).toEqual({ 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
+        expect(stack.resolve(importEB.env.region)).toEqual({ 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
     });
 
-    const statement2 = new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ArnPrincipal('arn')],
-      actions: ['events:DeleteRule'],
-      sid: 'statement2',
-      resources: [bus.eventBusArn],
+    test('cross account imported event bus has right resource env', () => {
+        const stack = new Stack();
+
+        const arnParts = {
+            resource: 'bus',
+            service: 'events',
+            account: 'myAccount',
+            region: 'us-west-1',
+        };
+
+        const arn = Arn.format(arnParts, stack);
+
+        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', arn);
+
+        // WHEN
+        expect(importEB.env.account).toEqual(arnParts.account);
+        expect(importEB.env.region).toEqual(arnParts.region);
     });
 
-    // WHEN
-    const add1 = bus.addToResourcePolicy(statement1);
-    const add2 = bus.addToResourcePolicy(statement2);
+    test('can get bus name', () => {
+        // GIVEN
+        const stack = new Stack();
+        const bus = new EventBus(stack, 'Bus', {
+            eventBusName: 'myEventBus',
+        });
 
-    // THEN
-    expect(add1.statementAdded).toBe(true);
-    expect(add2.statementAdded).toBe(true);
-    Template.fromStack(stack).resourceCountIs('AWS::Events::EventBusPolicy', 2);
-  });
+        // WHEN
+        new CfnResource(stack, 'Res', {
+            type: 'Test::Resource',
+            properties: {
+                EventBusName: bus.eventBusName,
+            },
+        });
 
-  test('Event Bus policy statements must have a sid', () => {
-    // GIVEN
-    const app = new App();
-    const stack = new Stack(app, 'Stack');
-    const bus = new EventBus(stack, 'Bus');
-
-    // THEN
-    expect(() => bus.addToResourcePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ArnPrincipal('arn')],
-      actions: ['events:PutEvents'],
-    }))).toThrow('Event Bus policy statements must have a sid');
-  });
-
-  test('set dead letter queue', () => {
-    const app = new App();
-    const stack = new Stack(app, 'Stack');
-    const dlq = new sqs.Queue(stack, 'DLQ');
-    new EventBus(stack, 'Bus', {
-      deadLetterQueue: dlq,
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+            EventBusName: { Ref: 'BusEA82B648' },
+        });
     });
 
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      DeadLetterConfig: {
-        Arn: {
-          'Fn::GetAtt': ['DLQ581697C4', 'Arn'],
-        },
-      },
-    });
-  });
-  test('Event Bus with a customer managed key', () => {
-    // GIVEN
-    const app = new App();
-    const stack = new Stack(app, 'Stack');
-    const key = new kms.Key(stack, 'Key');
+    test('can get bus arn', () => {
+        // GIVEN
+        const stack = new Stack();
+        const bus = new EventBus(stack, 'Bus', {
+            eventBusName: 'myEventBus',
+        });
 
-    // WHEN
-    new EventBus(stack, 'Bus', {
-      kmsKey: key,
-    });
+        // WHEN
+        new CfnResource(stack, 'Res', {
+            type: 'Test::Resource',
+            properties: {
+                EventBusArn: bus.eventBusArn,
+            },
+        });
 
-    // THEN
-    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-      KmsKeyIdentifier: stack.resolve(key.keyArn),
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+            EventBusArn: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+        });
     });
 
-    Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
-      KeyPolicy: {
-        Statement: [
-          {
-            Action: 'kms:*',
-            Effect: 'Allow',
-            Principal: {
-              AWS: {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
+    test('event bus name cannot be default', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventBusName: 'default',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventBusName' must not be 'default'/);
+    });
+
+    test('event bus name cannot contain slash', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventBusName: 'my/bus',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventBusName' must not contain '\/'/);
+    });
+
+    test('event bus cannot have name and source name', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventBusName: 'myBus',
+            eventSourceName: 'myBus',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventBusName' and 'eventSourceName' cannot both be provided/);
+    });
+
+    test('event bus name cannot be empty string', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventBusName: '',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventBusName' must satisfy: /);
+    });
+
+    test('does not throw if eventBusName is a token', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN / THEN
+        expect(() => new EventBus(stack, 'EventBus', {
+            eventBusName: Aws.STACK_NAME,
+        })).not.toThrow();
+    });
+
+    test('event bus source name must follow pattern', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventSourceName: 'invalid-partner',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventSourceName' must satisfy: \/\^aws/);
+    });
+
+    test('does not throw if eventSourceName is a token', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN / THEN
+        expect(() => new EventBus(stack, 'EventBus', {
+            eventSourceName: Aws.STACK_NAME,
+        })).not.toThrow();
+    });
+
+    test('event bus source name cannot be empty string', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const createInvalidBus = () => new EventBus(stack, 'Bus', {
+            eventSourceName: '',
+        });
+
+        // THEN
+        expect(() => {
+            createInvalidBus();
+        }).toThrow(/'eventSourceName' must satisfy: /);
+    });
+
+    test('event bus description cannot be too long', () => {
+        // GIVEN
+        const stack = new Stack();
+        const tooLongDescription = 'a'.repeat(513);
+
+        // WHEN / THEN
+        expect(() => {
+            new EventBus(stack, 'EventBusWithTooLongDescription', {
+                description: tooLongDescription,
+            });
+        }).toThrow('description must be less than or equal to 512 characters, got 513');
+    });
+
+    testDeprecated('can grant PutEvents', () => {
+        // GIVEN
+        const stack = new Stack();
+        const role = new iam.Role(stack, 'Role', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+
+        // WHEN
+        EventBus.grantPutEvents(role);
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+            PolicyDocument: {
+                Statement: [
                     {
-                      Ref: 'AWS::Partition',
+                        Action: 'events:PutEvents',
+                        Effect: 'Allow',
+                        Resource: '*',
                     },
-                    ':iam::',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':root',
-                  ],
                 ],
-              },
+                Version: '2012-10-17',
             },
-            Resource: '*',
-          },
-          {
-            Action: [
-              'kms:Decrypt',
-              'kms:GenerateDataKey',
-              'kms:DescribeKey',
+            Roles: [
+                {
+                    Ref: 'Role1ABCC5F0',
+                },
             ],
-            Condition: {
-              StringEquals: {
-                'aws:SourceAccount': {
-                  Ref: 'AWS::AccountId',
-                },
-                'aws:SourceArn': {
-                  'Fn::Join': [
-                    '',
-                    [
-                      'arn:',
-                      {
-                        Ref: 'AWS::Partition',
-                      },
-                      ':events:',
-                      {
-                        Ref: 'AWS::Region',
-                      },
-                      ':',
-                      {
-                        Ref: 'AWS::AccountId',
-                      },
-                      ':event-bus/StackBusAA0A1E4B',
-                    ],
-                  ],
-                },
-                'kms:EncryptionContext:aws:events:event-bus:arn': {
-                  'Fn::Join': [
-                    '',
-                    [
-                      'arn:',
-                      {
-                        Ref: 'AWS::Partition',
-                      },
-                      ':events:',
-                      {
-                        Ref: 'AWS::Region',
-                      },
-                      ':',
-                      {
-                        Ref: 'AWS::AccountId',
-                      },
-                      ':event-bus/StackBusAA0A1E4B',
-                    ],
-                  ],
-                },
-              },
-            },
-            Effect: 'Allow',
-            Principal: {
-              Service: 'events.amazonaws.com',
-            },
-            Resource: '*',
-          },
-        ],
-        Version: '2012-10-17',
-      },
+        });
     });
-  });
+
+    test('can grant PutEvents using grantAllPutEvents', () => {
+        // GIVEN
+        const stack = new Stack();
+        const role = new iam.Role(stack, 'Role', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+
+        // WHEN
+        EventBus.grantAllPutEvents(role);
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+            PolicyDocument: {
+                Statement: [
+                    {
+                        Action: 'events:PutEvents',
+                        Effect: 'Allow',
+                        Resource: '*',
+                    },
+                ],
+                Version: '2012-10-17',
+            },
+            Roles: [
+                {
+                    Ref: 'Role1ABCC5F0',
+                },
+            ],
+        });
+    });
+
+    test('can grant PutEvents to a specific event bus', () => {
+        // GIVEN
+        const stack = new Stack();
+        const role = new iam.Role(stack, 'Role', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+
+        const eventBus = new EventBus(stack, 'EventBus');
+
+        // WHEN
+        eventBus.grantPutEventsTo(role);
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+            PolicyDocument: {
+                Statement: [
+                    {
+                        Action: 'events:PutEvents',
+                        Effect: 'Allow',
+                        Resource: {
+                            'Fn::GetAtt': [
+                                'EventBus7B8748AA',
+                                'Arn',
+                            ],
+                        },
+                    },
+                ],
+                Version: '2012-10-17',
+            },
+            Roles: [
+                {
+                    Ref: 'Role1ABCC5F0',
+                },
+            ],
+        });
+    });
+
+    test('can archive events', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const event = new EventBus(stack, 'Bus');
+
+        event.archive('MyArchive', {
+            eventPattern: {
+                account: [stack.account],
+            },
+            archiveName: 'MyArchive',
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'Bus',
+        });
+
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+            SourceArn: {
+                'Fn::GetAtt': [
+                    'BusEA82B648',
+                    'Arn',
+                ],
+            },
+            Description: {
+                'Fn::Join': [
+                    '',
+                    [
+                        'Event Archive for ',
+                        {
+                            Ref: 'BusEA82B648',
+                        },
+                        ' Event Bus',
+                    ],
+                ],
+            },
+            EventPattern: {
+                account: [
+                    {
+                        Ref: 'AWS::AccountId',
+                    },
+                ],
+            },
+            RetentionDays: 0,
+            ArchiveName: 'MyArchive',
+        });
+    });
+
+    test('can archive events from an imported EventBus', () => {
+        // GIVEN
+        const stack = new Stack();
+
+        // WHEN
+        const bus = new EventBus(stack, 'Bus');
+
+        const importedBus = EventBus.fromEventBusArn(stack, 'ImportedBus', bus.eventBusArn);
+
+        importedBus.archive('MyArchive', {
+            eventPattern: {
+                account: [stack.account],
+            },
+            archiveName: 'MyArchive',
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'Bus',
+        });
+
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+            SourceArn: {
+                'Fn::GetAtt': [
+                    'BusEA82B648',
+                    'Arn',
+                ],
+            },
+            Description: {
+                'Fn::Join': [
+                    '',
+                    [
+                        'Event Archive for ',
+                        {
+                            'Fn::Select': [
+                                1,
+                                {
+                                    'Fn::Split': [
+                                        '/',
+                                        {
+                                            'Fn::Select': [
+                                                5,
+                                                {
+                                                    'Fn::Split': [
+                                                        ':',
+                                                        {
+                                                            'Fn::GetAtt': [
+                                                                'BusEA82B648',
+                                                                'Arn',
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        ' Event Bus',
+                    ],
+                ],
+            },
+            EventPattern: {
+                account: [
+                    {
+                        Ref: 'AWS::AccountId',
+                    },
+                ],
+            },
+            RetentionDays: 0,
+            ArchiveName: 'MyArchive',
+        });
+    });
+
+    test('archive forwards the kmsKey to the underlying Archive construct', () => {
+        // GIVEN
+        const stack = new Stack();
+        const bus = new EventBus(stack, 'Bus');
+        const key = new kms.Key(stack, 'Key');
+
+        // WHEN
+        bus.archive('MyArchive', {
+            eventPattern: {
+                account: [stack.account],
+            },
+            archiveName: 'MyArchive',
+            kmsKey: key,
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+            ArchiveName: 'MyArchive',
+            KmsKeyIdentifier: stack.resolve(key.keyArn),
+        });
+    });
+
+    test('cross account event bus uses generated physical name', () => {
+        // GIVEN
+        const app = new App();
+        const stack1 = new Stack(app, 'Stack1', {
+            env: {
+                account: '11111111111',
+                region: 'us-east-1',
+            },
+        });
+        const stack2 = new Stack(app, 'Stack2', {
+            env: {
+                account: '22222222222',
+                region: 'us-east-1',
+            },
+        });
+
+        // WHEN
+        const bus1 = new EventBus(stack1, 'Bus', {
+            eventBusName: PhysicalName.GENERATE_IF_NEEDED,
+        });
+
+        new CfnOutput(stack2, 'BusName', { value: bus1.eventBusName });
+
+        // THEN
+        Template.fromStack(stack1).hasResourceProperties('AWS::Events::EventBus', {
+            Name: 'stack1stack1busca19bdf8ab2e51b62a5a',
+        });
+    });
+
+    test('can add one event bus policy', () => {
+        // GIVEN
+        const app = new App();
+        const stack = new Stack(app, 'Stack');
+        const bus = new EventBus(stack, 'Bus');
+
+        // WHEN
+        bus.addToResourcePolicy(new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            principals: [new iam.AccountPrincipal('111111111111111')],
+            actions: ['events:PutEvents'],
+            sid: '123',
+            resources: [bus.eventBusArn],
+        }));
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBusPolicy', {
+            StatementId: 'cdk-123',
+            EventBusName: {
+                Ref: 'BusEA82B648',
+            },
+            Statement: {
+                Action: 'events:PutEvents',
+                Effect: 'Allow',
+                Principal: {
+                    AWS: {
+                        'Fn::Join': [
+                            '',
+                            [
+                                'arn:',
+                                {
+                                    Ref: 'AWS::Partition',
+                                },
+                                ':iam::111111111111111:root',
+                            ],
+                        ],
+                    },
+                },
+                Sid: 'cdk-123',
+                Resource: {
+                    'Fn::GetAtt': [
+                        'BusEA82B648',
+                        'Arn',
+                    ],
+                },
+            },
+        });
+    });
+
+    test('can add more than one event bus policy', () => {
+        // GIVEN
+        const app = new App();
+        const stack = new Stack(app, 'Stack');
+        const bus = new EventBus(stack, 'Bus');
+
+        const statement1 = new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            principals: [new iam.ArnPrincipal('arn')],
+            actions: ['events:PutEvents'],
+            sid: 'statement1',
+            resources: [bus.eventBusArn],
+        });
+
+        const statement2 = new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            principals: [new iam.ArnPrincipal('arn')],
+            actions: ['events:DeleteRule'],
+            sid: 'statement2',
+            resources: [bus.eventBusArn],
+        });
+
+        // WHEN
+        const add1 = bus.addToResourcePolicy(statement1);
+        const add2 = bus.addToResourcePolicy(statement2);
+
+        // THEN
+        expect(add1.statementAdded).toBe(true);
+        expect(add2.statementAdded).toBe(true);
+        Template.fromStack(stack).resourceCountIs('AWS::Events::EventBusPolicy', 2);
+    });
+
+    test('Event Bus policy statements must have a sid', () => {
+        // GIVEN
+        const app = new App();
+        const stack = new Stack(app, 'Stack');
+        const bus = new EventBus(stack, 'Bus');
+
+        // THEN
+        expect(() => bus.addToResourcePolicy(new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            principals: [new iam.ArnPrincipal('arn')],
+            actions: ['events:PutEvents'],
+        }))).toThrow('Event Bus policy statements must have a sid');
+    });
+
+    test('set dead letter queue', () => {
+        const app = new App();
+        const stack = new Stack(app, 'Stack');
+        const dlq = new sqs.Queue(stack, 'DLQ');
+        new EventBus(stack, 'Bus', {
+            deadLetterQueue: dlq,
+        });
+
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            DeadLetterConfig: {
+                Arn: {
+                    'Fn::GetAtt': ['DLQ581697C4', 'Arn'],
+                },
+            },
+        });
+    });
+    test('Event Bus with a customer managed key', () => {
+        // GIVEN
+        const app = new App();
+        const stack = new Stack(app, 'Stack');
+        const key = new kms.Key(stack, 'Key');
+
+        // WHEN
+        new EventBus(stack, 'Bus', {
+            kmsKey: key,
+        });
+
+        // THEN
+        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+            KmsKeyIdentifier: stack.resolve(key.keyArn),
+        });
+
+        Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
+            KeyPolicy: {
+                Statement: [
+                    {
+                        Action: 'kms:*',
+                        Effect: 'Allow',
+                        Principal: {
+                            AWS: {
+                                'Fn::Join': [
+                                    '',
+                                    [
+                                        'arn:',
+                                        {
+                                            Ref: 'AWS::Partition',
+                                        },
+                                        ':iam::',
+                                        {
+                                            Ref: 'AWS::AccountId',
+                                        },
+                                        ':root',
+                                    ],
+                                ],
+                            },
+                        },
+                        Resource: '*',
+                    },
+                    {
+                        Action: [
+                            'kms:Decrypt',
+                            'kms:GenerateDataKey',
+                            'kms:DescribeKey',
+                        ],
+                        Condition: {
+                            StringEquals: {
+                                'aws:SourceAccount': {
+                                    Ref: 'AWS::AccountId',
+                                },
+                                'aws:SourceArn': {
+                                    'Fn::Join': [
+                                        '',
+                                        [
+                                            'arn:',
+                                            {
+                                                Ref: 'AWS::Partition',
+                                            },
+                                            ':events:',
+                                            {
+                                                Ref: 'AWS::Region',
+                                            },
+                                            ':',
+                                            {
+                                                Ref: 'AWS::AccountId',
+                                            },
+                                            ':event-bus/StackBusAA0A1E4B',
+                                        ],
+                                    ],
+                                },
+                                'kms:EncryptionContext:aws:events:event-bus:arn': {
+                                    'Fn::Join': [
+                                        '',
+                                        [
+                                            'arn:',
+                                            {
+                                                Ref: 'AWS::Partition',
+                                            },
+                                            ':events:',
+                                            {
+                                                Ref: 'AWS::Region',
+                                            },
+                                            ':',
+                                            {
+                                                Ref: 'AWS::AccountId',
+                                            },
+                                            ':event-bus/StackBusAA0A1E4B',
+                                        ],
+                                    ],
+                                },
+                            },
+                        },
+                        Effect: 'Allow',
+                        Principal: {
+                            Service: 'events.amazonaws.com',
+                        },
+                        Resource: '*',
+                    },
+                ],
+                Version: '2012-10-17',
+            },
+        });
+    });
 });

--- a/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
+++ b/packages/aws-cdk-lib/aws-events/test/event-bus.test.ts
@@ -7,818 +7,818 @@ import { Aws, CfnResource, Stack, Arn, App, PhysicalName, CfnOutput } from '../.
 import { EventBus, IncludeDetail, Level } from '../lib';
 
 describe('event bus', () => {
-    test('default event bus', () => {
-        // GIVEN
-        const stack = new Stack();
+  test('default event bus', () => {
+    // GIVEN
+    const stack = new Stack();
 
-        // WHEN
-        new EventBus(stack, 'Bus');
+    // WHEN
+    new EventBus(stack, 'Bus');
 
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'Bus',
-        });
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'Bus',
+    });
+  });
+
+  test('default event bus with logConfig', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new EventBus(stack, 'Bus', {
+      logConfig: {
+        includeDetail: IncludeDetail.FULL,
+        level: Level.TRACE,
+      },
     });
 
-    test('default event bus with logConfig', () => {
-        // GIVEN
-        const stack = new Stack();
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'Bus',
+      LogConfig: {
+        IncludeDetail: 'FULL',
+        Level: 'TRACE',
+      },
+    });
+  });
 
-        // WHEN
-        new EventBus(stack, 'Bus', {
-            logConfig: {
-                includeDetail: IncludeDetail.FULL,
-                level: Level.TRACE,
+  test('default event bus with empty props object', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new EventBus(stack, 'Bus', {});
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'Bus',
+    });
+  });
+
+  test('named event bus', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new EventBus(stack, 'Bus', {
+      eventBusName: 'myEventBus',
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'myEventBus',
+    });
+  });
+
+  test('event bus with description', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new EventBus(stack, 'myEventBus', {
+      description: 'myEventBusDescription',
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Description: 'myEventBusDescription',
+    });
+  });
+
+  test('partner event bus', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new EventBus(stack, 'Bus', {
+      eventSourceName: 'aws.partner/PartnerName/acct1/repo1',
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'aws.partner/PartnerName/acct1/repo1',
+      EventSourceName: 'aws.partner/PartnerName/acct1/repo1',
+    });
+  });
+
+  test('imported event bus', () => {
+    const stack = new Stack();
+
+    const eventBus = new EventBus(stack, 'Bus');
+
+    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
+
+    // WHEN
+    new CfnResource(stack, 'Res', {
+      type: 'Test::Resource',
+      properties: {
+        EventBusArn1: eventBus.eventBusArn,
+        EventBusArn2: importEB.eventBusArn,
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+      EventBusArn1: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+      EventBusArn2: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+    });
+  });
+
+  test('imported event bus from name', () => {
+    const stack = new Stack();
+
+    const eventBus = new EventBus(stack, 'Bus', { eventBusName: 'test-bus-to-import-by-name' });
+
+    const importEB = EventBus.fromEventBusName(stack, 'ImportBus', eventBus.eventBusName);
+
+    // WHEN
+    expect(stack.resolve(eventBus.eventBusName)).toEqual(stack.resolve(importEB.eventBusName));
+  });
+
+  test('same account imported event bus has right resource env', () => {
+    const stack = new Stack();
+
+    const eventBus = new EventBus(stack, 'Bus');
+
+    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
+
+    // WHEN
+    expect(stack.resolve(importEB.env.account)).toEqual({ 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
+    expect(stack.resolve(importEB.env.region)).toEqual({ 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
+  });
+
+  test('cross account imported event bus has right resource env', () => {
+    const stack = new Stack();
+
+    const arnParts = {
+      resource: 'bus',
+      service: 'events',
+      account: 'myAccount',
+      region: 'us-west-1',
+    };
+
+    const arn = Arn.format(arnParts, stack);
+
+    const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', arn);
+
+    // WHEN
+    expect(importEB.env.account).toEqual(arnParts.account);
+    expect(importEB.env.region).toEqual(arnParts.region);
+  });
+
+  test('can get bus name', () => {
+    // GIVEN
+    const stack = new Stack();
+    const bus = new EventBus(stack, 'Bus', {
+      eventBusName: 'myEventBus',
+    });
+
+    // WHEN
+    new CfnResource(stack, 'Res', {
+      type: 'Test::Resource',
+      properties: {
+        EventBusName: bus.eventBusName,
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+      EventBusName: { Ref: 'BusEA82B648' },
+    });
+  });
+
+  test('can get bus arn', () => {
+    // GIVEN
+    const stack = new Stack();
+    const bus = new EventBus(stack, 'Bus', {
+      eventBusName: 'myEventBus',
+    });
+
+    // WHEN
+    new CfnResource(stack, 'Res', {
+      type: 'Test::Resource',
+      properties: {
+        EventBusArn: bus.eventBusArn,
+      },
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('Test::Resource', {
+      EventBusArn: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
+    });
+  });
+
+  test('event bus name cannot be default', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventBusName: 'default',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventBusName' must not be 'default'/);
+  });
+
+  test('event bus name cannot contain slash', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventBusName: 'my/bus',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventBusName' must not contain '\/'/);
+  });
+
+  test('event bus cannot have name and source name', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventBusName: 'myBus',
+      eventSourceName: 'myBus',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventBusName' and 'eventSourceName' cannot both be provided/);
+  });
+
+  test('event bus name cannot be empty string', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventBusName: '',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventBusName' must satisfy: /);
+  });
+
+  test('does not throw if eventBusName is a token', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN / THEN
+    expect(() => new EventBus(stack, 'EventBus', {
+      eventBusName: Aws.STACK_NAME,
+    })).not.toThrow();
+  });
+
+  test('event bus source name must follow pattern', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventSourceName: 'invalid-partner',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventSourceName' must satisfy: \/\^aws/);
+  });
+
+  test('does not throw if eventSourceName is a token', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN / THEN
+    expect(() => new EventBus(stack, 'EventBus', {
+      eventSourceName: Aws.STACK_NAME,
+    })).not.toThrow();
+  });
+
+  test('event bus source name cannot be empty string', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const createInvalidBus = () => new EventBus(stack, 'Bus', {
+      eventSourceName: '',
+    });
+
+    // THEN
+    expect(() => {
+      createInvalidBus();
+    }).toThrow(/'eventSourceName' must satisfy: /);
+  });
+
+  test('event bus description cannot be too long', () => {
+    // GIVEN
+    const stack = new Stack();
+    const tooLongDescription = 'a'.repeat(513);
+
+    // WHEN / THEN
+    expect(() => {
+      new EventBus(stack, 'EventBusWithTooLongDescription', {
+        description: tooLongDescription,
+      });
+    }).toThrow('description must be less than or equal to 512 characters, got 513');
+  });
+
+  testDeprecated('can grant PutEvents', () => {
+    // GIVEN
+    const stack = new Stack();
+    const role = new iam.Role(stack, 'Role', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    // WHEN
+    EventBus.grantPutEvents(role);
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'events:PutEvents',
+            Effect: 'Allow',
+            Resource: '*',
+          },
+        ],
+        Version: '2012-10-17',
+      },
+      Roles: [
+        {
+          Ref: 'Role1ABCC5F0',
+        },
+      ],
+    });
+  });
+
+  test('can grant PutEvents using grantAllPutEvents', () => {
+    // GIVEN
+    const stack = new Stack();
+    const role = new iam.Role(stack, 'Role', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    // WHEN
+    EventBus.grantAllPutEvents(role);
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'events:PutEvents',
+            Effect: 'Allow',
+            Resource: '*',
+          },
+        ],
+        Version: '2012-10-17',
+      },
+      Roles: [
+        {
+          Ref: 'Role1ABCC5F0',
+        },
+      ],
+    });
+  });
+
+  test('can grant PutEvents to a specific event bus', () => {
+    // GIVEN
+    const stack = new Stack();
+    const role = new iam.Role(stack, 'Role', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    const eventBus = new EventBus(stack, 'EventBus');
+
+    // WHEN
+    eventBus.grantPutEventsTo(role);
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'events:PutEvents',
+            Effect: 'Allow',
+            Resource: {
+              'Fn::GetAtt': [
+                'EventBus7B8748AA',
+                'Arn',
+              ],
             },
-        });
+          },
+        ],
+        Version: '2012-10-17',
+      },
+      Roles: [
+        {
+          Ref: 'Role1ABCC5F0',
+        },
+      ],
+    });
+  });
 
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'Bus',
-            LogConfig: {
-                IncludeDetail: 'FULL',
-                Level: 'TRACE',
+  test('can archive events', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const event = new EventBus(stack, 'Bus');
+
+    event.archive('MyArchive', {
+      eventPattern: {
+        account: [stack.account],
+      },
+      archiveName: 'MyArchive',
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'Bus',
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+      SourceArn: {
+        'Fn::GetAtt': [
+          'BusEA82B648',
+          'Arn',
+        ],
+      },
+      Description: {
+        'Fn::Join': [
+          '',
+          [
+            'Event Archive for ',
+            {
+              Ref: 'BusEA82B648',
             },
-        });
+            ' Event Bus',
+          ],
+        ],
+      },
+      EventPattern: {
+        account: [
+          {
+            Ref: 'AWS::AccountId',
+          },
+        ],
+      },
+      RetentionDays: 0,
+      ArchiveName: 'MyArchive',
+    });
+  });
+
+  test('can archive events from an imported EventBus', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    const bus = new EventBus(stack, 'Bus');
+
+    const importedBus = EventBus.fromEventBusArn(stack, 'ImportedBus', bus.eventBusArn);
+
+    importedBus.archive('MyArchive', {
+      eventPattern: {
+        account: [stack.account],
+      },
+      archiveName: 'MyArchive',
     });
 
-    test('default event bus with empty props object', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        new EventBus(stack, 'Bus', {});
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'Bus',
-        });
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'Bus',
     });
 
-    test('named event bus', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        new EventBus(stack, 'Bus', {
-            eventBusName: 'myEventBus',
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'myEventBus',
-        });
-    });
-
-    test('event bus with description', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        new EventBus(stack, 'myEventBus', {
-            description: 'myEventBusDescription',
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Description: 'myEventBusDescription',
-        });
-    });
-
-    test('partner event bus', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        new EventBus(stack, 'Bus', {
-            eventSourceName: 'aws.partner/PartnerName/acct1/repo1',
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'aws.partner/PartnerName/acct1/repo1',
-            EventSourceName: 'aws.partner/PartnerName/acct1/repo1',
-        });
-    });
-
-    test('imported event bus', () => {
-        const stack = new Stack();
-
-        const eventBus = new EventBus(stack, 'Bus');
-
-        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
-
-        // WHEN
-        new CfnResource(stack, 'Res', {
-            type: 'Test::Resource',
-            properties: {
-                EventBusArn1: eventBus.eventBusArn,
-                EventBusArn2: importEB.eventBusArn,
-            },
-        });
-
-        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-            EventBusArn1: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-            EventBusArn2: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-        });
-    });
-
-    test('imported event bus from name', () => {
-        const stack = new Stack();
-
-        const eventBus = new EventBus(stack, 'Bus', { eventBusName: 'test-bus-to-import-by-name' });
-
-        const importEB = EventBus.fromEventBusName(stack, 'ImportBus', eventBus.eventBusName);
-
-        // WHEN
-        expect(stack.resolve(eventBus.eventBusName)).toEqual(stack.resolve(importEB.eventBusName));
-    });
-
-    test('same account imported event bus has right resource env', () => {
-        const stack = new Stack();
-
-        const eventBus = new EventBus(stack, 'Bus');
-
-        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', eventBus.eventBusArn);
-
-        // WHEN
-        expect(stack.resolve(importEB.env.account)).toEqual({ 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
-        expect(stack.resolve(importEB.env.region)).toEqual({ 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] }] }] });
-    });
-
-    test('cross account imported event bus has right resource env', () => {
-        const stack = new Stack();
-
-        const arnParts = {
-            resource: 'bus',
-            service: 'events',
-            account: 'myAccount',
-            region: 'us-west-1',
-        };
-
-        const arn = Arn.format(arnParts, stack);
-
-        const importEB = EventBus.fromEventBusArn(stack, 'ImportBus', arn);
-
-        // WHEN
-        expect(importEB.env.account).toEqual(arnParts.account);
-        expect(importEB.env.region).toEqual(arnParts.region);
-    });
-
-    test('can get bus name', () => {
-        // GIVEN
-        const stack = new Stack();
-        const bus = new EventBus(stack, 'Bus', {
-            eventBusName: 'myEventBus',
-        });
-
-        // WHEN
-        new CfnResource(stack, 'Res', {
-            type: 'Test::Resource',
-            properties: {
-                EventBusName: bus.eventBusName,
-            },
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-            EventBusName: { Ref: 'BusEA82B648' },
-        });
-    });
-
-    test('can get bus arn', () => {
-        // GIVEN
-        const stack = new Stack();
-        const bus = new EventBus(stack, 'Bus', {
-            eventBusName: 'myEventBus',
-        });
-
-        // WHEN
-        new CfnResource(stack, 'Res', {
-            type: 'Test::Resource',
-            properties: {
-                EventBusArn: bus.eventBusArn,
-            },
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('Test::Resource', {
-            EventBusArn: { 'Fn::GetAtt': ['BusEA82B648', 'Arn'] },
-        });
-    });
-
-    test('event bus name cannot be default', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventBusName: 'default',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventBusName' must not be 'default'/);
-    });
-
-    test('event bus name cannot contain slash', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventBusName: 'my/bus',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventBusName' must not contain '\/'/);
-    });
-
-    test('event bus cannot have name and source name', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventBusName: 'myBus',
-            eventSourceName: 'myBus',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventBusName' and 'eventSourceName' cannot both be provided/);
-    });
-
-    test('event bus name cannot be empty string', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventBusName: '',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventBusName' must satisfy: /);
-    });
-
-    test('does not throw if eventBusName is a token', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN / THEN
-        expect(() => new EventBus(stack, 'EventBus', {
-            eventBusName: Aws.STACK_NAME,
-        })).not.toThrow();
-    });
-
-    test('event bus source name must follow pattern', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventSourceName: 'invalid-partner',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventSourceName' must satisfy: \/\^aws/);
-    });
-
-    test('does not throw if eventSourceName is a token', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN / THEN
-        expect(() => new EventBus(stack, 'EventBus', {
-            eventSourceName: Aws.STACK_NAME,
-        })).not.toThrow();
-    });
-
-    test('event bus source name cannot be empty string', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const createInvalidBus = () => new EventBus(stack, 'Bus', {
-            eventSourceName: '',
-        });
-
-        // THEN
-        expect(() => {
-            createInvalidBus();
-        }).toThrow(/'eventSourceName' must satisfy: /);
-    });
-
-    test('event bus description cannot be too long', () => {
-        // GIVEN
-        const stack = new Stack();
-        const tooLongDescription = 'a'.repeat(513);
-
-        // WHEN / THEN
-        expect(() => {
-            new EventBus(stack, 'EventBusWithTooLongDescription', {
-                description: tooLongDescription,
-            });
-        }).toThrow('description must be less than or equal to 512 characters, got 513');
-    });
-
-    testDeprecated('can grant PutEvents', () => {
-        // GIVEN
-        const stack = new Stack();
-        const role = new iam.Role(stack, 'Role', {
-            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-        });
-
-        // WHEN
-        EventBus.grantPutEvents(role);
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-            PolicyDocument: {
-                Statement: [
-                    {
-                        Action: 'events:PutEvents',
-                        Effect: 'Allow',
-                        Resource: '*',
-                    },
-                ],
-                Version: '2012-10-17',
-            },
-            Roles: [
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+      SourceArn: {
+        'Fn::GetAtt': [
+          'BusEA82B648',
+          'Arn',
+        ],
+      },
+      Description: {
+        'Fn::Join': [
+          '',
+          [
+            'Event Archive for ',
+            {
+              'Fn::Select': [
+                1,
                 {
-                    Ref: 'Role1ABCC5F0',
-                },
-            ],
-        });
-    });
-
-    test('can grant PutEvents using grantAllPutEvents', () => {
-        // GIVEN
-        const stack = new Stack();
-        const role = new iam.Role(stack, 'Role', {
-            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-        });
-
-        // WHEN
-        EventBus.grantAllPutEvents(role);
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-            PolicyDocument: {
-                Statement: [
+                  'Fn::Split': [
+                    '/',
                     {
-                        Action: 'events:PutEvents',
-                        Effect: 'Allow',
-                        Resource: '*',
-                    },
-                ],
-                Version: '2012-10-17',
-            },
-            Roles: [
-                {
-                    Ref: 'Role1ABCC5F0',
-                },
-            ],
-        });
-    });
-
-    test('can grant PutEvents to a specific event bus', () => {
-        // GIVEN
-        const stack = new Stack();
-        const role = new iam.Role(stack, 'Role', {
-            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-        });
-
-        const eventBus = new EventBus(stack, 'EventBus');
-
-        // WHEN
-        eventBus.grantPutEventsTo(role);
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
-            PolicyDocument: {
-                Statement: [
-                    {
-                        Action: 'events:PutEvents',
-                        Effect: 'Allow',
-                        Resource: {
-                            'Fn::GetAtt': [
-                                'EventBus7B8748AA',
+                      'Fn::Select': [
+                        5,
+                        {
+                          'Fn::Split': [
+                            ':',
+                            {
+                              'Fn::GetAtt': [
+                                'BusEA82B648',
                                 'Arn',
-                            ],
+                              ],
+                            },
+                          ],
                         },
+                      ],
                     },
-                ],
-                Version: '2012-10-17',
+                  ],
+                },
+              ],
             },
-            Roles: [
+            ' Event Bus',
+          ],
+        ],
+      },
+      EventPattern: {
+        account: [
+          {
+            Ref: 'AWS::AccountId',
+          },
+        ],
+      },
+      RetentionDays: 0,
+      ArchiveName: 'MyArchive',
+    });
+  });
+
+  test('archive forwards the kmsKey to the underlying Archive construct', () => {
+    // GIVEN
+    const stack = new Stack();
+    const bus = new EventBus(stack, 'Bus');
+    const key = new kms.Key(stack, 'Key');
+
+    // WHEN
+    bus.archive('MyArchive', {
+      eventPattern: {
+        account: [stack.account],
+      },
+      archiveName: 'MyArchive',
+      kmsKey: key,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
+      ArchiveName: 'MyArchive',
+      KmsKeyIdentifier: stack.resolve(key.keyArn),
+    });
+  });
+
+  test('cross account event bus uses generated physical name', () => {
+    // GIVEN
+    const app = new App();
+    const stack1 = new Stack(app, 'Stack1', {
+      env: {
+        account: '11111111111',
+        region: 'us-east-1',
+      },
+    });
+    const stack2 = new Stack(app, 'Stack2', {
+      env: {
+        account: '22222222222',
+        region: 'us-east-1',
+      },
+    });
+
+    // WHEN
+    const bus1 = new EventBus(stack1, 'Bus', {
+      eventBusName: PhysicalName.GENERATE_IF_NEEDED,
+    });
+
+    new CfnOutput(stack2, 'BusName', { value: bus1.eventBusName });
+
+    // THEN
+    Template.fromStack(stack1).hasResourceProperties('AWS::Events::EventBus', {
+      Name: 'stack1stack1busca19bdf8ab2e51b62a5a',
+    });
+  });
+
+  test('can add one event bus policy', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const bus = new EventBus(stack, 'Bus');
+
+    // WHEN
+    bus.addToResourcePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.AccountPrincipal('111111111111111')],
+      actions: ['events:PutEvents'],
+      sid: '123',
+      resources: [bus.eventBusArn],
+    }));
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBusPolicy', {
+      StatementId: 'cdk-123',
+      EventBusName: {
+        Ref: 'BusEA82B648',
+      },
+      Statement: {
+        Action: 'events:PutEvents',
+        Effect: 'Allow',
+        Principal: {
+          AWS: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
                 {
-                    Ref: 'Role1ABCC5F0',
+                  Ref: 'AWS::Partition',
                 },
+                ':iam::111111111111111:root',
+              ],
             ],
-        });
+          },
+        },
+        Sid: 'cdk-123',
+        Resource: {
+          'Fn::GetAtt': [
+            'BusEA82B648',
+            'Arn',
+          ],
+        },
+      },
+    });
+  });
+
+  test('can add more than one event bus policy', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const bus = new EventBus(stack, 'Bus');
+
+    const statement1 = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ArnPrincipal('arn')],
+      actions: ['events:PutEvents'],
+      sid: 'statement1',
+      resources: [bus.eventBusArn],
     });
 
-    test('can archive events', () => {
-        // GIVEN
-        const stack = new Stack();
+    const statement2 = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ArnPrincipal('arn')],
+      actions: ['events:DeleteRule'],
+      sid: 'statement2',
+      resources: [bus.eventBusArn],
+    });
 
-        // WHEN
-        const event = new EventBus(stack, 'Bus');
+    // WHEN
+    const add1 = bus.addToResourcePolicy(statement1);
+    const add2 = bus.addToResourcePolicy(statement2);
 
-        event.archive('MyArchive', {
-            eventPattern: {
-                account: [stack.account],
-            },
-            archiveName: 'MyArchive',
-        });
+    // THEN
+    expect(add1.statementAdded).toBe(true);
+    expect(add2.statementAdded).toBe(true);
+    Template.fromStack(stack).resourceCountIs('AWS::Events::EventBusPolicy', 2);
+  });
 
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'Bus',
-        });
+  test('Event Bus policy statements must have a sid', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const bus = new EventBus(stack, 'Bus');
 
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
-            SourceArn: {
-                'Fn::GetAtt': [
-                    'BusEA82B648',
-                    'Arn',
-                ],
-            },
-            Description: {
+    // THEN
+    expect(() => bus.addToResourcePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ArnPrincipal('arn')],
+      actions: ['events:PutEvents'],
+    }))).toThrow('Event Bus policy statements must have a sid');
+  });
+
+  test('set dead letter queue', () => {
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const dlq = new sqs.Queue(stack, 'DLQ');
+    new EventBus(stack, 'Bus', {
+      deadLetterQueue: dlq,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      DeadLetterConfig: {
+        Arn: {
+          'Fn::GetAtt': ['DLQ581697C4', 'Arn'],
+        },
+      },
+    });
+  });
+  test('Event Bus with a customer managed key', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+    const key = new kms.Key(stack, 'Key');
+
+    // WHEN
+    new EventBus(stack, 'Bus', {
+      kmsKey: key,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+      KmsKeyIdentifier: stack.resolve(key.keyArn),
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
+      KeyPolicy: {
+        Statement: [
+          {
+            Action: 'kms:*',
+            Effect: 'Allow',
+            Principal: {
+              AWS: {
                 'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':root',
+                  ],
+                ],
+              },
+            },
+            Resource: '*',
+          },
+          {
+            Action: [
+              'kms:Decrypt',
+              'kms:GenerateDataKey',
+              'kms:DescribeKey',
+            ],
+            Condition: {
+              StringEquals: {
+                'aws:SourceAccount': {
+                  Ref: 'AWS::AccountId',
+                },
+                'aws:SourceArn': {
+                  'Fn::Join': [
                     '',
                     [
-                        'Event Archive for ',
-                        {
-                            Ref: 'BusEA82B648',
-                        },
-                        ' Event Bus',
-                    ],
-                ],
-            },
-            EventPattern: {
-                account: [
-                    {
+                      'arn:',
+                      {
+                        Ref: 'AWS::Partition',
+                      },
+                      ':events:',
+                      {
+                        Ref: 'AWS::Region',
+                      },
+                      ':',
+                      {
                         Ref: 'AWS::AccountId',
-                    },
-                ],
-            },
-            RetentionDays: 0,
-            ArchiveName: 'MyArchive',
-        });
-    });
-
-    test('can archive events from an imported EventBus', () => {
-        // GIVEN
-        const stack = new Stack();
-
-        // WHEN
-        const bus = new EventBus(stack, 'Bus');
-
-        const importedBus = EventBus.fromEventBusArn(stack, 'ImportedBus', bus.eventBusArn);
-
-        importedBus.archive('MyArchive', {
-            eventPattern: {
-                account: [stack.account],
-            },
-            archiveName: 'MyArchive',
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'Bus',
-        });
-
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
-            SourceArn: {
-                'Fn::GetAtt': [
-                    'BusEA82B648',
-                    'Arn',
-                ],
-            },
-            Description: {
-                'Fn::Join': [
+                      },
+                      ':event-bus/StackBusAA0A1E4B',
+                    ],
+                  ],
+                },
+                'kms:EncryptionContext:aws:events:event-bus:arn': {
+                  'Fn::Join': [
                     '',
                     [
-                        'Event Archive for ',
-                        {
-                            'Fn::Select': [
-                                1,
-                                {
-                                    'Fn::Split': [
-                                        '/',
-                                        {
-                                            'Fn::Select': [
-                                                5,
-                                                {
-                                                    'Fn::Split': [
-                                                        ':',
-                                                        {
-                                                            'Fn::GetAtt': [
-                                                                'BusEA82B648',
-                                                                'Arn',
-                                                            ],
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                        ' Event Bus',
-                    ],
-                ],
-            },
-            EventPattern: {
-                account: [
-                    {
+                      'arn:',
+                      {
+                        Ref: 'AWS::Partition',
+                      },
+                      ':events:',
+                      {
+                        Ref: 'AWS::Region',
+                      },
+                      ':',
+                      {
                         Ref: 'AWS::AccountId',
-                    },
-                ],
-            },
-            RetentionDays: 0,
-            ArchiveName: 'MyArchive',
-        });
-    });
-
-    test('archive forwards the kmsKey to the underlying Archive construct', () => {
-        // GIVEN
-        const stack = new Stack();
-        const bus = new EventBus(stack, 'Bus');
-        const key = new kms.Key(stack, 'Key');
-
-        // WHEN
-        bus.archive('MyArchive', {
-            eventPattern: {
-                account: [stack.account],
-            },
-            archiveName: 'MyArchive',
-            kmsKey: key,
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::Archive', {
-            ArchiveName: 'MyArchive',
-            KmsKeyIdentifier: stack.resolve(key.keyArn),
-        });
-    });
-
-    test('cross account event bus uses generated physical name', () => {
-        // GIVEN
-        const app = new App();
-        const stack1 = new Stack(app, 'Stack1', {
-            env: {
-                account: '11111111111',
-                region: 'us-east-1',
-            },
-        });
-        const stack2 = new Stack(app, 'Stack2', {
-            env: {
-                account: '22222222222',
-                region: 'us-east-1',
-            },
-        });
-
-        // WHEN
-        const bus1 = new EventBus(stack1, 'Bus', {
-            eventBusName: PhysicalName.GENERATE_IF_NEEDED,
-        });
-
-        new CfnOutput(stack2, 'BusName', { value: bus1.eventBusName });
-
-        // THEN
-        Template.fromStack(stack1).hasResourceProperties('AWS::Events::EventBus', {
-            Name: 'stack1stack1busca19bdf8ab2e51b62a5a',
-        });
-    });
-
-    test('can add one event bus policy', () => {
-        // GIVEN
-        const app = new App();
-        const stack = new Stack(app, 'Stack');
-        const bus = new EventBus(stack, 'Bus');
-
-        // WHEN
-        bus.addToResourcePolicy(new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            principals: [new iam.AccountPrincipal('111111111111111')],
-            actions: ['events:PutEvents'],
-            sid: '123',
-            resources: [bus.eventBusArn],
-        }));
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBusPolicy', {
-            StatementId: 'cdk-123',
-            EventBusName: {
-                Ref: 'BusEA82B648',
-            },
-            Statement: {
-                Action: 'events:PutEvents',
-                Effect: 'Allow',
-                Principal: {
-                    AWS: {
-                        'Fn::Join': [
-                            '',
-                            [
-                                'arn:',
-                                {
-                                    Ref: 'AWS::Partition',
-                                },
-                                ':iam::111111111111111:root',
-                            ],
-                        ],
-                    },
-                },
-                Sid: 'cdk-123',
-                Resource: {
-                    'Fn::GetAtt': [
-                        'BusEA82B648',
-                        'Arn',
+                      },
+                      ':event-bus/StackBusAA0A1E4B',
                     ],
+                  ],
                 },
+              },
             },
-        });
-    });
-
-    test('can add more than one event bus policy', () => {
-        // GIVEN
-        const app = new App();
-        const stack = new Stack(app, 'Stack');
-        const bus = new EventBus(stack, 'Bus');
-
-        const statement1 = new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            principals: [new iam.ArnPrincipal('arn')],
-            actions: ['events:PutEvents'],
-            sid: 'statement1',
-            resources: [bus.eventBusArn],
-        });
-
-        const statement2 = new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            principals: [new iam.ArnPrincipal('arn')],
-            actions: ['events:DeleteRule'],
-            sid: 'statement2',
-            resources: [bus.eventBusArn],
-        });
-
-        // WHEN
-        const add1 = bus.addToResourcePolicy(statement1);
-        const add2 = bus.addToResourcePolicy(statement2);
-
-        // THEN
-        expect(add1.statementAdded).toBe(true);
-        expect(add2.statementAdded).toBe(true);
-        Template.fromStack(stack).resourceCountIs('AWS::Events::EventBusPolicy', 2);
-    });
-
-    test('Event Bus policy statements must have a sid', () => {
-        // GIVEN
-        const app = new App();
-        const stack = new Stack(app, 'Stack');
-        const bus = new EventBus(stack, 'Bus');
-
-        // THEN
-        expect(() => bus.addToResourcePolicy(new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            principals: [new iam.ArnPrincipal('arn')],
-            actions: ['events:PutEvents'],
-        }))).toThrow('Event Bus policy statements must have a sid');
-    });
-
-    test('set dead letter queue', () => {
-        const app = new App();
-        const stack = new Stack(app, 'Stack');
-        const dlq = new sqs.Queue(stack, 'DLQ');
-        new EventBus(stack, 'Bus', {
-            deadLetterQueue: dlq,
-        });
-
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            DeadLetterConfig: {
-                Arn: {
-                    'Fn::GetAtt': ['DLQ581697C4', 'Arn'],
-                },
+            Effect: 'Allow',
+            Principal: {
+              Service: 'events.amazonaws.com',
             },
-        });
+            Resource: '*',
+          },
+        ],
+        Version: '2012-10-17',
+      },
     });
-    test('Event Bus with a customer managed key', () => {
-        // GIVEN
-        const app = new App();
-        const stack = new Stack(app, 'Stack');
-        const key = new kms.Key(stack, 'Key');
-
-        // WHEN
-        new EventBus(stack, 'Bus', {
-            kmsKey: key,
-        });
-
-        // THEN
-        Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
-            KmsKeyIdentifier: stack.resolve(key.keyArn),
-        });
-
-        Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
-            KeyPolicy: {
-                Statement: [
-                    {
-                        Action: 'kms:*',
-                        Effect: 'Allow',
-                        Principal: {
-                            AWS: {
-                                'Fn::Join': [
-                                    '',
-                                    [
-                                        'arn:',
-                                        {
-                                            Ref: 'AWS::Partition',
-                                        },
-                                        ':iam::',
-                                        {
-                                            Ref: 'AWS::AccountId',
-                                        },
-                                        ':root',
-                                    ],
-                                ],
-                            },
-                        },
-                        Resource: '*',
-                    },
-                    {
-                        Action: [
-                            'kms:Decrypt',
-                            'kms:GenerateDataKey',
-                            'kms:DescribeKey',
-                        ],
-                        Condition: {
-                            StringEquals: {
-                                'aws:SourceAccount': {
-                                    Ref: 'AWS::AccountId',
-                                },
-                                'aws:SourceArn': {
-                                    'Fn::Join': [
-                                        '',
-                                        [
-                                            'arn:',
-                                            {
-                                                Ref: 'AWS::Partition',
-                                            },
-                                            ':events:',
-                                            {
-                                                Ref: 'AWS::Region',
-                                            },
-                                            ':',
-                                            {
-                                                Ref: 'AWS::AccountId',
-                                            },
-                                            ':event-bus/StackBusAA0A1E4B',
-                                        ],
-                                    ],
-                                },
-                                'kms:EncryptionContext:aws:events:event-bus:arn': {
-                                    'Fn::Join': [
-                                        '',
-                                        [
-                                            'arn:',
-                                            {
-                                                Ref: 'AWS::Partition',
-                                            },
-                                            ':events:',
-                                            {
-                                                Ref: 'AWS::Region',
-                                            },
-                                            ':',
-                                            {
-                                                Ref: 'AWS::AccountId',
-                                            },
-                                            ':event-bus/StackBusAA0A1E4B',
-                                        ],
-                                    ],
-                                },
-                            },
-                        },
-                        Effect: 'Allow',
-                        Principal: {
-                            Service: 'events.amazonaws.com',
-                        },
-                        Resource: '*',
-                    },
-                ],
-                Version: '2012-10-17',
-            },
-        });
-    });
+  });
 });


### PR DESCRIPTION
### Reason for this change
The EventBus.archive() method accepts a kmsKey parameter in its props argument, but was not forwarding this parameter to the underlying Archive construct. This prevented users from encrypting EventBridge archives using customer-managed KMS keys even when they explicitly specified the kmsKey prop.

### Description of changes
Modified the EventBus.archive() method in packages/aws-cdk-lib/aws-events/lib/event-bus.ts to forward the kmsKey  property from BaseArchiveProps to the Archive constructor: `kmsKey: props.kmsKey,`

This one-line change ensures that when users provide a KMS key for encryption, it is properly passed through to the underlying Archive construct, allowing customer-managed KMS encryption to work as originally intended.

### Describe any new or updated permissions being added

No new permissions are being added. This change enables the use of existing kms:Decrypt and kms:GenerateDataKey permissions that users would already have if they use customer-managed KMS keys for other AWS services.

### Description of how you validated changes

Added a new unit test to test that the archive forwards the kmsKey to the underlying Archive construct, which verifies the kmsKey parameter is properly forwarded to the underlying Archive construct and that KmsKeyIdentifier is correctly set on the CloudFormation Archive resource. All existing tests continue to pass.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
