### PR TITLE
chore(framework-integ): register shared validation-ack hook in jest config

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/jest.config.js
+++ b/packages/@aws-cdk-testing/framework-integ/jest.config.js
@@ -11,4 +11,9 @@ module.exports = {
   ],
 
   testEnvironment: 'node',
+
+  // Acknowledge test-only CloudFormationValidatePlugin warnings.
+  setupFilesAfterEnv: [
+    'aws-cdk-lib/testhelpers/jest-global-app-testhook',
+  ],
 };

--- a/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts
+++ b/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts
@@ -1,5 +1,5 @@
 // Registers a global App init hook that acknowledges common validation warnings for unit tests.
-// Used via Jest's `setupFilesAfterEnv` in both aws-cdk-lib and alpha module test suites.
+// Used via Jest's `setupFilesAfterEnv` in aws-cdk-lib, alpha module, and framework-integ test suites.
 
 import * as cdk from '../core';
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Since #38135 the default `CloudFormationValidatePlugin` runs on every `app.synth()`. The core jest unit tests in `@aws-cdk-testing/framework-integ` build stacks with invented resource types (e.g. `Aws::Some::Resource`) and resource-less stacks, tripping `F3006` ("unknown resource type") and `F0001` ("empty Resources section"). The `tree-metadata` scale test alone synths  A LOT of such resources, flooding build output with a warning per resource (example: https://github.com/aws/aws-cdk/actions/runs/29494171884/job/87607102933?pr=38324).

`aws-cdk-lib`'s unit tests already acknowledge these test-only rules via the shared `jest-global-app-testhook`, auto-registered by the `cdk-build-tools` base jest config for every `aws-cdk-lib`-dependent package. This package uses a standalone `jest.config.js` that never wired it up.

### Description of changes

Register the shared hook in `framework-integ`'s `jest.config.js` (`setupFilesAfterEnv`), matching every other `aws-cdk-lib`-dependent package. This affects only the jest unit tests here — integ tests run via the integ-runner so their validation is unchanged.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes
Checked Github build logs of this PR

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
