### PR TITLE
fix: cross-stack warnings are emitted for nested stacks

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/refs.ts
+++ b/packages/aws-cdk-lib/core/lib/private/refs.ts
@@ -137,6 +137,52 @@ function resolveValue(consumer: Stack, reference: CfnReference, strengthOverride
     return reference;
   }
 
+  // unsupported: stacks from different apps
+  if (producer.node.root !== consumer.node.root) {
+    throw new UnscopedValidationError(lit`CannotReferenceAcrossApps`, 'Cannot reference across apps. Consuming and producing stacks must be defined within the same CDK app.');
+  }
+
+  // ----------------------------------------------------------------------
+  // consumer is nested in the producer (directly or indirectly)
+  // ----------------------------------------------------------------------
+
+  // if the consumer is nested within the producer (directly or indirectly),
+  // wire through a CloudFormation parameter and then resolve the reference with
+  // the parent stack as the consumer.
+  if (consumer.nestedStackParent && isNested(consumer, producer)) {
+    const parameterValue = resolveValue(consumer.nestedStackParent, reference);
+    return createNestedStackParameter(consumer, reference, parameterValue);
+  }
+
+  // ----------------------------------------------------------------------
+  // producer is a nested stack
+  // ----------------------------------------------------------------------
+
+  // if the producer is nested, always publish the value through a
+  // cloudformation output and resolve recursively with the Fn::GetAtt
+  // of the output in the parent stack.
+
+  // one might ask, if the consumer is not a parent of the producer,
+  // why not just use export/import? the reason is that we cannot
+  // generate an "export name" from a nested stack because the export
+  // name must contain the stack name to ensure uniqueness, and we
+  // don't know the stack name of a nested stack before we deploy it.
+  // therefore, we can only export from a top-level stack.
+  if (producer.nested) {
+    const outputValue = createNestedStackOutput(producer, reference);
+    const resolvedValue = resolveValue(consumer, outputValue);
+
+    if (reference.typeHint === ResolutionTypeHint.STRING_LIST) {
+      return Tokenization.reverseList(Fn.split(STRING_LIST_REFERENCE_DELIMITER, Token.asString(resolvedValue))) as IResolvable;
+    } else {
+      return resolvedValue;
+    }
+  }
+
+  // ----------------------------------------------------------------------
+  // export/import
+  // ----------------------------------------------------------------------
+
   // Emit a once-per-app warning nudging users toward weak references
   const appRoot = consumer.node.root;
   if (!(appRoot as any)[WEAK_REFS_WARNING_EMITTED]) {
@@ -156,11 +202,6 @@ function resolveValue(consumer: Stack, reference: CfnReference, strengthOverride
         '(See: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/README.md#reference-strength)',
       );
     }
-  }
-
-  // unsupported: stacks from different apps
-  if (producer.node.root !== consumer.node.root) {
-    throw new UnscopedValidationError(lit`CannotReferenceAcrossApps`, 'Cannot reference across apps. Consuming and producing stacks must be defined within the same CDK app.');
   }
 
   // stacks are not in the same account
@@ -205,47 +246,6 @@ function resolveValue(consumer: Stack, reference: CfnReference, strengthOverride
       producerStackArn,
     });
   }
-
-  // ----------------------------------------------------------------------
-  // consumer is nested in the producer (directly or indirectly)
-  // ----------------------------------------------------------------------
-
-  // if the consumer is nested within the producer (directly or indirectly),
-  // wire through a CloudFormation parameter and then resolve the reference with
-  // the parent stack as the consumer.
-  if (consumer.nestedStackParent && isNested(consumer, producer)) {
-    const parameterValue = resolveValue(consumer.nestedStackParent, reference);
-    return createNestedStackParameter(consumer, reference, parameterValue);
-  }
-
-  // ----------------------------------------------------------------------
-  // producer is a nested stack
-  // ----------------------------------------------------------------------
-
-  // if the producer is nested, always publish the value through a
-  // cloudformation output and resolve recursively with the Fn::GetAtt
-  // of the output in the parent stack.
-
-  // one might ask, if the consumer is not a parent of the producer,
-  // why not just use export/import? the reason is that we cannot
-  // generate an "export name" from a nested stack because the export
-  // name must contain the stack name to ensure uniqueness, and we
-  // don't know the stack name of a nested stack before we deploy it.
-  // therefore, we can only export from a top-level stack.
-  if (producer.nested) {
-    const outputValue = createNestedStackOutput(producer, reference);
-    const resolvedValue = resolveValue(consumer, outputValue);
-
-    if (reference.typeHint === ResolutionTypeHint.STRING_LIST) {
-      return Tokenization.reverseList(Fn.split(STRING_LIST_REFERENCE_DELIMITER, Token.asString(resolvedValue))) as IResolvable;
-    } else {
-      return resolvedValue;
-    }
-  }
-
-  // ----------------------------------------------------------------------
-  // export/import
-  // ----------------------------------------------------------------------
 
   // Stacks are in the same account, but different regions
   if (producerRegion !== consumerRegion) {

--- a/packages/aws-cdk-lib/core/test/stack.test.ts
+++ b/packages/aws-cdk-lib/core/test/stack.test.ts
@@ -1165,6 +1165,37 @@ describe('stack', () => {
     expect(relevantWarnings[0].path).toContain('Stack2');
   });
 
+  test.each(['up', 'down'])('no cross-stack reference flag warning when referencing %s across nested stacks', (direction) => {
+    // GIVEN - context flag explicitly set to 'strong'
+    const app = makeCrossStackApp();
+    const stack1 = new Stack(app, 'Stack1');
+    const stack2 = new NestedStack(stack1, 'Stack2');
+
+    // WHEN
+    if (direction === 'up') {
+      const resource1 = new CfnResource(stack1, 'Resource1', { type: 'AWS::S3::Bucket' });
+      new CfnResource(stack2, 'Resource2', {
+        type: 'AWS::S3::Bucket',
+        properties: { Prop1: resource1.getAtt('Arn') },
+      });
+    } else {
+      const resource2 = new CfnResource(stack2, 'Resource2', { type: 'AWS::S3::Bucket' });
+      new CfnResource(stack1, 'Resource1', {
+        type: 'AWS::S3::Bucket',
+        properties: { Prop1: resource2.getAtt('Arn') },
+      });
+    }
+
+    const assembly = app.synth();
+    const warnings = getWarnings(assembly);
+
+    // THEN - no warning because nested stacks are not cross-stack references
+    const relevantWarnings = warnings.filter(w =>
+      w.message.includes('@aws-cdk/core:crossStackReferencesDefaultStrong'),
+    );
+    expect(relevantWarnings).toHaveLength(0);
+  });
+
   test('cross-region strong references use ExportWriter/ExportReader', () => {
     // GIVEN - strength is explicitly 'strong'
     const app = makeCrossStackApp({ [cxapi.DEFAULT_CROSS_STACK_REFERENCES]: 'strong' });


### PR DESCRIPTION
We did our warnings about cross-stack reference settings a little too early in the big function, before we had ruled out the case of referencing being across nested stacks. Those references do not count as cross-stack, so we shouldn't warn for them.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
