### PR TITLE
fix(custom-resources): retry CloudFormation response PUT in AwsCustomResource handler

### DIFF
--- a/packages/@aws-cdk/custom-resource-handlers/lib/custom-resources/aws-custom-resource-handler/utils.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/custom-resources/aws-custom-resource-handler/utils.ts
@@ -42,6 +42,29 @@ export function decodeCall(call: string | undefined): any {
 }
 
 /**
+ * Retry options used when sending the response to CloudFormation.
+ *
+ * Mirrors the behavior of the custom resource provider framework handler
+ * (see `core/nodejs-entrypoint-handler`): the PUT to the CloudFormation
+ * pre-signed S3 response URL is retried with exponential backoff on a network
+ * error or a non-successful (>= 400) HTTP response, instead of being sent
+ * exactly once and silently swallowed. Without this, a single transient PUT
+ * failure causes CloudFormation to wait out its ~1 hour timeout even though the
+ * function already logged a SUCCESS response.
+ */
+const RESPONSE_RETRY_OPTIONS: RetryOptions = {
+  attempts: 5,
+  sleep: 1000,
+};
+
+/**
+ * Indirection so unit tests can stub out the actual network call.
+ */
+export const external = {
+  sendHttpRequest: defaultSendHttpRequest,
+};
+
+/**
  * Responds to the CloudFormation Custom Resource.
  */
 export function respond(
@@ -82,9 +105,27 @@ export function respond(
     },
   };
 
