### PR TITLE
chore: remove dead codeowners rules for packages moved to aws-cdk-cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-/packages/aws-cdk/ @aws/aws-cdk-core-team
-/packages/@aws-cdk-testing/cli-integ/ @aws/aws-cdk-core-team
 /packages/aws-cdk-lib/core/ @aws/aws-cdk-core-team
-/packages/@aws-cdk/cli-lib-alpha/ @aws/aws-cdk-core-team


### PR DESCRIPTION
### Issue # (if applicable)

None — small repo-hygiene cleanup.

### Reason for this change

Three of the four rules in `.github/CODEOWNERS` point at packages that no longer exist in this repository (they moved to [aws/aws-cdk-cli](https://github.com/aws/aws-cdk-cli)), so those rules match nothing and silently assign no reviewers:

- `/packages/aws-cdk/` → 404 at current HEAD
- `/packages/@aws-cdk-testing/cli-integ/` → 404
- `/packages/@aws-cdk/cli-lib-alpha/` → 404

(Verified via the contents API pinned to `8a62b58`; `packages/` contains only `@aws-cdk-testing`, `@aws-cdk`, `aws-cdk-lib`, `awslint`, `decdk`.)

### Description of changes

Removes the three dead rules, keeping the still-valid `/packages/aws-cdk-lib/core/` entry. If you'd rather re-point them at new paths instead of removing them, happy to adjust.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

`gh api repos/aws/aws-cdk/contents/<path>?ref=8a62b58...` returns 404 for the three removed paths and 200 for the retained one.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

---

For transparency: I used AI assistance to spot and draft this; I verified the 404s and the retained path myself.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
