### PR TITLE
fix(core): bump `@aws/cloudformation-validate` to 1.5.1-beta to fix install on Node != 22.x

### DIFF
--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -121,7 +121,7 @@
     "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
     "@aws-cdk/cloud-assembly-api": "^2.2.6",
     "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-    "@aws/cloudformation-validate": "1.5.0-beta",
+    "@aws/cloudformation-validate": "1.5.1-beta",
     "@balena/dockerignore": "^1.0.2",
     "case": "1.6.3",
     "fs-extra": "^11.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,10 +2288,10 @@
     "@smithy/types" "^4.16.0"
     tslib "^2.6.2"
 
-"@aws/cloudformation-validate@1.5.0-beta":
-  version "1.5.0-beta"
-  resolved "https://registry.npmjs.org/@aws/cloudformation-validate/-/cloudformation-validate-1.5.0-beta.tgz#cb56e14108af1f2ab509f152b5f083cf23fb15f5"
-  integrity sha512-XV8rMURH8xJGZD2NfAxtUI1/wbarLylAr0yFwu4P7NYt7XZoWhAPTgORlvuStBQVLdc31oVfpswez0j04O/NHg==
+"@aws/cloudformation-validate@1.5.1-beta":
+  version "1.5.1-beta"
+  resolved "https://registry.npmjs.org/@aws/cloudformation-validate/-/cloudformation-validate-1.5.1-beta.tgz#c25166a2e6f22b3a7fd3b6454c2794df44f4cf13"
+  integrity sha512-AHua/1/kmVLxkk0qs5bt4vWy64ZV5JUb1MsGKbxttYCF/NykR7WrtQrAGExLi7fdkGa+Ys8U612nG7QIp/z3nQ==
 
 "@aws/lambda-invoke-store@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38380.

### Reason for this change

<!--What is the bug or use case behind this change?-->

`aws-cdk-lib` 2.262.0 bundled `@aws/cloudformation-validate@1.5.0-beta`, which pins `engines.node` to `^22.15.0` (`>=22.15.0 <23.0.0`). That rejects Node 20, 21, 23, and 24 and contradicts aws-cdk-lib's `engines.node: ">=20.0.0"`, so installs fail with `EBADENGINE` for Yarn classic users and anyone with strict engine checks enabled in npm or pnpm.

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->

The upstream package published `1.5.1-beta`, which widens `engines.node` to `>=20.0.0` and drops the npm engine constraint. This bumps the bundled dependency from `1.5.0-beta` to `1.5.1-beta` and regenerates the lockfile. No code changes.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->

None

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Metadata-only dependency bump. Verified `1.5.1-beta` installs cleanly on Node 20.0.0 and 24.16.0 across npm (default + engine-strict), pnpm (default + engine-strict), and yarn classic. All these cases were previously failing and now passes. The validation engine runs unchanged.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