-  return new Promise((resolve, reject) => {
+  return withRetries(RESPONSE_RETRY_OPTIONS, external.sendHttpRequest)(requestOptions, responseBody);
+}
+
+/**
+ * Sends a single PUT of the CloudFormation response to the pre-signed S3
+ * response URL. Rejects on a network error or a non-successful (>= 400) HTTP
+ * response so that the caller (via `withRetries`) can retry, rather than
+ * treating any received response as success.
+ */
+function defaultSendHttpRequest(requestOptions: any, responseBody: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     try {
-      const request = require('https').request(requestOptions, resolve);
+      const request = require('https').request(requestOptions, (response: any) => {
+        // Consume the response stream so the socket can be freed.
+        response.resume();
+        if (!response.statusCode || response.statusCode >= 400) {
+          reject(new Error(`Unsuccessful HTTP response: ${response.statusCode}`));
+        } else {
+          resolve();
+        }
+      });
       request.on('error', reject);
       request.write(responseBody);
       request.end();
@@ -92,6 +133,35 @@ export function respond(
       reject(e);
     }
   });
+}
+
+export interface RetryOptions {
+  /** How many retries (will at least try once) */
+  readonly attempts: number;
+  /** Sleep base, in ms */
+  readonly sleep: number;
+}
+
+export function withRetries<A extends Array<any>, B>(options: RetryOptions, fn: (...xs: A) => Promise<B>): (...xs: A) => Promise<B> {
+  return async (...xs: A) => {
+    let attempts = options.attempts;
+    let ms = options.sleep;
+    while (true) {
+      try {
+        return await fn(...xs);
+      } catch (e) {
+        if (attempts-- <= 0) {
+          throw e;
+        }
+        await sleep(Math.floor(Math.random() * ms));
+        ms *= 2;
+      }
+    }
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((ok) => setTimeout(ok, ms));
 }
 
 /**

--- a/packages/@aws-cdk/custom-resource-handlers/test/custom-resources/aws-custom-resource-handler/utils.test.ts
+++ b/packages/@aws-cdk/custom-resource-handlers/test/custom-resources/aws-custom-resource-handler/utils.test.ts
@@ -1,5 +1,8 @@
+import * as https from 'https';
 import type { AwsSdkCall } from '../../../lib/custom-resources/aws-custom-resource-handler/construct-types';
-import { getCredentials } from '../../../lib/custom-resources/aws-custom-resource-handler/utils';
+import { external, getCredentials, respond, withRetries } from '../../../lib/custom-resources/aws-custom-resource-handler/utils';
+
+jest.mock('https');
 
 // Mock the @aws-sdk/credential-providers import
 const mockFromTemporaryCredentials = jest.fn();
@@ -182,5 +185,151 @@ describe('getCredentials with External ID support', () => {
     expect(roleSessionName).toMatch(/^\d+-very-long-resource-id-that-exceeds-the-maximum-len$/);
     expect(callArgs.params.ExternalId).toBe('test-external-id-123');
     expect(result).toBe(mockCredentials);
+  });
+});
+
+// Captured at load time before any test overrides it.
+const defaultSendHttpRequest = external.sendHttpRequest;
+
+function makeEvent(): AWSLambda.CloudFormationCustomResourceEvent {
+  return {
+    ResponseURL: 'https://cfn.example.com/response?token=abc',
+    StackId: '<StackId>',
+    RequestId: '<RequestId>',
+    LogicalResourceId: '<LogicalResourceId>',
+    ResourceType: '<ResourceType>',
+    ServiceToken: '<ServiceToken>',
+    ResourceProperties: { ServiceToken: '<ServiceToken>' },
+    RequestType: 'Create',
+  } as any;
+}
+
+describe('withRetries', () => {
+  beforeEach(() => {
+    // make backoff sleeps instantaneous and deterministic
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns the result without retrying when the function succeeds', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+
+    const result = await withRetries({ attempts: 5, sleep: 1 }, fn)();
+
+    expect(result).toEqual('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries and eventually succeeds', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue('ok');
+
+    const result = await withRetries({ attempts: 5, sleep: 1 }, fn)();
+
+    expect(result).toEqual('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws the last error after exhausting all attempts', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('always fails'));
+
+    // attempts: 3 => 1 initial call + 3 retries = 4 invocations
+    await expect(withRetries({ attempts: 3, sleep: 1 }, fn)()).rejects.toThrow('always fails');
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('respond', () => {
+  beforeEach(() => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    external.sendHttpRequest = defaultSendHttpRequest;
+    jest.restoreAllMocks();
+  });
+
+  test('PUTs the response to the CloudFormation response URL exactly once on success', async () => {
+    // GIVEN
+    const send = jest.fn().mockResolvedValue(undefined);
+    external.sendHttpRequest = send;
+
+    // WHEN
+    await respond(makeEvent(), 'SUCCESS', 'reason', 'physical-id', { Foo: 'Bar' }, true);
+
+    // THEN
+    expect(send).toHaveBeenCalledTimes(1);
+    const [options, body] = send.mock.calls[0];
+    expect(options.method).toEqual('PUT');
+    expect(options.hostname).toEqual('cfn.example.com');
+    expect(options.path).toEqual('/response?token=abc');
+    const parsedBody = JSON.parse(body);
+    expect(parsedBody.Status).toEqual('SUCCESS');
+    expect(parsedBody.PhysicalResourceId).toEqual('physical-id');
+    expect(parsedBody.Data).toEqual({ Foo: 'Bar' });
+  });
+
+  test('retries a transient failure and then succeeds', async () => {
+    // GIVEN
+    const send = jest.fn()
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValue(undefined);
+    external.sendHttpRequest = send;
+
+    // WHEN
+    await respond(makeEvent(), 'SUCCESS', 'reason', 'physical-id', {}, false);
+
+    // THEN
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('rejects after exhausting retries', async () => {
+    // GIVEN
+    const send = jest.fn().mockRejectedValue(new Error('Unsuccessful HTTP response: 500'));
+    external.sendHttpRequest = send;
+
+    // WHEN / THEN
+    // RESPONSE_RETRY_OPTIONS.attempts is 5 => 1 initial call + 5 retries = 6 invocations
+    await expect(respond(makeEvent(), 'SUCCESS', 'reason', 'physical-id', {}, false))
+      .rejects.toThrow('Unsuccessful HTTP response: 500');
+    expect(send).toHaveBeenCalledTimes(6);
+  });
+
+  describe('HTTP status-code handling (default sender)', () => {
+    beforeEach(() => {
+      external.sendHttpRequest = defaultSendHttpRequest;
+      (https.request as jest.Mock).mockReset();
+    });
+
+    test('resolves on a 2xx response', async () => {
+      // GIVEN
+      (https.request as jest.Mock).mockImplementation((_options: any, cb: any) => {
+        cb({ statusCode: 200, resume: jest.fn() });
+        return { on: jest.fn(), write: jest.fn(), end: jest.fn() };
+      });
+
+      // WHEN / THEN
+      await expect(respond(makeEvent(), 'SUCCESS', 'reason', 'physical-id', {}, false)).resolves.toBeUndefined();
+      expect(https.request).toHaveBeenCalledTimes(1);
+    });
+
+    test('treats a >= 400 response as a failure and retries, then throws', async () => {
+      // GIVEN
+      (https.request as jest.Mock).mockImplementation((_options: any, cb: any) => {
+        cb({ statusCode: 500, resume: jest.fn() });
+        return { on: jest.fn(), write: jest.fn(), end: jest.fn() };
+      });
+
+      // WHEN / THEN
+      await expect(respond(makeEvent(), 'SUCCESS', 'reason', 'physical-id', {}, false))
+        .rejects.toThrow('Unsuccessful HTTP response: 500');
+      expect(https.request).toHaveBeenCalledTimes(6);
+    });
   });
 });


### PR DESCRIPTION
### Issue

None

### Reason for this change

The `AwsCustomResource` handler's `respond()` sends the CloudFormation response with a **single, un-retried** `https` PUT to the pre-signed S3 response URL, and passes `resolve` directly as the response callback so the **HTTP status code is never inspected**. A transient PUT failure or a non-2xx response is therefore silently swallowed: CloudFormation never receives the response and waits out its **~1 hour timeout**, even though the function already logged a `SUCCESS` payload and exited cleanly. (The `"Responding {SUCCESS...}"` log line is emitted *before* the PUT, so it does not prove delivery.)

### Description of changes

Wrap the response PUT in the **same retry + exponential-backoff behavior already used by the custom resource provider framework handler** (`core/nodejs-entrypoint-handler`):

- `withRetries` (attempts: 5, base sleep: 1000ms, exponential backoff with jitter) — copied to match the framework handler for consistency.
- `defaultSendHttpRequest` consumes the response stream, **rejects on a `>= 400` status code** (and on socket errors), and resolves only on a successful response.
- An `external.sendHttpRequest` seam so the network call can be stubbed in unit tests (same pattern as the framework handler).

This fixes the class of transient response-delivery failures for **all** `AwsCustomResource` users, since they share this singleton handler.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added unit tests in `utils.test.ts` covering `withRetries` (success, retry-then-succeed, exhaustion) and `respond` (single PUT on success, retry on transient failure, rejection after exhausting retries, and 2xx-resolve / >=400-retry status-code handling). All pass.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.*