### PR TITLE
docs: fix broken and malformed links in contributing and package docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1320,7 +1320,7 @@ $ yarn test
 ## Changing Cloud Assembly Schema
 
 If you plan on making changes to the `cloud-assembly-schema` package, make sure you familiarize yourself with
-its own [contribution guide](./packages/@aws-cdk/cloud-assembly-schema/CONTRIBUTING.md)
+its own [contribution guide](https://github.com/aws/aws-cdk-cli/blob/main/packages/@aws-cdk/cloud-assembly-schema/CONTRIBUTING.md)
 
 ## Feature Flags
 
@@ -1419,7 +1419,7 @@ aws-cdk/packages/aws-cdk-lib/aws-events-targets/lib/aws-api.ts:7:27 - error TS27
 7 import * as metadata from '../../custom-resources/lib/helpers-internal/sdk-v3-metadata.json';
 ```
 
-This is most probably caused by the fact that your CDK app is using `--prefer-ts-exts` option (which is the [default in new CDK TS-based apps]([url](https://github.com/aws/aws-cdk/issues/7475))). To fix this, try one of the following:
+This is most probably caused by the fact that your CDK app is using `--prefer-ts-exts` option (which is the [default in new CDK TS-based apps](https://github.com/aws/aws-cdk/issues/7475)). To fix this, try one of the following:
 - Don't compile aws-cdk-lib. You can do this by removing `--prefer-ts-exts` from your app command in `cdk.json` - this means you will have to run a build in the lib repo every time you make a change (or use `npm run watch / yarn watch`).
 - Update your `tsconfig.json`. In this case it's going to be adding `"resolveJsonModule": true` as suggested by the error to the `"compilerOptions"` section. If you change the test app, different or more errors might come up that will have a similar resolution.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,7 +100,7 @@ Developers love CDK because it provides them with the ability to configure and m
  
 * **Give assets a display name:** This [feature](https://github.com/aws/aws-cdk/issues/9628) allows specifying a display name for AWS CDK assets to improve clarity in asset publishing and deployment.
 * **Enhanced L1 constructs:** This [rfc](https://github.com/aws/aws-cdk-rfcs/pull/657) is a proposal to enhance the L1 constructs by adding support for enums, resource interfaces, and CFN contraints to generated L1s.
-* **CLI: Enable client-side telemetry and analytics:** This [change]((https://github.com/aws/aws-cdk/issues/32010)) is to enable client-side telemetry and analytics collection in the CDK CLI.
+* **CLI: Enable client-side telemetry and analytics:** This [change](https://github.com/aws/aws-cdk/issues/32010) is to enable client-side telemetry and analytics collection in the CDK CLI.
 
 **_Research Items_**
 

--- a/docs/NEW_CONSTRUCTS_GUIDE.md
+++ b/docs/NEW_CONSTRUCTS_GUIDE.md
@@ -35,7 +35,7 @@ comprehensive opinionated experience for a service.
 
 ## Do My Constructs Belong in aws-cdk-lib?
 
-Users of the aws-cdk can use constructs from a number of packages within their application. `aws-cdk-lib` and/or any of the other constructs vended from npm, maven, pypi, nuget, or GitHub (for go) that are publicly available are indexed and searchable on [Construct Hub](constructs.dev). Anyone can create and publish new constructs that will be indexed on Construct Hub using repositories and packages that they own. However, if you believe your constructs should be part of the core aws construct library, here are some guidelines that they must adhere to.
+Users of the aws-cdk can use constructs from a number of packages within their application. `aws-cdk-lib` and/or any of the other constructs vended from npm, maven, pypi, nuget, or GitHub (for go) that are publicly available are indexed and searchable on [Construct Hub](https://constructs.dev). Anyone can create and publish new constructs that will be indexed on Construct Hub using repositories and packages that they own. However, if you believe your constructs should be part of the core aws construct library, here are some guidelines that they must adhere to.
 
 1. They meet the definition of [L2 constructs](https://github.com/aws/aws-cdk/blob/e4fdb0217edd7ecccdd4cbc20de958e3ba1a2349/docs/DESIGN_GUIDELINES.md?plain=1#L139-L147)
 1. They follow the relevant [design guidelines](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

--- a/packages/aws-cdk-lib/assertions/MIGRATING.md
+++ b/packages/aws-cdk-lib/assertions/MIGRATING.md
@@ -5,7 +5,7 @@ Make the following modifications to your CDK test files to migrate to the
 `@aws-cdk/assertions` module.
 
 For a migration script that handles most common use cases for you, see
-[Migration Script](migration-script).
+[Migration Script](#migration-script).
 
 ## Translation Guide
 

--- a/packages/aws-cdk-lib/cloud-assembly-schema/README.md
+++ b/packages/aws-cdk-lib/cloud-assembly-schema/README.md
@@ -23,7 +23,7 @@ between the assembly and its consumers, we treat the manifest file as a well def
 ## Schema
 
 This module contains the typescript structs that comprise the `manifest.json` file, as well as the
-generated [_json-schema_](./schema/cloud-assembly.schema.json).
+generated [_json-schema_](https://github.com/aws/aws-cdk-cli/blob/main/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json).
 
 ## Versioning
 
@@ -38,7 +38,7 @@ is considered `major` version bump. All changes that do not impact the schema ar
 
 ## How to consume
 
-If you'd like to consume the [schema file](./schema/cloud-assembly.schema.json) in order to do validations on `manifest.json` files,
+If you'd like to consume the [schema file](https://github.com/aws/aws-cdk-cli/blob/main/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json) in order to do validations on `manifest.json` files,
 simply download it from this repo and run it against standard _json-schema_ validators, such as [jsonschema](https://www.npmjs.com/package/jsonschema).
 
 Consumers must take into account the `major` version of the schema they are consuming. They should reject cloud assemblies


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38374.

### Reason for this change

A mechanical link audit (resolving every relative markdown link against the filesystem, plus malformed-syntax detection) found 7 broken or malformed links in repo and package documentation. Details in the linked issue.

### Description of changes

- `ROADMAP.md` — `[change]((https://...32010))` double parentheses render the link broken → single parentheses
- `CONTRIBUTING.md` — `[default in new CDK TS-based apps]([url](https://...7475))` nested-bracket link renders as literal text → plain link; the cloud-assembly-schema CONTRIBUTING link points at `./packages/@aws-cdk/cloud-assembly-schema/`, which no longer exists in this repo (package moved to [aws/aws-cdk-cli](https://github.com/aws/aws-cdk-cli)) → GitHub URL
- `docs/NEW_CONSTRUCTS_GUIDE.md` — `[Construct Hub](constructs.dev)` bare-domain link resolves as a relative path and 404s → `https://constructs.dev`
- `packages/aws-cdk-lib/assertions/MIGRATING.md` — `[Migration Script](migration-script)` missing the `#` anchor for the in-page heading
- `packages/aws-cdk-lib/cloud-assembly-schema/README.md` — two links to `./schema/cloud-assembly.schema.json`; the schema directory only exists in aws-cdk-cli → GitHub URL (file verified to exist there)

Not touched: a CONTRIBUTING.md reference to `tools/@aws-cdk/cdk-build-tools/config/eslintrc.js`, which no longer exists — I couldn't determine the successor location with confidence.

### Describe any new or updated permissions being added

None — documentation only.

### Description of how you validated changes

Docs-only; each new target verified to exist (filesystem for relative links, GitHub API for cross-repo links). Re-ran the link audit: no remaining broken links in the touched files.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)