### PR TITLE
fix(backup): generated backup plan name is not unique across stacks (…

### DIFF
--- a/packages/aws-cdk-lib/aws-backup/lib/plan.ts
+++ b/packages/aws-cdk-lib/aws-backup/lib/plan.ts
@@ -8,13 +8,14 @@ import { BackupSelection } from './selection';
 import type { IBackupVault } from './vault';
 import { BackupVault } from './vault';
 import type { IResource } from '../../core';
-import { ArnFormat, Resource, ValidationError } from '../../core';
+import { ArnFormat, FeatureFlags, Names, Resource, ValidationError } from '../../core';
 import type { IArrayBox } from '../../core/lib/helpers-internal';
 import { Box } from '../../core/lib/helpers-internal';
 import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-resource';
 import { noBoxStackTraces } from '../../core/lib/no-box-stack-traces';
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
+import * as cxapi from '../../cx-api';
 import type { BackupPlanReference, IBackupPlanRef, IBackupVaultRef } from '../../interfaces/generated/aws-backup-interfaces.generated';
 
 /**
@@ -174,7 +175,7 @@ export class BackupPlan extends Resource implements IBackupPlan {
     const plan = new CfnBackupPlan(this, 'Resource', {
       backupPlan: {
         advancedBackupSettings: this.advancedBackupSettings(props),
-        backupPlanName: props.backupPlanName || id,
+        backupPlanName: props.backupPlanName || this.generateBackupPlanName(id),
         backupPlanRule: this.rules,
       },
     });
@@ -190,6 +191,16 @@ export class BackupPlan extends Resource implements IBackupPlan {
     }
 
     this.node.addValidation({ validate: () => this.validatePlan() });
+  }
+
+  private generateBackupPlanName(id: string): string {
+    if (!FeatureFlags.of(this).isEnabled(cxapi.BACKUP_PLAN_UNIQUE_GENERATED_NAME)) {
+      return id;
+    }
+    return Names.uniqueResourceName(this, {
+      maxLength: 50,
+      allowedSpecialCharacters: '-_.',
+    });
   }
 
   private advancedBackupSettings(props: BackupPlanProps) {

--- a/packages/aws-cdk-lib/aws-backup/test/plan.test.ts
+++ b/packages/aws-cdk-lib/aws-backup/test/plan.test.ts
@@ -1,6 +1,7 @@
 import { Match, Template } from '../../assertions';
 import * as events from '../../aws-events';
 import { App, CfnParameter, Duration, Lazy, Stack, TimeZone } from '../../core';
+import * as cxapi from '../../cx-api';
 import { BackupPlan, BackupPlanRule, BackupVault } from '../lib';
 
 let stack: Stack;
@@ -472,6 +473,87 @@ test('does not throw when copy action durations are tokens, regardless of token 
       moveToColdStorageAfter,
     }],
   })).not.toThrow();
+});
+
+describe('generated backupPlanName', () => {
+  test('uses the construct id verbatim when the feature flag is not set (backwards compat)', () => {
+    // WHEN
+    new BackupPlan(stack, 'MyPlan', {
+      backupPlanRules: [BackupPlanRule.daily()],
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::Backup::BackupPlan', {
+      BackupPlan: {
+        BackupPlanName: 'MyPlan',
+      },
+    });
+  });
+
+  test('generates a unique name when the feature flag is enabled', () => {
+    // GIVEN
+    const app = new App({
+      context: { [cxapi.BACKUP_PLAN_UNIQUE_GENERATED_NAME]: true },
+    });
+    const flaggedStack = new Stack(app, 'MyStack');
+
+    // WHEN
+    new BackupPlan(flaggedStack, 'MyPlan', {
+      backupPlanRules: [BackupPlanRule.daily()],
+    });
+
+    // THEN
+    const template = Template.fromStack(flaggedStack);
+    const name = template.findResources('AWS::Backup::BackupPlan')[
+      Object.keys(template.findResources('AWS::Backup::BackupPlan'))[0]
+    ].Properties.BackupPlan.BackupPlanName;
+    // Includes the stack + construct id, must be alphanumerics + '-_.'
+    expect(name).not.toBe('MyPlan');
+    expect(name).toMatch(/^[A-Za-z0-9\-_.]{1,50}$/);
+    expect(name).toContain('MyPlan');
+  });
+
+  test('does not collide when the same id is used in two stacks with the feature flag enabled', () => {
+    // GIVEN
+    const app = new App({
+      context: { [cxapi.BACKUP_PLAN_UNIQUE_GENERATED_NAME]: true },
+    });
+    const stackA = new Stack(app, 'StackA');
+    const stackB = new Stack(app, 'StackB');
+
+    // WHEN
+    new BackupPlan(stackA, 'MyPlan', { backupPlanRules: [BackupPlanRule.daily()] });
+    new BackupPlan(stackB, 'MyPlan', { backupPlanRules: [BackupPlanRule.daily()] });
+
+    // THEN
+    const getName = (s: Stack) => {
+      const resources = Template.fromStack(s).findResources('AWS::Backup::BackupPlan');
+      const key = Object.keys(resources)[0];
+      return resources[key].Properties.BackupPlan.BackupPlanName;
+    };
+    expect(getName(stackA)).not.toBe(getName(stackB));
+  });
+
+  test('respects an explicit backupPlanName even when the feature flag is enabled', () => {
+    // GIVEN
+    const app = new App({
+      context: { [cxapi.BACKUP_PLAN_UNIQUE_GENERATED_NAME]: true },
+    });
+    const flaggedStack = new Stack(app, 'MyStack');
+
+    // WHEN
+    new BackupPlan(flaggedStack, 'MyPlan', {
+      backupPlanName: 'my-explicit-name',
+      backupPlanRules: [BackupPlanRule.daily()],
+    });
+
+    // THEN
+    Template.fromStack(flaggedStack).hasResourceProperties('AWS::Backup::BackupPlan', {
+      BackupPlan: {
+        BackupPlanName: 'my-explicit-name',
+      },
+    });
+  });
 });
 
 test('renders a lifecycle that references a CloudFormation parameter', () => {

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -117,6 +117,7 @@ Flags come in three types:
 | [@aws-cdk/core:annotationsInValidationReport](#aws-cdkcoreannotationsinvalidationreport) | Include construct annotations (warnings and errors) in the policy validation report | 2.253.0 | config |
 | [@aws-cdk/core:defaultCrossStackReferences](#aws-cdkcoredefaultcrossstackreferences) | Controls whether cross-region stack references are strong, weak, or both | 2.254.0 | config |
 | [@aws-cdk/aws-eks:defaultToAL2023](#aws-cdkaws-eksdefaulttoal2023) | Use AL2023 as the default AMI type for EKS managed node groups using non-GPU instance types instead of the deprecated AL2 | 2.259.0 | new default |
+| [@aws-cdk/aws-backup:generateUniqueBackupPlanName](#aws-cdkaws-backupgenerateuniquebackupplanname) | Generate a unique BackupPlanName when none is provided, instead of using the construct id verbatim | V2NEXT | new default |
 | [@aws-cdk/core:validateAgainstDefaultRules](#aws-cdkcorevalidateagainstdefaultrules) | Treat CloudFormation Validate findings as errors | V2NEXT | config |
 
 <!-- END table -->
@@ -136,6 +137,7 @@ The following json shows the current recommended set of flags, as `cdk init` wou
     "@aws-cdk/aws-appsync:appSyncGraphQLAPIScopeLambdaPermission": true,
     "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
     "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/aws-backup:generateUniqueBackupPlanName": true,
     "@aws-cdk/aws-batch:defaultToAL2023": true,
     "@aws-cdk/aws-cloudfront:defaultFunctionRuntimeV2_0": true,
     "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
@@ -2531,6 +2533,29 @@ When disabled, the default AMI types remain AL2 for backward compatibility.
 **Compatibility with old behavior:** Explicitly set `amiType` to the desired AL2 type (e.g., `NodegroupAmiType.AL2_X86_64`) in your nodegroup configuration.
 
 **Warning**: Enabling this flag on existing stacks will cause node group replacement, which terminates running pods. To migrate safely, first pin existing node groups to their current amiType explicitly, then enable the flag for new node groups.
+
+
+### @aws-cdk/aws-backup:generateUniqueBackupPlanName
+
+*Generate a unique BackupPlanName when none is provided, instead of using the construct id verbatim*
+
+Flag type: New default behavior
+
+When enabled, `BackupPlan` generates a unique `BackupPlanName` derived from the
+construct path (via `Names.uniqueResourceName`) when `backupPlanName` is not supplied.
+This prevents `AlreadyExistsException` errors when the same construct id is used to
+create backup plans in multiple stacks within the same account and region.
+
+When disabled, `BackupPlan` falls back to using the raw construct id as the plan name,
+which can collide when the same id is reused across stacks.
+
+
+| Since | Unset behaves like | Recommended value |
+| ----- | ----- | ----- |
+| (not in v1) |  |  |
+| V2NEXT | `false` | `true` |
+
+**Compatibility with old behavior:** Pass an explicit `backupPlanName` to the `BackupPlan` constructor to preserve the existing plan name and avoid a resource replacement.
 
 
 ### @aws-cdk/core:validateAgainstDefaultRules

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -158,6 +158,7 @@ export const EKS_DEFAULT_AL2023 = '@aws-cdk/aws-eks:defaultToAL2023';
 export const ANNOTATIONS_IN_VALIDATION_REPORT = '@aws-cdk/core:annotationsInValidationReport';
 export const DEFAULT_CROSS_STACK_REFERENCES = '@aws-cdk/core:defaultCrossStackReferences';
 export const VALIDATE_AGAINST_DEFAULT_RULES = '@aws-cdk/core:validateAgainstDefaultRules';
+export const BACKUP_PLAN_UNIQUE_GENERATED_NAME = '@aws-cdk/aws-backup:generateUniqueBackupPlanName';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1931,6 +1932,24 @@ export const FLAGS: Record<string, FlagInfo> = {
     introducedIn: { v2: 'V2NEXT' },
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: false },
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [BACKUP_PLAN_UNIQUE_GENERATED_NAME]: {
+    type: FlagType.ApiDefault,
+    summary: 'Generate a unique BackupPlanName when none is provided, instead of using the construct id verbatim',
+    detailsMd: `
+      When enabled, \`BackupPlan\` generates a unique \`BackupPlanName\` derived from the
+      construct path (via \`Names.uniqueResourceName\`) when \`backupPlanName\` is not supplied.
+      This prevents \`AlreadyExistsException\` errors when the same construct id is used to
+      create backup plans in multiple stacks within the same account and region.
+
+      When disabled, \`BackupPlan\` falls back to using the raw construct id as the plan name,
+      which can collide when the same id is reused across stacks.`,
+    introducedIn: { v2: 'V2NEXT' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
+    compatibilityWithOldBehaviorMd: 'Pass an explicit \`backupPlanName\` to the \`BackupPlan\` constructor to preserve the existing plan name and avoid a resource replacement.',
   },
 };
 

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -52,6 +52,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.EKS_DEFAULT_AL2023]: false,
     [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
     [feats.VALIDATE_AGAINST_DEFAULT_RULES]: false,
+    [feats.BACKUP_PLAN_UNIQUE_GENERATED_NAME]: false,
 
   });
 });

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -87,5 +87,6 @@
   "@aws-cdk/aws-eks:defaultToAL2023": true,
   "@aws-cdk/core:annotationsInValidationReport": true,
   "@aws-cdk/core:defaultCrossStackReferences": "weak",
-  "@aws-cdk/core:validateAgainstDefaultRules": true
+  "@aws-cdk/core:validateAgainstDefaultRules": true,
+  "@aws-cdk/aws-backup:generateUniqueBackupPlanName": true
 }


### PR DESCRIPTION
  ### Issue # (if applicable)

  Closes #38318.

  ### Reason for this change

  When `backupPlanName` is not supplied, `BackupPlan` uses the construct id verbatim as the `BackupPlanName`.
  Unlike other CDK resources whose generated physical names are unique, this causes an `AlreadyExistsException`
  at deploy time when two stacks in the same account and region create a backup plan with the same construct id.
  Synth succeeds, so the failure only surfaces during deployment.

  ### Description of changes

  Added a new feature flag `@aws-cdk/aws-backup:generateUniqueBackupPlanName` (`ApiDefault`, `introducedIn:
  V2NEXT`, `recommendedValue: true`, `unconfiguredBehavesLike: false`).

  - **Flag enabled**: when `backupPlanName` is not supplied, `BackupPlan` generates a unique name from the
  construct path via `Names.uniqueResourceName` with `maxLength: 50` and `allowedSpecialCharacters: '-_.'`,
  matching the AWS Backup plan name constraints (`^[a-zA-Z0-9\-\_\.]{1,50}$`).
  - **Flag disabled** (default for existing apps): behavior is unchanged — the construct id is used verbatim, so
  existing apps do not see a resource replacement.
  - An explicitly supplied `backupPlanName` always takes precedence, regardless of the flag.

  A feature flag is required because enabling the new behavior changes the generated `BackupPlanName` of
  existing plans and causes a resource replacement. Users who enable the flag can keep the old name by passing
  an explicit `backupPlanName` (documented in `compatibilityWithOldBehaviorMd`).

  Regenerated `FEATURE_FLAGS.md` and `recommended-feature-flags.json` via `flag-report.ts`.

  ### Describe any new or updated permissions being added

  None.

  ### Description of how you validated changes

  Added unit tests covering:

  - backwards compatibility: the construct id is used verbatim when the flag is not set
  - a unique name matching `^[A-Za-z0-9\-_.]{1,50}$` is generated when the flag is enabled
  - two stacks using the same construct id no longer collide when the flag is enabled (the exact scenario from
  the issue)
  - an explicit `backupPlanName` takes precedence even when the flag is enabled

  Full `aws-backup` (60 tests) and `cx-api` (122 tests) suites pass. Existing integ snapshots are unaffected
  because the flag is off by default and not yet in the integ-runner's bundled recommended flags (same rollout
  pattern as `@aws-cdk/aws-signer:signingProfileNamePassedToCfn`).

  ### Checklist
  - [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)
  and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

  ----

  *By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0
  license*