### PR TITLE
fix(lambda-nodejs): fails to find esbuild in npm workspace-local node_modules

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
@@ -1,6 +1,7 @@
 import type { SpawnSyncOptions } from 'child_process';
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as path from 'path';
 import { Runtime } from '../../aws-lambda';
 import { UnscopedValidationError } from '../../core';
@@ -91,12 +92,21 @@ export function exec(cmd: string, args: string[], options?: SpawnSyncOptions) {
 }
 
 /**
- * Returns a module version by requiring its package.json file
+ * Returns a module version by requiring its package.json file.
+ *
+ * Resolves from `process.cwd()` so packages installed in workspace-local
+ * `node_modules/` (e.g. npm workspaces) are found when they are not hoisted
+ * to the monorepo root. A bare `require()` would resolve from this module's
+ * location under `aws-cdk-lib` and miss those installs.
+ *
+ * @see https://github.com/aws/aws-cdk/issues/37545
  */
 export function tryGetModuleVersionFromRequire(mod: string): string | undefined {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(`${mod}/package.json`).version;
+    // Resolve relative to the project where `cdk synth` is invoked, not from
+    // aws-cdk-lib's own node_modules path.
+    const req = createRequire(path.join(process.cwd(), 'package.json'));
+    return req(`${mod}/package.json`).version;
   } catch (err) {
     return undefined;
   }

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/util.ts
@@ -94,20 +94,34 @@ export function exec(cmd: string, args: string[], options?: SpawnSyncOptions) {
 /**
  * Returns a module version by requiring its package.json file.
  *
- * Resolves from `process.cwd()` so packages installed in workspace-local
- * `node_modules/` (e.g. npm workspaces) are found when they are not hoisted
- * to the monorepo root. A bare `require()` would resolve from this module's
- * location under `aws-cdk-lib` and miss those installs.
+ * Tries resolution in order:
+ * 1. Optional `fromPath` (e.g. the caller's package.json) for workspace-local installs
+ * 2. `process.cwd()` so packages in the synth project's node_modules are found
+ * 3. Bare `require()` from this module's location (legacy / hoisted root installs)
  *
  * @see https://github.com/aws/aws-cdk/issues/37545
  */
-export function tryGetModuleVersionFromRequire(mod: string): string | undefined {
+export function tryGetModuleVersionFromRequire(mod: string, fromPath?: string): string | undefined {
+  const anchors: string[] = [];
+  if (fromPath !== undefined) {
+    anchors.push(fromPath);
+  }
+  anchors.push(path.join(process.cwd(), 'package.json'));
+
+  for (const anchor of anchors) {
+    try {
+      const req = createRequire(anchor);
+      return req(`${mod}/package.json`).version;
+    } catch {
+      // try next anchor
+    }
+  }
+
   try {
-    // Resolve relative to the project where `cdk synth` is invoked, not from
-    // aws-cdk-lib's own node_modules path.
-    const req = createRequire(path.join(process.cwd(), 'package.json'));
-    return req(`${mod}/package.json`).version;
-  } catch (err) {
+    // Fallback: resolve from this module's location (hoisted root deps)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(`${mod}/package.json`).version;
+  } catch {
     return undefined;
   }
 }
@@ -150,7 +164,7 @@ export function extractDependencies(pkgPath: string, modules: string[]): { [key:
 
   for (const mod of modules) {
     const version = tryGetModuleVersionFromPkg(mod, pkgJson, pkgPath)
-      ?? tryGetModuleVersionFromRequire(mod);
+      ?? tryGetModuleVersionFromRequire(mod, pkgPath);
     if (!version) {
       throw new UnscopedValidationError(lit`CannotExtractModuleVersion`, `Cannot extract version for module '${mod}'. Check that it's referenced in your package.json or installed.`);
     }

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
@@ -1,8 +1,9 @@
 import child_process from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { bockfs } from '@aws-cdk/cdk-build-tools';
-import { callsites, exec, extractDependencies, findUp, findUpMultiple, getTsconfigCompilerOptions, getTsconfigCompilerOptionsArray } from '../lib/util';
+import { callsites, exec, extractDependencies, findUp, findUpMultiple, getTsconfigCompilerOptions, getTsconfigCompilerOptionsArray, tryGetModuleVersionFromRequire } from '../lib/util';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -153,6 +154,35 @@ describe('exec', () => {
     expect(() => exec('cmd', ['arg1', 'arg2'])).toThrow(new Error('bad error'));
 
     spawnSyncMock.mockRestore();
+  });
+});
+
+describe('tryGetModuleVersionFromRequire', () => {
+  test('resolves modules from process.cwd() (workspace-local node_modules)', () => {
+    // Mimic an npm workspace where the package lives under packages/my-app and
+    // esbuild is installed only in that workspace's node_modules (not hoisted).
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-esbuild-detect-'));
+    const workspaceDir = path.join(tmpRoot, 'packages', 'my-app');
+    const moduleDir = path.join(workspaceDir, 'node_modules', 'fake-esbuild');
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'my-app' }));
+    fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({
+      name: 'fake-esbuild',
+      version: '9.9.9',
+    }));
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(workspaceDir);
+      expect(tryGetModuleVersionFromRequire('fake-esbuild')).toBe('9.9.9');
+    } finally {
+      process.chdir(previousCwd);
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('returns undefined when module is not installed', () => {
+    expect(tryGetModuleVersionFromRequire('definitely-not-a-real-module-xyz')).toBeUndefined();
   });
 });
 

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/util.test.ts
@@ -181,6 +181,23 @@ describe('tryGetModuleVersionFromRequire', () => {
     }
   });
 
+  test('falls back to require() when module is not resolvable from cwd', () => {
+    // Empty temp dir has no node_modules, so the cwd anchor misses. typescript is
+    // installed in this monorepo and still resolvable via the legacy require()
+    // anchor under aws-cdk-lib.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-esbuild-fallback-'));
+    fs.writeFileSync(path.join(tmpRoot, 'package.json'), JSON.stringify({ name: 'empty' }));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpRoot);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      expect(tryGetModuleVersionFromRequire('typescript')).toBe(require('typescript/package.json').version);
+    } finally {
+      process.chdir(previousCwd);
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   test('returns undefined when module is not installed', () => {
     expect(tryGetModuleVersionFromRequire('definitely-not-a-real-module-xyz')).toBeUndefined();
   });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37545.

### Reason for this change

In npm workspaces, esbuild often ends up in a package-local `node_modules/` instead of the repo root. `PackageInstallation.detect()` used a bare `require()`, which only looks from inside `aws-cdk-lib`, so it missed those installs and fell back to Docker bundling even when local esbuild was fine.

### Description of changes

Changed `tryGetModuleVersionFromRequire()` to resolve from `process.cwd()` with `Module.createRequire()`. That matches where people usually run `cdk synth`, so workspace-local esbuild gets picked up.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Added unit tests in `aws-lambda-nodejs/test/util.test.ts` for workspace-local resolution and the missing-module case. Also sanity-checked the old vs new resolution behavior against the repro in #37545.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*