### PR TITLE
fix(core): suppress false-positive E9002 validation warning for ICMP security group rules

### DIFF
--- a/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
@@ -1,5 +1,6 @@
+import * as fs from 'fs';
 import { RegoEngine, TemplateFile, version } from '@aws/cloudformation-validate';
-import type { Engine, EngineConfig, RuleInfo, Severity } from '@aws/cloudformation-validate';
+import type { DetailedDiagnostic, Engine, EngineConfig, RuleInfo, Severity } from '@aws/cloudformation-validate';
 import type { PolicyValidationPluginReport, PolicyViolatingResource } from './report';
 import type { IPolicyValidationPlugin, IPolicyValidationContext } from './validation';
 
@@ -124,7 +125,17 @@ export class CloudFormationValidatePlugin implements IPolicyValidationPlugin {
         severityLevel: 'WARN',
       });
 
+      // Parsed lazily (and only once) because it is only needed to filter out
+      // specific engine false positives, which most templates don't trigger.
+      let parsedTemplate: any;
+      const template = () => parsedTemplate ??= JSON.parse(fs.readFileSync(templatePath, 'utf-8'));
+
       for (const diagnostic of report.diagnostics) {
+        // The engine reports a false positive for ICMP security group rules; drop those findings.
+        if (diagnostic.ruleId === 'E9002' && isIcmpPortRangeFalsePositive(diagnostic, template())) {
+          continue;
+        }
+
         const severity = mapSeverity(diagnostic.severity);
 
         const violatingResource: PolicyViolatingResource = {
@@ -175,6 +186,70 @@ function mapSeverity(severity: Severity): string {
     case 'DEBUG': return 'debug';
     default: return 'warning';
   }
+}
+
+const SECURITY_GROUP_RULE_TYPES = new Set([
+  'AWS::EC2::SecurityGroup',
+  'AWS::EC2::SecurityGroupIngress',
+  'AWS::EC2::SecurityGroupEgress',
+]);
+
+/**
+ * Whether an `E9002` ("FromPort is greater than ToPort") finding is a false positive on an ICMP rule.
+ *
+ * For ICMP/ICMPv6 security group rules the `FromPort`/`ToPort` fields encode the ICMP type and code
+ * (where `-1` means "all"), not an ordered port range, so e.g. `Port.icmpPing()` legitimately renders
+ * `FromPort: 8, ToPort: -1`. The engine's generic range check flags these as errors. We correlate the
+ * finding back to the offending rule (by the ports named in the message, since the property path only
+ * points at the rule array) and drop it only when that rule uses an ICMP protocol, leaving genuine
+ * TCP/UDP range errors — including on the same resource — reported.
+ *
+ * Remove once the engine understands ICMP rules: <https://github.com/aws/aws-cdk/issues/38389>.
+ */
+function isIcmpPortRangeFalsePositive(diagnostic: DetailedDiagnostic, template: any): boolean {
+  if (!diagnostic.resourceType || !SECURITY_GROUP_RULE_TYPES.has(diagnostic.resourceType)) {
+    return false;
+  }
+
+  const match = /FromPort (-?\d+) is greater than ToPort (-?\d+)/.exec(diagnostic.message ?? '');
+  if (!match) {
+    return false;
+  }
+  const fromPort = Number(match[1]);
+  const toPort = Number(match[2]);
+
+  const resource = template?.Resources?.[diagnostic.resourceId ?? ''];
+  if (!resource) {
+    return false;
+  }
+
+  const props = resource.Properties ?? {};
+  // A rule can live in a SecurityGroup's inline ingress/egress arrays, or be the standalone
+  // SecurityGroupIngress/Egress resource's own properties.
+  const rules = [
+    ...(Array.isArray(props.SecurityGroupIngress) ? props.SecurityGroupIngress : []),
+    ...(Array.isArray(props.SecurityGroupEgress) ? props.SecurityGroupEgress : []),
+    props,
+  ];
+
+  return rules.some((rule) => rule != null
+    && isIcmpProtocol(rule.IpProtocol)
+    && Number(rule.FromPort) === fromPort
+    && Number(rule.ToPort) === toPort);
+}
+
+/**
+ * Whether an `IpProtocol` value refers to ICMP or ICMPv6, given either as a name or an IANA number.
+ */
+function isIcmpProtocol(protocol: unknown): boolean {
+  if (typeof protocol === 'string') {
+    const normalized = protocol.toLowerCase();
+    return normalized === 'icmp' || normalized === 'icmpv6' || normalized === '1' || normalized === '58';
+  }
+  if (typeof protocol === 'number') {
+    return protocol === 1 || protocol === 58;
+  }
+  return false;
 }
 
 // Rules that the engine will report but we want to ignore because CDK creates

--- a/packages/aws-cdk-lib/core/test/validation/cloudformation-validate-plugin.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/cloudformation-validate-plugin.test.ts
@@ -300,6 +300,82 @@ describe('CloudFormationValidatePlugin', () => {
 
     fs.rmSync(tmpDir, { recursive: true });
   });
+
+  describe('ICMP E9002 false positive suppression', () => {
+    function validateTemplate(resources: Record<string, unknown>) {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-validate-'));
+      const templatePath = path.join(tmpDir, 'template.json');
+      fs.writeFileSync(templatePath, JSON.stringify({ Resources: resources }));
+      try {
+        return new core.CloudFormationValidatePlugin().validate({
+          templatePaths: [templatePath],
+          stackTemplates: [{ stackConstructPath: 'TestStack', templatePath }],
+          appConstruct: new Construct(undefined as any, ''),
+          accountId: undefined,
+          region: undefined,
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    }
+
+    // For ICMP rules, FromPort/ToPort are the ICMP type/code (with -1 meaning "all"), not an ordered
+    // port range, so the engine's generic "FromPort > ToPort" check (E9002) is a false positive.
+    test.each([
+      ['icmp', 8],
+      ['icmpv6', 128],
+      ['1', 8], // IANA protocol number for ICMP
+    ])('does not report E9002 for an ICMP rule (IpProtocol: %s)', (ipProtocol, fromPort) => {
+      const report = validateTemplate({
+        IcmpSg: {
+          Type: 'AWS::EC2::SecurityGroup',
+          Properties: {
+            GroupDescription: 'test',
+            SecurityGroupIngress: [
+              { CidrIp: '0.0.0.0/0', FromPort: fromPort, IpProtocol: ipProtocol, ToPort: -1 },
+            ],
+          },
+        },
+      });
+
+      expect(report.violations.find(v => v.ruleName === 'E9002')).toBeUndefined();
+    });
+
+    test('still reports E9002 for a genuine TCP range error', () => {
+      const report = validateTemplate({
+        BadTcpSg: {
+          Type: 'AWS::EC2::SecurityGroup',
+          Properties: {
+            GroupDescription: 'test',
+            SecurityGroupIngress: [
+              { CidrIp: '0.0.0.0/0', FromPort: 443, IpProtocol: 'tcp', ToPort: 80 },
+            ],
+          },
+        },
+      });
+
+      expect(report.violations.find(v => v.ruleName === 'E9002')).toBeDefined();
+    });
+
+    test('suppresses only the ICMP finding when a resource mixes ICMP and a bad TCP range', () => {
+      const report = validateTemplate({
+        MixedSg: {
+          Type: 'AWS::EC2::SecurityGroup',
+          Properties: {
+            GroupDescription: 'test',
+            SecurityGroupIngress: [
+              { CidrIp: '0.0.0.0/0', FromPort: 8, IpProtocol: 'icmp', ToPort: -1 },
+              { CidrIp: '0.0.0.0/0', FromPort: 443, IpProtocol: 'tcp', ToPort: 80 },
+            ],
+          },
+        },
+      });
+
+      const e9002 = report.violations.filter(v => v.ruleName === 'E9002');
+      expect(e9002).toHaveLength(1);
+      expect(e9002[0].description).toContain('FromPort 443 is greater than ToPort 80');
+    });
+  });
 });
 
 describe('CDK_VALIDATION environment variable', () => {


### PR DESCRIPTION
Closes #38389.

### Reason for this change

Since the `@aws/cloudformation-validate` engine was wired into synth-time validation, `cdk synth` emits a spurious warning for perfectly valid ICMP security group rules:

```
WARNING SecurityGroupIngress: FromPort 8 is greater than ToPort -1 (CloudFormation Validate)
   .../EmcEc21Sg/Resource (EmcEc21Sg6A5E663D) aws-cdk-lib.aws_ec2.CfnSecurityGroup
   Suggested fix: Set FromPort to a value less than or equal to ToPort
   Acknowledge with 'CloudFormation-Validate::E9002'
```

The engine's `E9002` rule is a generic "`FromPort` must be `<= ToPort`" port-range check. It does not account for the fact that **for ICMP/ICMPv6 rules, `FromPort` and `ToPort` are not a port range** — they encode the ICMP **type** and **code**, where `-1` means "all". So a completely ordinary rule like:

```ts
sg.addIngressRule(Peer.anyIpv4(), Port.icmpPing());
```

renders the valid CloudFormation below and yet trips `E9002`:

```yaml
SecurityGroupIngress:
  - CidrIp: 0.0.0.0/0
    FromPort: 8       # ICMP type 8 (echo request)
    IpProtocol: icmp
    ToPort: -1        # ICMP code -1 (all codes)
```

There is no consumer-side workaround short of acknowledging/suppressing the rule globally, which is undesirable (see below).

### Description of changes

The finding is a false positive that originates in the upstream engine's rule, so the fix lives where CDK already curates engine output: the `CloudFormationValidatePlugin`.

Instead of suppressing `E9002` globally, the plugin now **correlates each `E9002` finding back to the specific security group rule that produced it and drops the finding only when that rule uses an ICMP protocol.** The engine emits one `E9002` diagnostic per offending rule, and its message names the exact ports (`"FromPort 8 is greater than ToPort -1"`), so we match those ports against the rule declared in the template and check its `IpProtocol`. ICMP is recognized whether given by name (`icmp`/`icmpv6`) or IANA number (`1`/`58`). The check covers inline `SecurityGroupIngress`/`SecurityGroupEgress` arrays as well as the standalone `AWS::EC2::SecurityGroupIngress`/`Egress` resources.

The template is parsed lazily (once per stack, only when an `E9002` finding is actually present), so there is no cost for the common case.

A code comment links back to this issue so the workaround can be removed once the engine understands ICMP rules.

#### Why not simply add `E9002` to the `IGNORE_RULES` list?

That was the originally suggested fix, but adding `E9002` to `IGNORE_RULES` (or excluding it per-service via the engine's `exclude.services`) suppresses the rule for **every** resource, which would silently hide *genuine* misconfigurations that `E9002` is meant to catch. `E9002` is a real, useful rule for TCP/UDP — it only misfires on ICMP.

Concretely, all of the following are legitimate `E9002` errors that a blanket ignore would swallow:

```yaml
# A TCP range typo — 443 down to 80 is invalid and would be rejected by CloudFormation.
- IpProtocol: tcp
  FromPort: 443
  ToPort: 80
```

```yaml
# A UDP range that is backwards.
- IpProtocol: udp
  FromPort: 8080
  ToPort: 8000
```

The targeted approach keeps those errors visible. This is verified explicitly by the tests, including the case where a **single security group mixes an ICMP rule and a bad TCP range** — only the ICMP finding is dropped:

| Rule on the security group | `E9002` before | `E9002` after this change |
| --- | --- | --- |
| `icmp`, FromPort 8, ToPort -1 (`Port.icmpPing()`) | ⚠️ reported (false positive) | ✅ suppressed |
| `icmpv6`, FromPort 128, ToPort -1 | ⚠️ reported (false positive) | ✅ suppressed |
| protocol `1` (numeric ICMP), FromPort 8, ToPort -1 | ⚠️ reported (false positive) | ✅ suppressed |
| `tcp`, FromPort 443, ToPort 80 (real typo) | ⚠️ reported | ⚠️ still reported |

A per-service exclude (`AWS::EC2` / `AWS::EC2::SecurityGroup`) has the same problem: security groups carry both ICMP and TCP/UDP rules, so scoping the suppression to the service would still hide the TCP typo above. Only correlating down to the individual rule's protocol preserves the rule's value while removing the false positive.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added unit tests in `cloudformation-validate-plugin.test.ts`:

- **No `E9002` for ICMP rules** — parametrized over `icmp`, `icmpv6`, and the numeric protocol `1`.
- **`E9002` is still reported for a genuine TCP range error** (`FromPort: 443, ToPort: 80`), guarding against over-suppression.
- **Mixed security group** — a resource containing both an ICMP rule and a bad TCP range yields exactly one `E9002` finding (the TCP one), proving the suppression is per-rule, not per-resource.

I also reproduced the original false positive and validated the suppression logic directly against the pinned engine version (`@aws/cloudformation-validate@1.5.1-beta`) for every case in the table above.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
