### PR TITLE
chore: pin external github actions to full commit shas

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: hmarr/auto-approve-action@v4.0.0
+    - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/issue-reprioritization.yml
+++ b/.github/workflows/issue-reprioritization.yml
@@ -19,7 +19,7 @@ jobs:
           new-label: p1
           reprioritization-threshold: 20
           project-column-url: https://github.com/aws/aws-cdk/projects/13#column-18002436
-      - uses: kaizencc/pr-triage-manager@main
+      - uses: kaizencc/pr-triage-manager@3a2558737a4d072feaaa4c1768b92f51abfde53b # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           on-pulls: ${{ steps.reprioritization-manager.outputs.linked-pulls }}


### PR DESCRIPTION
### Issue # (if applicable)

None — CI supply-chain hardening, 2 lines.

### Reason for this change

Two workflows reference GitHub Actions that live **outside the AWS org** on mutable refs:

- `issue-reprioritization.yml` uses `kaizencc/pr-triage-manager@main` — a personal account, running with `issues: write` and the repo `GITHUB_TOKEN`.
- `auto-approve.yml` uses `hmarr/auto-approve-action@v4.0.0` — a movable tag, running on `pull_request_target` with `pull-requests: write`.

A branch or tag can move after review; a full commit SHA cannot. Dependabot keeps SHA pins current but cannot manage `@main` branch refs.

### Description of changes

Pins both to the commit each ref resolves to today, with the original ref kept as a comment:

- `kaizencc/pr-triage-manager@3a25587… # main`
- `hmarr/auto-approve-action@f0939ea… # v4.0.0`

I deliberately left the AWS-owned `cdklabs/*` and `aws-github-ops/*` `@main` refs untouched — those are your own orgs, so the trust calculus is yours; happy to extend the PR if you'd like them pinned too.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

`gh api repos/kaizencc/pr-triage-manager/commits/main --jq .sha` and `gh api repos/hmarr/auto-approve-action/git/ref/tags/v4.0.0` — the pinned SHAs are the current resolutions of the existing refs, so behavior is unchanged.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

---

For transparency: I used AI assistance to spot and draft this; I resolved and verified both SHAs myself.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
