### PR TITLE
fix(lambda-nodejs): detect esbuild in npm workspace-local node_modules

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
@@ -1,6 +1,7 @@
 import type { SpawnSyncOptions } from 'child_process';
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as path from 'path';
 import { Runtime } from '../../aws-lambda';
 import { UnscopedValidationError } from '../../core';
@@ -91,12 +92,21 @@ export function exec(cmd: string, args: string[], options?: SpawnSyncOptions) {
 }
 
 /**
- * Returns a module version by requiring its package.json file
+ * Returns a module version by requiring its package.json file.
+ *
+ * Resolves from `process.cwd()` so packages installed in workspace-local
+ * `node_modules/` (e.g. npm workspaces) are found when they are not hoisted
+ * to the monorepo root. A bare `require()` would resolve from this module's
+ * location under `aws-cdk-lib` and miss those installs.
+ *
+ * @see https://github.com/aws/aws-cdk/issues/37545
  */
 export function tryGetModuleVersionFromRequire(mod: string): string | undefined {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(`${mod}/package.json`).version;
+    // Resolve relative to the project where `cdk synth` is invoked, not from
+    // aws-cdk-lib's own node_modules path.
+    const req = createRequire(path.join(process.cwd(), 'package.json'));
+    return req(`${mod}/package.json`).version;
   } catch (err) {
     return undefined;
   }

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
@@ -1,8 +1,9 @@
 import child_process from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { bockfs } from '@aws-cdk/cdk-build-tools';
-import { callsites, exec, extractDependencies, findUp, findUpMultiple, getTsconfigCompilerOptions, getTsconfigCompilerOptionsArray } from '../lib/util';
+import { callsites, exec, extractDependencies, findUp, findUpMultiple, getTsconfigCompilerOptions, getTsconfigCompilerOptionsArray, tryGetModuleVersionFromRequire } from '../lib/util';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -153,6 +154,35 @@ describe('exec', () => {
     expect(() => exec('cmd', ['arg1', 'arg2'])).toThrow(new Error('bad error'));
 
     spawnSyncMock.mockRestore();
+  });
+});
+
+describe('tryGetModuleVersionFromRequire', () => {
+  test('resolves modules from process.cwd() (workspace-local node_modules)', () => {
+    // Mimic an npm workspace where the package lives under packages/my-app and
+    // esbuild is installed only in that workspace's node_modules (not hoisted).
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-esbuild-detect-'));
+    const workspaceDir = path.join(tmpRoot, 'packages', 'my-app');
+    const moduleDir = path.join(workspaceDir, 'node_modules', 'fake-esbuild');
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'my-app' }));
+    fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({
+      name: 'fake-esbuild',
+      version: '9.9.9',
+    }));
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(workspaceDir);
+      expect(tryGetModuleVersionFromRequire('fake-esbuild')).toBe('9.9.9');
+    } finally {
+      process.chdir(previousCwd);
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('returns undefined when module is not installed', () => {
+    expect(tryGetModuleVersionFromRequire('definitely-not-a-real-module-xyz')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- `PackageInstallation.detect()` / `tryGetModuleVersionFromRequire()` now resolves modules from `process.cwd()` via `Module.createRequire()`, instead of a bare `require()` that only searches from `aws-cdk-lib`'s own location.
- This finds `esbuild` (and other modules) installed in workspace-local `node_modules/` when npm does not hoist them to the monorepo root, avoiding a silent Docker bundling fallback.
- Adds unit tests covering workspace-local resolution and missing-module behavior.

fixes #37545

## Test plan

- [x] Standalone repro of old vs new resolution (workspace-local module found from cwd, missed from CDK module path)
- [x] Unit tests added in `aws-lambda-nodejs/test/util.test.ts`
- [ ] `yarn test aws-lambda-nodejs` after build
- [ ] Manual check with the npm workspaces repro from #37545: `PackageInstallation.detect('esbuild')` succeeds when esbuild is only under `packages/my-app/node_modules/`
