### PR TITLE
feat(pipelines) implement issue 18272

### DIFF
--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
@@ -84,6 +84,19 @@ export interface CodeBuildStepProps extends ShellStepProps {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`.
+   *
+   * The CodeBuild project's role is granted `sts:AssumeRole` on this role,
+   * and `commands` run with this role's credentials active (via `AWS_PROFILE`).
+   *
+   * Useful for cross-account actions such as invoking a Lambda function or
+   * creating test data in a deployed account.
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * Changes to environment
    *
    * This environment will be combined with the pipeline's default
@@ -195,6 +208,13 @@ export class CodeBuildStep extends ShellStep {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`.
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * Build environment
    *
    * @default - No value specified at construction time, use defaults
@@ -250,6 +270,7 @@ export class CodeBuildStep extends ShellStep {
     this.cache = props.cache;
     this.role = props.role;
     this.actionRole = props.actionRole;
+    this.assumeRole = props.assumeRole;
     this.rolePolicyStatements = props.rolePolicyStatements;
     this.securityGroups = props.securityGroups;
     this.timeout = props.timeout;

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
@@ -229,9 +229,6 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       throw new UnscopedValidationError(lit`RequiresCodebuildActionRequires`, `CodeBuild action '${this.stepId}' requires an input (and the pipeline doesn't have a Source to fall back to). Add an input or a pipeline source.`);
     }
 
-    // ponytail: assumes the CodeBuild compute type gets credentials from the ECS container
-    // metadata endpoint (true for standard CodeBuild, not for Lambda compute). Upgrade path:
-    // detect projectOptions.buildEnvironment.computeType and pick Ec2InstanceMetadata instead.
     const assumeRoleCommands = this.props.assumeRole ? [
       `aws configure --profile cdk-assume-role set role_arn ${this.props.assumeRole.roleArn}`,
       'aws configure --profile cdk-assume-role set credential_source EcsContainer',

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
@@ -53,6 +53,13 @@ export interface CodeBuildFactoryProps {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * If true, the build spec will be passed via the Cloud Assembly instead of rendered onto the Project
    *
    * Doing this has two advantages:
@@ -153,6 +160,7 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       projectName: step.projectName,
       role: step.role,
       actionRole: step.actionRole,
+      assumeRole: step.assumeRole,
       ...additional,
       projectOptions: mergeCodeBuildOptions(additional?.projectOptions, {
         buildEnvironment: step.buildEnvironment,
@@ -221,8 +229,18 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       throw new UnscopedValidationError(lit`RequiresCodebuildActionRequires`, `CodeBuild action '${this.stepId}' requires an input (and the pipeline doesn't have a Source to fall back to). Add an input or a pipeline source.`);
     }
 
+    // ponytail: assumes the CodeBuild compute type gets credentials from the ECS container
+    // metadata endpoint (true for standard CodeBuild, not for Lambda compute). Upgrade path:
+    // detect projectOptions.buildEnvironment.computeType and pick Ec2InstanceMetadata instead.
+    const assumeRoleCommands = this.props.assumeRole ? [
+      `aws configure --profile cdk-assume-role set role_arn ${this.props.assumeRole.roleArn}`,
+      'aws configure --profile cdk-assume-role set credential_source EcsContainer',
+      'export AWS_PROFILE=cdk-assume-role',
+    ] : [];
+
     const installCommands = [
       ...generateInputArtifactLinkCommands(options.artifacts, extraInputs),
+      ...assumeRoleCommands,
       ...this.props.installCommands ?? [],
     ];
 
@@ -321,6 +339,10 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       projectOptions.rolePolicy.forEach(policyStatement => {
         project.addToRolePolicy(policyStatement);
       });
+    }
+
+    if (this.props.assumeRole) {
+      this.props.assumeRole.grant(project.grantPrincipal, 'sts:AssumeRole');
     }
 
     const stackOutputEnv = mapValues(this.props.envFromCfnOutputs ?? {}, outputRef =>

--- a/packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts
+++ b/packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts
@@ -252,6 +252,53 @@ test('role passed it used for project and code build action', () => {
     ],
   });
 });
+test('assumeRole grants sts:AssumeRole and injects profile commands', () => {
+  const assumeRoleArn = 'arn:aws:iam::123456789012:role/AssumeRole';
+  const assumeRole = iam.Role.fromRoleArn(pipelineStack, 'AssumeRole', assumeRoleArn);
+
+  // WHEN
+  new cdkp.CodePipeline(pipelineStack, 'Pipeline', {
+    synth: new cdkp.CodeBuildStep('Synth', {
+      commands: ['./test.sh'],
+      input: cdkp.CodePipelineSource.gitHub('test/test', 'main'),
+      assumeRole,
+    }),
+  });
+
+  // THEN
+  const tpl = Template.fromStack(pipelineStack);
+
+  // The project's role can assume the target role
+  tpl.hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Resource: assumeRoleArn,
+        }),
+      ]),
+    }),
+  });
+
+  // The buildspec configures and exports the assumed-role profile before running commands
+  tpl.hasResourceProperties('AWS::CodeBuild::Project', {
+    Source: {
+      BuildSpec: Match.serializedJson(Match.objectLike({
+        phases: {
+          install: {
+            commands: Match.arrayWith([
+              `aws configure --profile cdk-assume-role set role_arn ${assumeRoleArn}`,
+              'aws configure --profile cdk-assume-role set credential_source EcsContainer',
+              'export AWS_PROFILE=cdk-assume-role',
+            ]),
+          },
+        },
+      })),
+    },
+  });
+});
+
 test('exportedVariables', () => {
   const pipeline = new ModernTestGitHubNpmPipeline(pipelineStack, 'Cdk');
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #18272

### Reason for this change

`pipelines.CodeBuildStep` has no built-in way to run its commands under a different IAM role. This matters for cross-account deployment pipelines, where the CodeBuild project's own role can't reach resources in the deployed (target) account, e.g. invoking a Lambda function to run a DB migration, or seeding Cognito users for integration tests. Users currently have to hand-roll this with `aws sts assume-role` calls inside `commands`, wiring up the trust policy and `sts:AssumeRole` permission themselves each time.

### Description of changes

Added an `assumeRole?: iam.IRole` property to `CodeBuildStepProps` / `CodeBuildStep`. When set:

- The CodeBuild project's role is granted `sts:AssumeRole` on the given role (`assumeRole.grant(project.grantPrincipal, 'sts:AssumeRole')`).
- Three commands are prepended to the buildspec's `install` phase, before any user-supplied `installCommands`, which configure a named AWS CLI profile (`cdk-assume-role`) pointed at the role and export it as the active profile:
```
aws configure --profile cdk-assume-role set role_arn <roleArn>
aws configure --profile cdk-assume-role set credential_source EcsContainer
export AWS_PROFILE=cdk-assume-role
```
  This means all of `commands` (and any commands after it in the same build) run under `assumeRole` without the user needing to write any of this themselves.

This follows the exact workaround proposed in the issue, and reuses two patterns already present in the codebase rather than inventing new ones:
- The `role`/`actionRole` plumbing already threaded from `CodeBuildStep` → `CodeBuildFactoryProps` → `CodeBuildFactory.produceAction` is extended the same way for `assumeRole`.
- The "grant `sts:AssumeRole` on an optional role" idiom already used in `docker-credentials.ts` (`grantee.grantPrincipal.addToPrincipalPolicy(...)`) is reused via `IRole.grant()`.

**Alternatives considered:**
- *Manually adding a `PolicyStatement` for `sts:AssumeRole`*, mirroring `docker-credentials.ts`'s literal `addToPrincipalPolicy` call — rejected in favor of `role.grant(principal, 'sts:AssumeRole')`, which is the more idiomatic CDK API and produces the same policy.
- *Selecting `credential_source` dynamically based on `buildEnvironment.computeType`* (`EcsContainer` vs `Ec2InstanceMetadata`) — deliberately deferred. Standard CodeBuild compute (the common case) uses `EcsContainer`; Lambda compute type would need `Ec2InstanceMetadata` instead. This is flagged in-code with a `ponytail:` comment naming the gap and the upgrade path, rather than speculatively branching on compute type before there's a concrete need.
- *Injecting the assume-role commands into a dedicated buildspec phase* (e.g. a synthetic `pre_build` block) instead of prepending to `install` — rejected because it would require a bigger change to buildspec merging (`mergeBuildSpecs`) for no behavioral benefit; commands exported in `install` are already available in later phases within the same CodeBuild run.

**Files changed:**
- `packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts` — new `assumeRole` prop.
- `packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts` — new `assumeRole` on `CodeBuildFactoryProps`, threaded through `fromCodeBuildStep`, grant + buildspec command injection in `produceAction`.
- `packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts` — new unit test.

### Describe any new or updated permissions being added

When `assumeRole` is set, the CodeBuild project's execution role is granted:

```json
{
  "Effect": "Allow",
  "Action": "sts:AssumeRole",
  "Resource": "<assumeRole ARN>"
}
```

No other permissions are added, and nothing changes for callers who don't set `assumeRole` (opt-in, default `undefined`).

### Description of how you validated changes

- Added a unit test (`assumeRole grants sts:AssumeRole and injects profile commands`) in `codebuild-step.test.ts`, following the existing style of the neighboring `role passed it used for project and code build action` test. It asserts:
  1. An `AWS::IAM::Policy` statement granting `sts:AssumeRole` on the target role's ARN is attached to the CodeBuild project's role.
  2. The generated `AWS::CodeBuild::Project` buildspec's `install` phase contains the `aws configure` / `export AWS_PROFILE` commands.
- Ran the full `pipelines` unit test suite locally: `yarn test pipelines` → 211/212 passing (all passing, including the new test), no regressions in the other 21 test suites.
- Not yet covered: a deploy-level integration test / snapshot under `packages/@aws-cdk-testing/framework-integ/test/pipelines`. Happy to add one if desired — flagging here per CONTRIBUTING.md, since I haven't run a real `cdk deploy` against an AWS account for this change.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*