### PR TITLE
docs(signer): remove trailing whitespace in README example

### DIFF
--- a/packages/aws-cdk-lib/aws-signer/README.md
+++ b/packages/aws-cdk-lib/aws-signer/README.md
@@ -33,7 +33,7 @@ For more information, visit [Signing Profiles in AWS Signer](https://docs.aws.am
 The following code sets up a signing profile for signing lambda code bundles -
 
 ```ts
-const signingProfile = new signer.SigningProfile(this, 'SigningProfile', { 
+const signingProfile = new signer.SigningProfile(this, 'SigningProfile', {
   platform: signer.Platform.AWS_LAMBDA_SHA384_ECDSA,
 });
 ```


### PR DESCRIPTION
Removes a stray trailing space inside the `SigningProfile` code example in the aws-signer README. Docs-only, no functional change.

> Draft opened to exercise CI on the branch — not intended for merge as-is.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*