### PR TITLE
feat(pipelines): add assumeRole parameter to CodeBuildStep

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/pipelines/test/integ.pipeline-with-assume-role.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/pipelines/test/integ.pipeline-with-assume-role.ts
@@ -1,0 +1,61 @@
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { ExpectedResult, IntegTest } from '@aws-cdk/integ-tests-alpha';
+import type { StackProps } from 'aws-cdk-lib';
+import { App, Stack, RemovalPolicy } from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+import * as pipelines from 'aws-cdk-lib/pipelines';
+
+const pipelineName = 'integ-pipelines-assume-role';
+
+class PipelineStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const sourceBucket = new s3.Bucket(this, 'SourceBucket', {
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    const pipeline = new pipelines.CodePipeline(this, 'Pipeline', {
+      pipelineName,
+      synth: new pipelines.ShellStep('Synth', {
+        input: pipelines.CodePipelineSource.s3(sourceBucket, 'key'),
+        commands: ['mkdir cdk.out', 'touch cdk.out/dummy'],
+      }),
+      selfMutation: false,
+    });
+
+    const assumeRole = new iam.Role(this, 'AssumeRole', {
+      assumedBy: new iam.AccountPrincipal(this.account),
+    });
+
+    const integTest = new pipelines.CodeBuildStep('IntegTest', {
+      commands: ['aws sts get-caller-identity'],
+      assumeRole,
+    });
+
+    // WHEN
+    pipeline.addWave('MyWave', {
+      post: [integTest],
+    });
+  }
+}
+
+const app = new App({
+  postCliContext: {
+    '@aws-cdk/core:newStyleStackSynthesis': '1',
+    '@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2': false,
+    '@aws-cdk/pipelines:reduceStageRoleTrustScope': true,
+  },
+});
+
+const stack = new PipelineStack(app, 'PipelineWithAssumeRole');
+
+const apiCall = new IntegTest(app, 'PipelineWithAssumeRoleTest', {
+  testCases: [stack],
+  diffAssets: true,
+}).assertions.awsApiCall('CodePipeline', 'getPipeline', { name: pipelineName });
+apiCall.assertAtPath('pipeline.name', ExpectedResult.stringLikeRegexp(pipelineName));
+
+app.synth();

--- a/packages/aws-cdk-lib/pipelines/README.md
+++ b/packages/aws-cdk-lib/pipelines/README.md
@@ -771,6 +771,25 @@ new pipelines.CodeBuildStep('Synth', {
 });
 ```
 
+#### Assuming a role before running commands
+
+If your `commands` need to act on a different account (for example, to invoke a
+Lambda function or seed test data in a deployed environment), pass `assumeRole`.
+CDK Pipelines grants the CodeBuild project's role `sts:AssumeRole` on the given
+role, and configures the AWS CLI to use it for the duration of the build:
+
+```ts
+declare const crossAccountRole: iam.IRole;
+new pipelines.CodeBuildStep('IntegTest', {
+  commands: ['./run-integ-tests.sh'],
+  assumeRole: crossAccountRole,
+});
+```
+
+`crossAccountRole` must already trust the CodeBuild project's role (or an ancestor
+of it) in its own trust policy; this property only grants the `sts:AssumeRole`
+permission, it does not create or modify the target role.
+
 You can also configure defaults for _all_ CodeBuild projects by passing `codeBuildDefaults`,
 or just for the synth, asset publishing, and self-mutation projects by passing `synthCodeBuildDefaults`,
 `assetPublishingCodeBuildDefaults`, or `selfMutationCodeBuildDefaults`:

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts
@@ -84,6 +84,19 @@ export interface CodeBuildStepProps extends ShellStepProps {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`.
+   *
+   * The CodeBuild project's role is granted `sts:AssumeRole` on this role,
+   * and `commands` run with this role's credentials active (via `AWS_PROFILE`).
+   *
+   * Useful for cross-account actions such as invoking a Lambda function or
+   * creating test data in a deployed account.
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * Changes to environment
    *
    * This environment will be combined with the pipeline's default
