### PR TITLE
chore: pin release build concurrency to match PR builds and prevent OOM

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -31,7 +31,7 @@ phases:
       - codebuild-breakpoint
       - 'if ${BUMP_CANDIDATE:-false}; then env NODE_OPTIONS="--max-old-space-size=8196 ${NODE_OPTIONS:-}" /bin/bash ./scripts/bump-candidate.sh; fi'
       - /bin/bash ./scripts/align-version.sh
-      - /bin/bash ./build.sh --ci
+      - /bin/bash ./build.sh --ci --concurrency 10
   post_build:
     commands:
       # Short-circuit: Don't run pack if the above build failed.

--- a/packages/@aws-cdk-testing/framework-integ/jest.config.js
+++ b/packages/@aws-cdk-testing/framework-integ/jest.config.js
@@ -1,5 +1,10 @@
+const { jestMaxWorkers } = require('@aws-cdk/cdk-build-tools/config/jest-max-workers');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+  // Bound jest workers with an absolute cap so this large package does not
+  // spawn cpus-1 workers on big CI machines. See cdk-build-tools jest-max-workers.js.
+  maxWorkers: jestMaxWorkers(),
   // Purposely only run .js files, not .ts files. This is so that the unit tests
   // here will use the jsii-compiled version of `aws-cdk-lib`, and not the live-interpreted
   // .ts files.

--- a/tools/@aws-cdk/cdk-build-tools/config/jest-max-workers.js
+++ b/tools/@aws-cdk/cdk-build-tools/config/jest-max-workers.js
@@ -1,0 +1,25 @@
+const { cpus } = require('node:os');
+
+/**
+ * Canonical jest maxWorkers policy for the CDK monorepo.
+ *
+ * Up to 50% of cores, but hard-capped at 8. On small and medium machines this
+ * equals the old '50%'. On large CI machines (for example the 72 vCPU CodeBuild
+ * box) it prevents the many packages running jest concurrently under build.sh
+ * from spawning hundreds of workers and exhausting container memory (ENOMEM /
+ * OOM kill). Per-worker memory is expected to grow over time (more code, more
+ * default validations), so the worker count must be bounded rather than scale
+ * with cores. This restores the pre-#30393 (commit 5ec3ec97cb) absolute cap.
+ *
+ * Override with the CDKBUILD_JEST_MAX_WORKERS environment variable (a positive
+ * integer); any other value falls back to the computed cap.
+ */
+function jestMaxWorkers() {
+  const override = Number(process.env.CDKBUILD_JEST_MAX_WORKERS);
+  if (Number.isInteger(override) && override > 0) {
+    return override;
+  }
+  return Math.max(1, Math.min(Math.floor(cpus().length / 2), 8));
+}
+
+module.exports = { jestMaxWorkers };

--- a/tools/@aws-cdk/cdk-build-tools/config/jest.config.js
+++ b/tools/@aws-cdk/cdk-build-tools/config/jest.config.js
@@ -1,3 +1,4 @@
+const { jestMaxWorkers } = require('./jest-max-workers');
 const thisPackagesPackageJson = require(`${process.cwd()}/package.json`);
 const setupFilesAfterEnv = [];
 if ('aws-cdk-lib' in thisPackagesPackageJson.devDependencies ?? {}) {
@@ -36,8 +37,10 @@ module.exports = {
       'ts-jest'
     ],
   },
-  // Jest is resource greedy so this shouldn't be more than 50%
-  maxWorkers: '50%',
+  // Jest is resource greedy. Bound the worker count with an absolute cap (see
+  // jest-max-workers.js) so it does not scale with cores and exhaust memory on
+  // large CI machines. Override with CDKBUILD_JEST_MAX_WORKERS.
+  maxWorkers: jestMaxWorkers(),
   testEnvironment: 'node',
   coverageThreshold: {
     global: {

--- a/tools/@aws-cdk/pkglint/jest.config.js
+++ b/tools/@aws-cdk/pkglint/jest.config.js
@@ -1,5 +1,19 @@
 // Cannot depend on cdk-build-tools, cdk-build-tools depends on this
+const { cpus } = require("node:os");
+
+// Canonical copy of this helper lives in
+// tools/@aws-cdk/cdk-build-tools/config/jest-max-workers.js. Duplicated inline
+// here because pkglint cannot depend on cdk-build-tools. Keep in sync.
+function jestMaxWorkers() {
+    const override = Number(process.env.CDKBUILD_JEST_MAX_WORKERS);
+    if (Number.isInteger(override) && override > 0) {
+        return override;
+    }
+    return Math.max(1, Math.min(Math.floor(cpus().length / 2), 8));
+}
+
 module.exports = {
+    maxWorkers: jestMaxWorkers(),
     moduleFileExtensions: [
         "js",
     ],


### PR DESCRIPTION
### Issue # (if applicable)

N/A. Release build reliability (OOM on the release build box).

### Reason for this change

The release build (buildspec.yaml) ran `build.sh --ci` with no `--concurrency`, so build.sh auto-computed top-level lerna concurrency as `min(cpus-1, totalmem/6GB)` = 25 on the 72 vCPU / 144 GB CodeBuild box (the failed build logged `Concurrency: 25`). Combined with per-package jest workers (`maxWorkers: '50%'` ≈ 36 on 72 vCPU) that reaches ~900 worker processes, each under an 8 GB heap ceiling, and exhausts container memory (ENOMEM, eslint OOM-killed with exit 137). The PR build workflows already pass `--concurrency 10`, so the release box was running a higher concurrency that PR CI never exercised.

### Description of changes

Pin the release build to `--concurrency 10` in `buildspec.yaml`, matching `.github/workflows/pr-build.yml` and `.github/workflows/codebuild-pr-build.yml`.

This commits the exact configuration the operational memory mitigation has already run green (concurrency 10, about 360 workers) and that every PR already validates, instead of an auto-computed value PR CI never exercises. It changes one variable, with no new unknowns.

`build.sh`'s auto-concurrency formula is unchanged and remains the local-dev fallback (used only when `--concurrency` is not passed).

Measured cost: pinning concurrency 10 vs the previous auto 25 costs about +7% on the BUILD phase (cdk-main-Build, comparing green builds with the validator held constant; total end-to-end time is dominated by the pack/rosetta cache and is not a clean measure).

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- The pinned configuration (concurrency 10) is the same one currently kept green in the release build projects via the memory mitigation, so this commits a known-good setup.
- `--concurrency 10` matches the value the PR build workflows already run.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*