### PR TITLE
chore: pin release build concurrency to match PR builds and prevent OOM

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -31,7 +31,7 @@ phases:
       - codebuild-breakpoint
       - 'if ${BUMP_CANDIDATE:-false}; then env NODE_OPTIONS="--max-old-space-size=8196 ${NODE_OPTIONS:-}" /bin/bash ./scripts/bump-candidate.sh; fi'
       - /bin/bash ./scripts/align-version.sh
-      - /bin/bash ./build.sh --ci
+      - /bin/bash ./build.sh --ci --concurrency 10
   post_build:
     commands:
       # Short-circuit: Don't run pack if the above build failed.


### PR DESCRIPTION
### Issue # (if applicable)

N/A. Release build reliability (OOM on the release build box).

### Reason for this change

The release build (buildspec.yaml) ran `build.sh --ci` with no `--concurrency`, so build.sh auto-computed top-level lerna concurrency as `min(cpus-1, totalmem/6GB)` = 25 on the 72 vCPU / 144 GB CodeBuild box (the failed build logged `Concurrency: 25`). Combined with per-package jest workers (`maxWorkers: '50%'` ≈ 36 on 72 vCPU) that reaches ~900 worker processes, each under an 8 GB heap ceiling, and exhausts container memory (ENOMEM, eslint OOM-killed with exit 137). The PR build workflows already pass `--concurrency 10`, so the release box was running a higher concurrency that PR CI never exercised.

### Description of changes

Pin the release build to `--concurrency 10` in `buildspec.yaml`, matching `.github/workflows/pr-build.yml` and `.github/workflows/codebuild-pr-build.yml`.

This commits the exact configuration the operational memory mitigation has already run green (concurrency 10, about 360 workers) and that every PR already validates, instead of an auto-computed value PR CI never exercises. It changes one variable, with no new unknowns.

`build.sh`'s auto-concurrency formula is unchanged and remains the local-dev fallback (used only when `--concurrency` is not passed).

Measured cost: pinning concurrency 10 vs the previous auto 25 costs about +7% on the BUILD phase (cdk-main-Build, comparing green builds with the validator held constant; total end-to-end time is dominated by the pack/rosetta cache and is not a clean measure).

Follow-up: an absolute jest worker cap (bounding per-package workers so per-worker memory growth cannot re-breach the limit) will land as a separate, data-driven change once the post-merge measurement run informs its value. This PR is intentionally the pin alone.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- The pinned configuration (concurrency 10) is the same one currently kept green in the release build projects via the memory mitigation, so this commits a known-good setup.
- `--concurrency 10` matches the value the PR build workflows already run.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*