@@ -195,6 +208,13 @@ export class CodeBuildStep extends ShellStep {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`.
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * Build environment
    *
    * @default - No value specified at construction time, use defaults
@@ -250,6 +270,7 @@ export class CodeBuildStep extends ShellStep {
     this.cache = props.cache;
     this.role = props.role;
     this.actionRole = props.actionRole;
+    this.assumeRole = props.assumeRole;
     this.rolePolicyStatements = props.rolePolicyStatements;
     this.securityGroups = props.securityGroups;
     this.timeout = props.timeout;

--- a/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts
@@ -53,6 +53,13 @@ export interface CodeBuildFactoryProps {
   readonly actionRole?: iam.IRole;
 
   /**
+   * Role to assume before executing `commands`
+   *
+   * @default - Commands run under the CodeBuild project's own role
+   */
+  readonly assumeRole?: iam.IRole;
+
+  /**
    * If true, the build spec will be passed via the Cloud Assembly instead of rendered onto the Project
    *
    * Doing this has two advantages:
@@ -153,6 +160,7 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       projectName: step.projectName,
       role: step.role,
       actionRole: step.actionRole,
+      assumeRole: step.assumeRole,
       ...additional,
       projectOptions: mergeCodeBuildOptions(additional?.projectOptions, {
         buildEnvironment: step.buildEnvironment,
@@ -221,8 +229,15 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       throw new UnscopedValidationError(lit`RequiresCodebuildActionRequires`, `CodeBuild action '${this.stepId}' requires an input (and the pipeline doesn't have a Source to fall back to). Add an input or a pipeline source.`);
     }
 
+    const assumeRoleCommands = this.props.assumeRole ? [
+      `aws configure --profile cdk-assume-role set role_arn ${this.props.assumeRole.roleArn}`,
+      'aws configure --profile cdk-assume-role set credential_source EcsContainer',
+      'export AWS_PROFILE=cdk-assume-role',
+    ] : [];
+
     const installCommands = [
       ...generateInputArtifactLinkCommands(options.artifacts, extraInputs),
+      ...assumeRoleCommands,
       ...this.props.installCommands ?? [],
     ];
 
@@ -321,6 +336,10 @@ export class CodeBuildFactory implements ICodePipelineActionFactory {
       projectOptions.rolePolicy.forEach(policyStatement => {
         project.addToRolePolicy(policyStatement);
       });
+    }
+
+    if (this.props.assumeRole) {
+      this.props.assumeRole.grant(project.grantPrincipal, 'sts:AssumeRole');
     }
 
     const stackOutputEnv = mapValues(this.props.envFromCfnOutputs ?? {}, outputRef =>

--- a/packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts
+++ b/packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts
@@ -252,6 +252,53 @@ test('role passed it used for project and code build action', () => {
     ],
   });
 });
