### PR TITLE
fix(bedrockagentcore): set default child on Gateway L2 so applyRemovalPolicy works

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/BedrockAgentCoreGatewayRemovalPolicyIntegTest.metadata.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/BedrockAgentCoreGatewayRemovalPolicyIntegTest.metadata.json
@@ -1,0 +1,24 @@
+{
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest": [
+    {
+      "type": "aws:cdk:analytics:construct",
+      "data": "*"
+    }
+  ],
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway": [
+    {
+      "type": "aws:cdk:analytics:construct",
+      "data": "*"
+    }
+  ],
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/ServiceRole": [
+    {
+      "type": "aws:cdk:analytics:construct",
+      "data": "*"
+    }
+  ],
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/ServiceRole/Resource": null,
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/Resource": null,
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/BootstrapVersion": null,
+  "/BedrockAgentCoreGatewayRemovalPolicyIntegTest/CheckBootstrapVersion": null
+}

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/BedrockAgentCoreGatewayRemovalPolicyIntegTest.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/BedrockAgentCoreGatewayRemovalPolicyIntegTest.template.json
@@ -1,0 +1,118 @@
+{
+  "Resources": {
+    "RemovalPolicyGatewayServiceRole51B3A40B": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock-agentcore.amazonaws.com"
+              }
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                },
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":bedrock-agentcore:",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId"
+                        },
+                        ":gateway/integ-test-removal-policy-gateway*"
+                      ]
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock-agentcore.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Description": "Service role for Bedrock AgentCore Gateway integ-test-removal-policy-gateway"
+      }
+    },
+    "RemovalPolicyGateway919242FF": {
+      "Type": "AWS::BedrockAgentCore::Gateway",
+      "Properties": {
+        "AuthorizerType": "NONE",
+        "Description": "Gateway used to verify applyRemovalPolicy on the L2",
+        "Name": "integ-test-removal-policy-gateway",
+        "ProtocolConfiguration": {
+          "Mcp": {
+            "Instructions": "Default gateway to connect to external MCP tools",
+            "SearchType": "SEMANTIC",
+            "SupportedVersions": [
+              "2025-03-26"
+            ]
+          }
+        },
+        "ProtocolType": "MCP",
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "RemovalPolicyGatewayServiceRole51B3A40B",
+            "Arn"
+          ]
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    }
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+    }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                  ],
+                  {
+                    "Ref": "BootstrapVersion"
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+        }
+      ]
+    }
+  }
+}

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/integ.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/integ.json
@@ -1,0 +1,16 @@
+{
+  "version": "53.0.0",
+  "testCases": {
+    "GatewayRemovalPolicyIntegTest/DefaultTest": {
+      "stacks": [
+        "BedrockAgentCoreGatewayRemovalPolicyIntegTest"
+      ],
+      "regions": [
+        "us-east-1", "us-east-2", "us-west-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"
+      ],
+      "assertionStack": "GatewayRemovalPolicyIntegTest/DefaultTest/DeployAssert",
+      "assertionStackName": "GatewayRemovalPolicyIntegTestDefaultTestDeployAssertA1B2C3D4"
+    }
+  },
+  "minimumCliVersion": "2.1121.0"
+}

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/tree.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.js.snapshot/tree.json
@@ -1,0 +1,163 @@
+{
+  "version": "tree-0.1",
+  "tree": {
+    "id": "App",
+    "path": "",
+    "constructInfo": {
+      "fqn": "aws-cdk-lib.App",
+      "version": "0.0.0"
+    },
+    "children": {
+      "BedrockAgentCoreGatewayRemovalPolicyIntegTest": {
+        "id": "BedrockAgentCoreGatewayRemovalPolicyIntegTest",
+        "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest",
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.Stack",
+          "version": "0.0.0"
+        },
+        "children": {
+          "RemovalPolicyGateway": {
+            "id": "RemovalPolicyGateway",
+            "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_bedrockagentcore.Gateway",
+              "version": "0.0.0"
+            },
+            "children": {
+              "ServiceRole": {
+                "id": "ServiceRole",
+                "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/ServiceRole",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Role",
+                  "version": "0.0.0"
+                },
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/ServiceRole/Resource",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                      "version": "0.0.0"
+                    },
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                      "aws:cdk:cloudformation:logicalId": "RemovalPolicyGatewayServiceRole51B3A40B",
+                      "aws:cdk:cloudformation:props": {
+                        "assumeRolePolicyDocument": {
+                          "Statement": [
+                            {
+                              "Action": "sts:AssumeRole",
+                              "Effect": "Allow",
+                              "Principal": {
+                                "Service": "bedrock-agentcore.amazonaws.com"
+                              }
+                            },
+                            {
+                              "Action": "sts:AssumeRole",
+                              "Condition": {
+                                "StringEquals": {
+                                  "aws:SourceAccount": {
+                                    "Ref": "AWS::AccountId"
+                                  }
+                                },
+                                "ArnLike": {
+                                  "aws:SourceArn": {
+                                    "Fn::Join": [
+                                      "",
+                                      [
+                                        "arn:",
+                                        {
+                                          "Ref": "AWS::Partition"
+                                        },
+                                        ":bedrock-agentcore:",
+                                        {
+                                          "Ref": "AWS::Region"
+                                        },
+                                        ":",
+                                        {
+                                          "Ref": "AWS::AccountId"
+                                        },
+                                        ":gateway/integ-test-removal-policy-gateway*"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "Effect": "Allow",
+                              "Principal": {
+                                "Service": "bedrock-agentcore.amazonaws.com"
+                              }
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "description": "Service role for Bedrock AgentCore Gateway integ-test-removal-policy-gateway"
+                      }
+                    }
+                  }
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/RemovalPolicyGateway/Resource",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_bedrockagentcore.CfnGateway",
+                  "version": "0.0.0"
+                },
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::BedrockAgentCore::Gateway",
+                  "aws:cdk:cloudformation:logicalId": "RemovalPolicyGateway919242FF",
+                  "aws:cdk:cloudformation:props": {
+                    "authorizerType": "NONE",
+                    "description": "Gateway used to verify applyRemovalPolicy on the L2",
+                    "name": "integ-test-removal-policy-gateway",
+                    "protocolConfiguration": {
+                      "mcp": {
+                        "instructions": "Default gateway to connect to external MCP tools",
+                        "searchType": "SEMANTIC",
+                        "supportedVersions": [
+                          "2025-03-26"
+                        ]
+                      }
+                    },
+                    "protocolType": "MCP",
+                    "roleArn": {
+                      "Fn::GetAtt": [
+                        "RemovalPolicyGatewayServiceRole51B3A40B",
+                        "Arn"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "BootstrapVersion": {
+            "id": "BootstrapVersion",
+            "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/BootstrapVersion",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnParameter",
+              "version": "0.0.0"
+            }
+          },
+          "CheckBootstrapVersion": {
+            "id": "CheckBootstrapVersion",
+            "path": "BedrockAgentCoreGatewayRemovalPolicyIntegTest/CheckBootstrapVersion",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnRule",
+              "version": "0.0.0"
+            }
+          }
+        }
+      },
+      "Tree": {
+        "id": "Tree",
+        "path": "Tree",
+        "constructInfo": {
+          "fqn": "constructs.Construct",
+          "version": "10.6.0"
+        }
+      }
+    }
+  }
+}

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-bedrockagentcore/test/agentcore/gateway/integ.gateway-removal-policy.ts
@@ -1,0 +1,20 @@
+import * as integ from '@aws-cdk/integ-tests-alpha';
+import * as cdk from 'aws-cdk-lib';
+import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'BedrockAgentCoreGatewayRemovalPolicyIntegTest', {
+});
+
+// Verify applyRemovalPolicy works on the Gateway L2 (sets DeletionPolicy/UpdateReplacePolicy on the CfnGateway)
+const gateway = new agentcore.Gateway(stack, 'RemovalPolicyGateway', {
+  gatewayName: 'integ-test-removal-policy-gateway',
+  description: 'Gateway used to verify applyRemovalPolicy on the L2',
+  authorizerConfiguration: agentcore.GatewayAuthorizer.withNoAuth(),
+});
+
+gateway.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+
+new integ.IntegTest(app, 'GatewayRemovalPolicyIntegTest', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-bedrockagentcore/lib/gateway/gateway.ts
+++ b/packages/aws-cdk-lib/aws-bedrockagentcore/lib/gateway/gateway.ts
@@ -594,6 +594,10 @@ export class Gateway extends GatewayBase {
     this.createdAt = _resource.attrCreatedAt;
     this.updatedAt = _resource.attrUpdatedAt;
     this.statusReason = _resource.attrStatusReasons;
+    // Explicitly set the default child: the construct also creates a ServiceRole
+    // and (for some authorizers) a UserPool child, so CDK does not auto-assign
+    // the Cfn resource as the default child, which breaks applyRemovalPolicy().
+    this.node.defaultChild = _resource;
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-bedrockagentcore/test/agentcore/gateway/gateway-coverage.test.ts
+++ b/packages/aws-cdk-lib/aws-bedrockagentcore/test/agentcore/gateway/gateway-coverage.test.ts
@@ -486,6 +486,15 @@ describe('Gateway grant methods tests', () => {
     });
   });
 
+  test('Should apply removal policy via the L2 construct', () => {
+    expect(() => gateway.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY)).not.toThrow();
+
+    const cfnGateway = gateway.node.defaultChild as cdk.CfnResource;
+    expect(cfnGateway).toBeDefined();
+    expect(cfnGateway.cfnOptions.deletionPolicy).toBe('Delete');
+    expect(cfnGateway.cfnOptions.updateReplacePolicy).toBe('Delete');
+  });
+
   test('Should grant custom actions to IAM principal scoped to gateway ARN', () => {
     gateway.grant(grantee, 'bedrock-agentcore:GetGateway', 'bedrock-agentcore:ListGatewayTargets');
 


### PR DESCRIPTION
### Issue # (if applicable)

Part of #38327.

### Reason
The `Gateway` L2 construct creates a `CfnGateway` plus a `ServiceRole` (and a `UserPool` for some authorizers), so CDK never auto-assigns the `CfnGateway` as `node.defaultChild`. Calling `gateway.applyRemovalPolicy(...)` on the L2 threw `CannotApplyRemovalPolicy`.

### Solution
Explicitly set `this.node.defaultChild = _resource` right after constructing the `CfnGateway`, matching how other L2 resources behave. `applyRemovalPolicy()` now resolves to the L1 and correctly sets `DeletionPolicy` / `UpdateReplacePolicy`.

### Changes
- `packages/aws-cdk-lib/aws-bedrockagentcore/lib/gateway/gateway.ts` — assign `node.defaultChild` to the `CfnGateway`.
- `packages/aws-cdk-lib/aws-bedrockagentcore/test/agentcore/gateway/gateway-coverage.test.ts` — regression test asserting `applyRemovalPolicy(RemovalPolicy.DESTROY)` does not throw and propagates to the underlying `CfnGateway`.

### Test
`npx jest aws-bedrockagentcore/test/agentcore/gateway/gateway-coverage.test.ts` passes (49 tests).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license and that I've followed the contributing guidelines.*