+test('assumeRole grants sts:AssumeRole and injects profile commands', () => {
+  const assumeRoleArn = 'arn:aws:iam::123456789012:role/AssumeRole';
+  const assumeRole = iam.Role.fromRoleArn(pipelineStack, 'AssumeRole', assumeRoleArn);
+
+  // WHEN
+  new cdkp.CodePipeline(pipelineStack, 'Pipeline', {
+    synth: new cdkp.CodeBuildStep('Synth', {
+      commands: ['./test.sh'],
+      input: cdkp.CodePipelineSource.gitHub('test/test', 'main'),
+      assumeRole,
+    }),
+  });
+
+  // THEN
+  const tpl = Template.fromStack(pipelineStack);
+
+  // The project's role can assume the target role
+  tpl.hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Resource: assumeRoleArn,
+        }),
+      ]),
+    }),
+  });
+
+  // The buildspec configures and exports the assumed-role profile before running commands
+  tpl.hasResourceProperties('AWS::CodeBuild::Project', {
+    Source: {
+      BuildSpec: Match.serializedJson(Match.objectLike({
+        phases: {
+          install: {
+            commands: Match.arrayWith([
+              `aws configure --profile cdk-assume-role set role_arn ${assumeRoleArn}`,
+              'aws configure --profile cdk-assume-role set credential_source EcsContainer',
+              'export AWS_PROFILE=cdk-assume-role',
+            ]),
+          },
+        },
+      })),
+    },
+  });
+});
+
 test('exportedVariables', () => {
   const pipeline = new ModernTestGitHubNpmPipeline(pipelineStack, 'Cdk');
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #18272

### Ai Usage

* Claude Code Sonnet 5 (Medium) + ponytail skill https://github.com/DietrichGebert/ponytail
* Generating unit tests and integration tests

### Reason for this change

`pipelines.CodeBuildStep` has no built-in way to run its commands under a different IAM role. This matters for cross-account deployment pipelines, where the CodeBuild project's own role can't reach resources in the deployed (target) account, e.g. invoking a Lambda function to run a DB migration, or seeding Cognito users for integration tests. Users currently have to hand-roll this with `aws sts assume-role` calls inside `commands`, wiring up the trust policy and `sts:AssumeRole` permission themselves each time.

### Description of changes

Added an `assumeRole?: iam.IRole` property to `CodeBuildStepProps` / `CodeBuildStep`. When set:

- The CodeBuild project's role is granted `sts:AssumeRole` on the given role (`assumeRole.grant(project.grantPrincipal, 'sts:AssumeRole')`).
- Three commands are prepended to the buildspec's `install` phase, before any user-supplied `installCommands`, which configure a named AWS CLI profile (`cdk-assume-role`) pointed at the role and export it as the active profile:

```
aws configure --profile cdk-assume-role set role_arn <roleArn>
aws configure --profile cdk-assume-role set credential_source EcsContainer
export AWS_PROFILE=cdk-assume-role
```

This means all of `commands` (and any commands after it in the same build) run under `assumeRole` without the user needing to write any of this themselves.

This follows the exact workaround proposed in the issue, and reuses two patterns already present in the codebase rather than inventing new ones:
- The `role`/`actionRole` plumbing already threaded from `CodeBuildStep` → `CodeBuildFactoryProps` → `CodeBuildFactory.produceAction` is extended the same way for `assumeRole`.
- The "grant `sts:AssumeRole` on an optional role" idiom already used in `docker-credentials.ts` (`grantee.grantPrincipal.addToPrincipalPolicy(...)`) is reused via `IRole.grant()`.

**Files changed:**
- `packages/aws-cdk-lib/pipelines/lib/codepipeline/codebuild-step.ts` new `assumeRole` prop.
- `packages/aws-cdk-lib/pipelines/lib/codepipeline/private/codebuild-factory.ts` new `assumeRole` on `CodeBuildFactoryProps`, threaded through `fromCodeBuildStep`, grant + buildspec command injection in `produceAction`.
- `packages/aws-cdk-lib/pipelines/test/codepipeline/codebuild-step.test.ts` new unit test.

### Describe any new or updated permissions being added

When `assumeRole` is set, the CodeBuild project's execution role is granted:

```json
{
  "Effect": "Allow",
  "Action": "sts:AssumeRole",
  "Resource": "<assumeRole ARN>"
}
```

No other permissions are added, and nothing changes for callers who don't set `assumeRole` (opt-in, default `undefined`).


### Description of how you validated changes

- Added a unit test (`assumeRole grants sts:AssumeRole and injects profile commands`) in `codebuild-step.test.ts`, following the existing style of the neighboring `role passed it used for project and code build action` test. It asserts:
  1. An `AWS::IAM::Policy` statement granting `sts:AssumeRole` on the target role's ARN is attached to the CodeBuild project's role.
  2. The generated `AWS::CodeBuild::Project` buildspec's `install` phase contains the `aws configure` / `export AWS_PROFILE` commands.
- Ran the full `pipelines` unit test suite locally: `yarn test pipelines` → 211/212 passing (all passing, including the new test), no regressions in the other 21 test suites.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
