### PR TITLE
fix(core): upgrade cloudformation-validate library

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/core/test/tree-metadata.test.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/core/test/tree-metadata.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
 
 function acknowledgeProblems() {
   Validations.of(app).acknowledge(
-    { id: 'CloudFormation-Validate::F3006', reason: 'We are using fake resource types here' },
     { id: 'CloudFormation-Validate::F0001', reason: 'Empty resource sections' },
   );
 }

--- a/packages/@aws-cdk/aws-elasticache-alpha/test/password-user.test.ts
+++ b/packages/@aws-cdk/aws-elasticache-alpha/test/password-user.test.ts
@@ -156,7 +156,7 @@ describe('PasswordUser', () => {
         userId: 'test-user',
         accessControl: AccessControl.fromAccessString('on ~* +@all'),
         passwords: [
-          SecretValue.ssmSecure('/elasticache/user/password'),
+          SecretValue.secretsManager('elasticache/user/password'),
           SecretValue.unsafePlainText('plaintext-password'),
         ],
       });

--- a/packages/@aws-cdk/aws-mediaconnect-alpha/lib/flow-entitlement.ts
+++ b/packages/@aws-cdk/aws-mediaconnect-alpha/lib/flow-entitlement.ts
@@ -1,5 +1,5 @@
 import type { IResource } from 'aws-cdk-lib';
-import { Resource, Lazy, Names, Token, Validations, ValidationError } from 'aws-cdk-lib';
+import { Resource, Lazy, Names, Token, ValidationError } from 'aws-cdk-lib';
 import { CfnFlowEntitlement } from 'aws-cdk-lib/aws-mediaconnect';
 import type { IFlowEntitlementRef, FlowEntitlementReference } from 'aws-cdk-lib/aws-mediaconnect';
 import { lit } from 'aws-cdk-lib/core/lib/helpers-internal';
@@ -163,14 +163,6 @@ export class FlowEntitlement extends FlowEntitlementBase {
       dataTransferSubscriberFeePercent: props.dataTransferSubscriberFeePercent,
       entitlementStatus: props.entitlementStatus,
       encryption: props.encryption ? renderStaticKeyEncryption(this, props.encryption, props.flow.flowArn) : undefined,
-    });
-
-    // cfn-validate false positive: the engine's embedded schema flags FlowEntitlement.Encryption
-    // as deprecated, but it is a current property. Remove once the upstream schema is corrected.
-    // Tracking: https://github.com/aws-cloudformation/cloudformation-validate/issues/144
-    Validations.of(resource).acknowledge({
-      id: 'CloudFormation-Validate::W9009',
-      reason: 'cfn-validate false positive: MediaConnect FlowEntitlement.Encryption is not deprecated (see cloudformation-validate#144)',
     });
 
     this.entitlementArn = resource.attrEntitlementArn;

--- a/packages/@aws-cdk/aws-mediaconnect-alpha/lib/flow.ts
+++ b/packages/@aws-cdk/aws-mediaconnect-alpha/lib/flow.ts
@@ -1,5 +1,5 @@
 import type { Bitrate, IResource, RemovalPolicy } from 'aws-cdk-lib';
-import { ArnFormat, Resource, Lazy, Names, Duration, Stack, Token, Fn, UnscopedValidationError, Validations, ValidationError } from 'aws-cdk-lib';
+import { ArnFormat, Resource, Lazy, Names, Duration, Stack, Token, Fn, UnscopedValidationError, ValidationError } from 'aws-cdk-lib';
 import type { MetricOptions } from 'aws-cdk-lib/aws-cloudwatch';
 import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import { CfnFlow } from 'aws-cdk-lib/aws-mediaconnect';
@@ -1505,15 +1505,6 @@ export class Flow extends FlowBase implements IFlow {
         }] : undefined,
       } : undefined,
       vpcInterfaces: Lazy.any({ produce: () => this.vpcInterfaces }, { omitEmptyArray: true }),
-    });
-
-    // cfn-validate false positive: the engine's embedded schema flags Flow.Source as deprecated,
-    // but it is a required, current property (no alternative exists). Remove once the upstream
-    // schema is corrected.
-    // Tracking: https://github.com/aws-cloudformation/cloudformation-validate/issues/144
-    Validations.of(flow).acknowledge({
-      id: 'CloudFormation-Validate::W9009',
-      reason: 'cfn-validate false positive: MediaConnect Flow.Source is required and not deprecated (see cloudformation-validate#144)',
     });
 
     this.flowArn = flow.attrFlowArn;

--- a/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts
@@ -36,7 +36,6 @@ import {
   Stack,
   Token,
   ValidationError,
-  Validations,
 } from '../../core';
 import type { IArrayBox, IBox, IReadableBox } from '../../core/lib/helpers-internal';
 import { Box } from '../../core/lib/helpers-internal';
@@ -447,10 +446,6 @@ export class Distribution extends Resource implements IDistribution {
         // eslint-disable-next-line @cdklabs/no-unconditional-token-allocation
         webAclId: Token.asString(this._webAclId),
       },
-    });
-    Validations.of(distribution).acknowledge({
-      id: 'CloudFormation-Validate::W9009',
-      reason: 'distributionConfig is deprecated, but still in use for historical reasons',
     });
 
     this.distributionRef = distribution.distributionRef;

--- a/packages/aws-cdk-lib/aws-cloudfront/lib/web-distribution.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/web-distribution.ts
@@ -1034,10 +1034,6 @@ export class CloudFrontWebDistribution extends cdk.Resource implements IDistribu
     }
 
     const distribution = new CfnDistribution(this, 'CFDistribution', { distributionConfig });
-    cdk.Validations.of(distribution).acknowledge({
-      id: 'CloudFormation-Validate::W9009',
-      reason: 'distributionConfig is deprecated, but still in use for historical reasons',
-    });
     this.distributionRef = distribution.distributionRef;
     this.node.defaultChild = distribution;
     this.domainName = distribution.attrDomainName;

--- a/packages/aws-cdk-lib/aws-ecs-patterns/test/util.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/test/util.ts
@@ -7,10 +7,7 @@ import * as cdk from '../../core';
  */
 export function acknowledgeTestValidationRules(scope: IConstruct) {
   cdk.Validations.of(scope).acknowledge(
-    { id: 'CloudFormation-Validate::E1152', reason: 'SSM parameter reference is resolved at deploy time' },
     { id: 'CloudFormation-Validate::W3697', reason: 'LaunchConfiguration used intentionally in tests' },
-    { id: 'CloudFormation-Validate::E3049', reason: 'HostPort 0 with dynamic port mapping is intentional in tests' },
-    { id: 'CloudFormation-Validate::E9004', reason: 'Intentionally testing invalid Fargate CPU/Memory combinations' },
     { id: 'CloudFormation-Validate::E3047', reason: 'Intentionally testing invalid Fargate CPU/Memory combinations' },
     { id: 'CloudFormation-Validate::W9013', reason: 'Duplicate subnets are intentional in tests' },
     { id: 'CloudFormation-Validate::W9002', reason: 'Deprecated properties used intentionally in tests' },

--- a/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts
@@ -1002,6 +1002,10 @@ describe('ec2 service', () => {
         vpc,
       });
 
+      cdk.Validations.of(stack).acknowledge(
+        { id: 'CloudFormation-Validate::F3034', reason: 'failureThreshold intentionally exceeds the CloudFormation maximum of 10; the test asserts it is passed through to HealthCheckCustomConfig unmodified' },
+      );
+
       new ecs.Ec2Service(stack, 'Ec2Service', {
         cluster,
         taskDefinition,
@@ -1070,6 +1074,10 @@ describe('ec2 service', () => {
       });
 
       // WHEN
+      cdk.Validations.of(stack).acknowledge(
+        { id: 'CloudFormation-Validate::F3034', reason: 'failureThreshold intentionally exceeds the CloudFormation maximum of 10; this test exercises every property, not valid value ranges' },
+      );
+
       const service = new ecs.Ec2Service(stack, 'Ec2Service', {
         cluster,
         taskDefinition,

--- a/packages/aws-cdk-lib/aws-ecs/test/fargate/fargate-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/fargate/fargate-service.test.ts
@@ -538,6 +538,10 @@ describe('fargate service', () => {
         vpc,
       });
 
+      cdk.Validations.of(stack).acknowledge(
+        { id: 'CloudFormation-Validate::F3034', reason: 'failureThreshold intentionally exceeds the CloudFormation maximum of 10; the test asserts it is passed through to HealthCheckCustomConfig unmodified' },
+      );
+
       new ecs.FargateService(stack, 'FargateService', {
         cluster,
         taskDefinition,
@@ -695,6 +699,10 @@ describe('fargate service', () => {
       taskDefinition.addContainer('web', {
         image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
       });
+
+      cdk.Validations.of(stack).acknowledge(
+        { id: 'CloudFormation-Validate::F3034', reason: 'failureThreshold intentionally exceeds the CloudFormation maximum of 10; this test exercises every property, not valid value ranges' },
+      );
 
       const svc = new ecs.FargateService(stack, 'FargateService', {
         cluster,

--- a/packages/aws-cdk-lib/aws-ecs/test/util.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/util.ts
@@ -11,7 +11,6 @@ import * as ecs from '../lib';
 export function acknowledgeTestValidationRules(scope: IConstruct) {
   cdk.Validations.of(scope).acknowledge(
     { id: 'CloudFormation-Validate::W3697', reason: 'LaunchConfiguration used intentionally in tests' },
-    { id: 'CloudFormation-Validate::E9004', reason: 'Intentionally testing invalid Fargate CPU/Memory combinations' },
     { id: 'CloudFormation-Validate::W9013', reason: 'Duplicate subnets are intentional in tests' },
     { id: 'CloudFormation-Validate::W2001', reason: 'Unreferenced parameters are expected in test stacks' },
     { id: 'CloudFormation-Validate::W2531', reason: 'Hardcoded ARNs are expected in tests' },

--- a/packages/aws-cdk-lib/aws-elasticloadbalancing/lib/load-balancer.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancing/lib/load-balancer.ts
@@ -6,7 +6,7 @@ import {
   SecurityGroup, SubnetType,
 } from '../../aws-ec2';
 import type { IResource } from '../../core';
-import { Duration, Resource, Token, Validations } from '../../core';
+import { Duration, Resource, Token } from '../../core';
 import { ValidationError } from '../../core/lib/errors';
 import type { IArrayBox } from '../../core/lib/helpers-internal';
 import { Box } from '../../core/lib/helpers-internal';
@@ -278,12 +278,6 @@ export class LoadBalancer extends Resource implements ILoadBalancer, IConnectabl
 
   constructor(scope: Construct, id: string, props: LoadBalancerProps) {
     super(scope, id);
-
-    // https://github.com/aws-cloudformation/cloudformation-validate/issues/186
-    Validations.of(this).acknowledge({
-      id: 'CloudFormation-Validate::W3030',
-      reason: 'Validation will incorrectly flag a lowercase protocol as invalid.',
-    });
 
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);

--- a/packages/aws-cdk-lib/aws-iam/test/escape-hatch.test.ts
+++ b/packages/aws-cdk-lib/aws-iam/test/escape-hatch.test.ts
@@ -11,7 +11,6 @@ function makeStackAndUser() {
   const stack = new Stack();
   Validations.of(stack).acknowledge(
     { id: 'CloudFormation-Validate::F3002', reason: "For these tests, we don't care about property names being valid" },
-    { id: 'CloudFormation-Validate::F3003', reason: "For these tests, we don't care about property names being valid" },
   );
   const user = new iam.User(stack, 'user', { userName: 'MyUserName' });
   return { stack, user };

--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -307,7 +307,7 @@ describe('function', () => {
     test('applies source arn condition if principal has conditions', () => {
       const stack = new cdk.Stack();
       const fn = newTestLambda(stack);
-      const sourceArn = 'arn:aws:sqs:us-east-1:1111111111:MyQueue';
+      const sourceArn = 'arn:aws:sqs:us-east-1:111111111111:MyQueue';
       const service = 'my-service';
       const principal = new iam.PrincipalWithConditions(new iam.ServicePrincipal(service), {
         ArnLike: {
@@ -4497,7 +4497,6 @@ test('test 2.87.0 version hash stability', () => {
     },
   });
   cdk.Validations.of(app).acknowledge(
-    { id: 'CloudFormation-Validate::E3071', reason: 'Node 99.x supports inline code' },
     { id: 'CloudFormation-Validate::W3030', reason: 'Node 99.x is not valid, sure' },
   );
   const stack = new cdk.Stack(app, 'Stack');

--- a/packages/aws-cdk-lib/aws-lambda/test/lambda-version.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/lambda-version.test.ts
@@ -11,7 +11,6 @@ describe('lambda version', () => {
   test('can import a Lambda version by ARN', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
 
     // WHEN
     const version = lambda.Version.fromVersionArn(stack, 'Version', 'arn:aws:lambda:region:account-id:function:function-name:version');
@@ -39,7 +38,6 @@ describe('lambda version', () => {
   test('can import an imported Lambda version by ARN', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
 
     // WHEN
     const func = new lambda.Function(stack, 'Fn', {
@@ -60,7 +58,6 @@ describe('lambda version', () => {
     // GIVEN
     const stack = new cdk.Stack();
     cdk.Validations.of(stack).acknowledge(
-      { id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' },
       { id: 'CloudFormation-Validate::W3030', reason: 'Tests intentionally use a bogus runtime' },
     );
     const fn = new lambda.Function(stack, 'Fn', {
@@ -95,7 +92,6 @@ describe('lambda version', () => {
   test('throws when calling configureAsyncInvoke on already configured version', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'Fn', {
       runtime: THE_RUNTIME,
       handler: 'index.handler',
@@ -114,7 +110,6 @@ describe('lambda version', () => {
   test('event invoke config on imported versions', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const version1 = lambda.Version.fromVersionArn(stack, 'Version1', 'arn:aws:lambda:region:account-id:function:function-name:version1');
     const version2 = lambda.Version.fromVersionArn(stack, 'Version2', 'arn:aws:lambda:region:account-id:function:function-name:version2');
 
@@ -143,7 +138,6 @@ describe('lambda version', () => {
     // GIVEN
     const stack = new cdk.Stack();
     cdk.Validations.of(stack).acknowledge(
-      { id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' },
       { id: 'CloudFormation-Validate::W3030', reason: 'Tests intentionally use a bogus runtime' },
     );
     const fn = new lambda.Function(stack, 'Fn', {
@@ -174,7 +168,6 @@ describe('lambda version', () => {
   test('edgeArn', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'Fn', {
       runtime: THE_RUNTIME,
       handler: 'index.handler',
@@ -189,7 +182,6 @@ describe('lambda version', () => {
   test('edgeArn throws with $LATEST', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const version = lambda.Version.fromVersionArn(stack, 'Version', 'arn:aws:lambda:region:account-id:function:function-name:$LATEST');
 
     // THEN
@@ -200,7 +192,6 @@ describe('lambda version', () => {
     // GIVEN
     const app = new cdk.App();
     const stack = new cdk.Stack(app, 'Stack');
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'Fn', {
       runtime: THE_RUNTIME,
       handler: 'index.handler',
@@ -228,7 +219,6 @@ describe('lambda version', () => {
   test('throws when adding FunctionUrl to a Version', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'MyLambda', {
       code: new lambda.InlineCode('hello()'),
       handler: 'index.hello',
@@ -249,7 +239,6 @@ describe('lambda version', () => {
   test('version\'s implementation of IFunctionRef should point to the version', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'MyLambda', {
       code: new lambda.InlineCode('hello()'),
       handler: 'index.hello',
@@ -268,7 +257,6 @@ describe('lambda version', () => {
   test('should throw error when version has provisioned concurrency and function has tenancy config', () => {
     // GIVEN
     const stack = new cdk.Stack();
-    cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
     const fn = new lambda.Function(stack, 'MyLambda', {
       code: new lambda.InlineCode('hello()'),
       handler: 'index.hello',
@@ -310,7 +298,6 @@ describe('lambda version', () => {
   describe('version scaling configuration', () => {
     test('version with min and max execution environments', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -333,7 +320,6 @@ describe('lambda version', () => {
 
     test('version with only min execution environments', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -354,7 +340,6 @@ describe('lambda version', () => {
 
     test('version with only max execution environments', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -375,7 +360,6 @@ describe('lambda version', () => {
 
     test('throws when minExecutionEnvironments is negative', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -392,7 +376,6 @@ describe('lambda version', () => {
 
     test('throws when maxExecutionEnvironments is negative', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -409,7 +392,6 @@ describe('lambda version', () => {
 
     test('throws when minExecutionEnvironments is greater than capacityProviderMaxExecutionEnvironments', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',
@@ -427,7 +409,6 @@ describe('lambda version', () => {
 
     test('accepts tokens for execution environment scaling config', () => {
       const stack = new cdk.Stack();
-      cdk.Validations.of(stack).acknowledge({ id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' });
       const fn = new lambda.Function(stack, 'Fn', {
         code: new lambda.InlineCode('foo'),
         handler: 'index.handler',

--- a/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
+++ b/packages/aws-cdk-lib/aws-logs/test/loggroup.test.ts
@@ -3,7 +3,7 @@ import { Template } from '../../assertions';
 import * as iam from '../../aws-iam';
 import * as kms from '../../aws-kms';
 import { Bucket } from '../../aws-s3';
-import { App, CfnParameter, Fn, RemovalPolicy, Stack, Validations } from '../../core';
+import { App, CfnParameter, Fn, RemovalPolicy, Stack } from '../../core';
 import type { ILogGroup, ILogSubscriptionDestination } from '../lib';
 import { LogGroupGrants, LogGroup, RetentionDays, LogGroupClass, DataProtectionPolicy, DataIdentifier, CustomDataIdentifier, FilterPattern, FieldIndexPolicy, ParserProcessor, ParserProcessorType, JsonMutatorType, JsonMutatorProcessor, CfnLogGroup } from '../lib';
 
@@ -101,12 +101,6 @@ describe('log group', () => {
     // GIVEN
     const stack = new Stack();
 
-    // Local silence for the test, this is very unlikely to occur in practice.
-    // https://github.com/aws-cloudformation/cloudformation-validate/issues/185
-    Validations.of(stack).acknowledge({
-      id: 'CloudFormation-Validate::W3030',
-      reason: 'Only for this test',
-    });
     const parameter = new CfnParameter(stack, 'RetentionInDays', { default: 30, type: 'Number' });
 
     // WHEN

--- a/packages/aws-cdk-lib/aws-sns-subscriptions/test/subs.test.ts
+++ b/packages/aws-cdk-lib/aws-sns-subscriptions/test/subs.test.ts
@@ -2029,7 +2029,7 @@ test('with filter policy scope MessageBody', () => {
 });
 
 test('region property is present on an imported topic - sqs', () => {
-  const imported = sns.Topic.fromTopicArn(stack, 'mytopic', 'arn:aws:sns:us-east-1:1234567890:mytopic');
+  const imported = sns.Topic.fromTopicArn(stack, 'mytopic', 'arn:aws:sns:us-east-1:123456789012:mytopic');
   const queue = new sqs.Queue(stack, 'myqueue');
   imported.addSubscription(new subs.SqsSubscription(queue));
 
@@ -2052,7 +2052,7 @@ test('region property on an imported topic as a parameter - sqs', () => {
 });
 
 test('region property is present on an imported topic - lambda', () => {
-  const imported = sns.Topic.fromTopicArn(stack, 'mytopic', 'arn:aws:sns:us-east-1:1234567890:mytopic');
+  const imported = sns.Topic.fromTopicArn(stack, 'mytopic', 'arn:aws:sns:us-east-1:123456789012:mytopic');
   const func = new lambda.Function(stack, 'MyFunc', {
     runtime: lambda.Runtime.NODEJS_LATEST,
     handler: 'index.handler',

--- a/packages/aws-cdk-lib/cloudformation-include/test/test-warnings.ts
+++ b/packages/aws-cdk-lib/cloudformation-include/test/test-warnings.ts
@@ -8,7 +8,9 @@ export function acknowledgeTestWarnings(construct: IConstruct) {
     'E3045',
     'F0005',
     'F0013',
-    'F0014',
+    // This fixture intentionally uses a CDK intrinsic object as an operand where Fn::Equals expects a scalar.
+    // Validator reports this invalid Fn::Equals operand as E8003 instead of the broader F0014.
+    'E8003',
     'F1029',
     'F2002',
     'F2012',
@@ -20,6 +22,12 @@ export function acknowledgeTestWarnings(construct: IConstruct) {
     'F3012',
     'F3014',
     'W1020',
+    // This fixture intentionally contains an unused Fn::Sub variable to test that
+    // cloudformation-include preserves the original expression unchanged.
+    'W1019',
+    // These fixtures intentionally contain literal AWS::Region and AWS::NoValue strings.
+    // The tests exercise template ingestion, not W1054's recommendation to replace them with Ref.
+    'W1054',
     'W1102',
     'W2531',
     'W3011',

--- a/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
@@ -127,10 +127,14 @@ export class CloudFormationValidatePlugin implements IPolicyValidationPlugin {
       for (const diagnostic of report.diagnostics) {
         const severity = mapSeverity(diagnostic.severity);
 
+        const resourceLogicalId = diagnostic.entity?.entityType === 'Resource'
+          ? diagnostic.entity.logicalId
+          : undefined;
+
         const violatingResource: PolicyViolatingResource = {
-          resourceLogicalId: diagnostic.resourceId,
+          resourceLogicalId,
           // If this is not about any resources, best we can do is point it to the stack
-          constructPath: !diagnostic.resourceId ? stackConstructPath : undefined,
+          constructPath: !resourceLogicalId ? stackConstructPath : undefined,
           templatePath,
           locations: diagnostic.propertyPath ? [diagnostic.propertyPath] : [],
         };
@@ -190,10 +194,6 @@ const IGNORE_RULES = new Set([
   // Will be silenced forever.
   'W1020',
 
-  // WHAT: Condition can never be false.
-  // WHY: The engine assumes AWS::Partition can only ever equal 'aws', which is not true. Should be removed.
-  'W1028',
-
   // WHAT: Circular dependency detection
   // WHY: Something seems fishy about it
   // Remove after <https://github.com/aws-cloudformation/cloudformation-validate/issues/53>.
@@ -207,11 +207,6 @@ const IGNORE_RULES = new Set([
   // WHY: Hardcoding an account ID in ARNs is commonly done in CDK when we are setting up large applications that
   // span accounts.
   'W9013',
-
-  // WHAT: Lambda Permission should always have a SourceAccount
-  // WHY: It doesn't seem to detect the account that's there in the ARN?
-  // <https://github.com/aws-cloudformation/cloudformation-validate/issues/183>
-  'W3663',
 
   // WHAT: value type tracking (parameter default should be a string)
   // WHY: When the value is imported, it is considered not a string.

--- a/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
@@ -194,6 +194,12 @@ const IGNORE_RULES = new Set([
   // Will be silenced forever.
   'W1020',
 
+  // WHAT: Fn::GetStackOutput is not an allowed direct source for Fn::Split.
+  // WHY: CDK generates this nesting when deserializing weak string-list cross-stack references,
+  // and customers cannot control the generated expression.
+  // https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-split.html
+  'E1018',
+
   // WHAT: Circular dependency detection
   // WHY: Something seems fishy about it
   // Remove after <https://github.com/aws-cloudformation/cloudformation-validate/issues/53>.

--- a/packages/aws-cdk-lib/core/test/validation/__snapshots__/validation.test.ts.snap
+++ b/packages/aws-cdk-lib/core/test/validation/__snapshots__/validation.test.ts.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validations multiple plugins 1`] = `
-"[Warning] Template validation found issues in your templates (reported as warnings).
-Set feature flag "@aws-cdk/core:validateAgainstDefaultRules" to true to turn these into errors.
-
-core/test/validation/validation.test.ts:328:5
+"core/test/validation/validation.test.ts:328:5
 ERROR do something (plugin1)
    Default/Fake (Fake) constructs.Construct
    Acknowledge with 'plugin1::rule-1'
@@ -18,10 +15,7 @@ A copy of this report can be found in: <assembly-directory>/validation-report.js
 `;
 
 exports[`validations multiple plugins with mixed results 1`] = `
-"[Warning] Template validation found issues in your templates (reported as warnings).
-Set feature flag "@aws-cdk/core:validateAgainstDefaultRules" to true to turn these into errors.
-
-core/test/validation/validation.test.ts:354:5
+"core/test/validation/validation.test.ts:354:5
 ERROR do another thing (plugin2)
    Default/Fake (Fake) constructs.Construct
    Acknowledge with 'plugin2::rule-2'
@@ -30,10 +24,7 @@ A copy of this report can be found in: <assembly-directory>/validation-report.js
 `;
 
 exports[`validations multiple stacks 1`] = `
-"[Warning] Template validation found issues in your templates (reported as warnings).
-Set feature flag "@aws-cdk/core:validateAgainstDefaultRules" to true to turn these into errors.
-
-core/test/validation/validation.test.ts:101:5
+"core/test/validation/validation.test.ts:101:5
 ERROR test recommendation (test-plugin)
    stack1/DefaultResource (DefaultResource) constructs.Construct
    Acknowledge with 'test-plugin::test-rule'
@@ -47,10 +38,7 @@ A copy of this report can be found in: <assembly-directory>/validation-report.js
 `;
 
 exports[`validations multiple stages 1`] = `
-"[Warning] Template validation found issues in your templates (reported as warnings).
-Set feature flag "@aws-cdk/core:validateAgainstDefaultRules" to true to turn these into errors.
-
-core/test/validation/validation.test.ts:169:5
+"core/test/validation/validation.test.ts:169:5
 ERROR do something (test-plugin2)
    Stage1/stack1/DefaultResource (DefaultResource) constructs.Construct
    Acknowledge with 'test-plugin2::test-rule2'
@@ -74,10 +62,7 @@ A copy of this report can be found in: <assembly-directory>/validation-report.js
 `;
 
 exports[`validations validation failure 1`] = `
-"[Warning] Template validation found issues in your templates (reported as warnings).
-Set feature flag "@aws-cdk/core:validateAgainstDefaultRules" to true to turn these into errors.
-
-core/test/validation/validation.test.ts:46:5
+"core/test/validation/validation.test.ts:46:5
 custom test recommendation (test-plugin)
    Default/Fake (Fake) constructs.Construct
    Acknowledge with 'test-plugin::test-rule'

--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -121,7 +121,7 @@
     "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
     "@aws-cdk/cloud-assembly-api": "^2.2.6",
     "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-    "@aws/cloudformation-validate": "1.5.1-beta",
+    "@aws/cloudformation-validate": "1.6.0-beta",
     "@balena/dockerignore": "^1.0.2",
     "case": "1.6.3",
     "fs-extra": "^11.3.6",

--- a/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts
+++ b/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts
@@ -29,7 +29,6 @@ const APP_INIT_HOOK_SYMBOL = Symbol.for('@aws-cdk/core.App#initHook');
     { id: 'CloudFormation-Validate::W9010', reason: 'Hardcoded AMI IDs are fine in tests' },
     { id: 'CloudFormation-Validate::E3710', reason: 'We still have tests for shutdown services' },
     { id: 'CloudFormation-Validate::F3006', reason: 'We invent a lot of resource types for tests.' },
-    { id: 'CloudFormation-Validate::E3702', reason: 'Structurally malformed CodePipeline tests.' },
     { id: 'CloudFormation-Validate::E3677', reason: 'ZipFile does not support node99.x' },
     { id: 'CloudFormation-Validate::W9012', reason: 'We inject bogus AWS AccountIds on the regular (12345) and so on' },
     { id: 'CloudFormation-Validate::E1152', reason: 'Invalid AMI IDs all over the place' },

--- a/packages/aws-cdk-lib/triggers/test/triggers.test.ts
+++ b/packages/aws-cdk-lib/triggers/test/triggers.test.ts
@@ -11,7 +11,6 @@ const THE_RUNTIME = new lambda.Runtime('node99.x', lambda.RuntimeFamily.NODEJS, 
 function testStack() {
   const stack = new Stack();
   Validations.of(stack).acknowledge(
-    { id: 'CloudFormation-Validate::E3071', reason: 'Tests intentionally use a bogus runtime' },
     { id: 'CloudFormation-Validate::W3030', reason: 'Tests intentionally use a bogus runtime' },
   );
   return stack;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2335,10 +2335,10 @@
     "@smithy/types" "^4.16.0"
     tslib "^2.6.2"
 
-"@aws/cloudformation-validate@1.5.1-beta":
-  version "1.5.1-beta"
-  resolved "https://registry.npmjs.org/@aws/cloudformation-validate/-/cloudformation-validate-1.5.1-beta.tgz#c25166a2e6f22b3a7fd3b6454c2794df44f4cf13"
-  integrity sha512-AHua/1/kmVLxkk0qs5bt4vWy64ZV5JUb1MsGKbxttYCF/NykR7WrtQrAGExLi7fdkGa+Ys8U612nG7QIp/z3nQ==
+"@aws/cloudformation-validate@1.6.0-beta":
+  version "1.6.0-beta"
+  resolved "https://registry.npmjs.org/@aws/cloudformation-validate/-/cloudformation-validate-1.6.0-beta.tgz#f1760f823462bd04f9810479e287d8bb62b2570a"
+  integrity sha512-criDxL/FP0Te5HIH6p+TvENftgUztOMKw7LMLhAIDuq/N/kkMsYfxlG7XeyHlq0lEpQwUUek3tgPdSjhLTK3jQ==
 
 "@aws/lambda-invoke-store@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
Upgrade cloudformation-validate library and remove suppressions that has been fixed

## Issue # (if applicable)

Closes #38412  and other issues.

## Reason for this change

Need to upgrade the library to pull in new features and bug fixes

## Description of changes
Upgrading cloudformation-validate library from `1.5.1-beta` to `1.6.0-beta`

### Suppressions removed
#### `E3071` — Lambda ZipFile requires nodejs or python runtime
**Removed from** [`aws-lambda/test/lambda-version.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda/test/lambda-version.test.ts), [`aws-lambda/test/function.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda/test/function.test.ts), [`triggers/test/triggers.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/triggers/test/triggers.test.ts).

**Why.** The rule was renamed to `E3677` by [cloudformation-validate PR 31](https://github.com/aws-cloudformation/cloudformation-validate/pull/31) in 1.2.0-beta, and `E3071` is absent from the 1.6.0-beta inventory.

The check still fires. A `node99.x` runtime with `InlineCode` produces `E3677` at error severity, plus `W3030` at warning severity for the runtime not being in the allowed enum. Both are already acknowledged outside the removed entries: `E3677` in [`testhelpers/jest-global-app-testhook.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts), which applies to every `aws-cdk-lib` test, and `W3030` in each of the three test files above.

#### `E3049` — ECS dynamic host port needs traffic-port target groups
**Removed from** [`aws-ecs-patterns/test/util.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs-patterns/test/util.ts).

**Why.** [cloudformation-validate PR 110](https://github.com/aws-cloudformation/cloudformation-validate/pull/110) split the rule in 1.3.0-beta into `W3049` (a fixed health-check port will not follow an ECS dynamic host port) and `I3049` (relies on the default traffic-port health check), turning one error into a warning and an info.

Neither replacement is acknowledged anywhere in `packages/`, and the tests still pass, for two different reasons. `I3049` is info severity, which the plugin filters out before validation runs. `W3049` fires only when a target group pins a fixed health-check port, which these tests do not do.

#### `W9009` — deprecated property
**Removed from** [`aws-cloudfront/lib/distribution.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-cloudfront/lib/distribution.ts) and [`aws-cloudfront/lib/web-distribution.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-cloudfront/lib/web-distribution.ts).

**Why.** The CloudFront resource schema marks exactly two nested leaves deprecated — `DistributionConfig/CustomOrigin` and `DistributionConfig/S3Origin` — and never `DistributionConfig` itself. Before [cloudformation-validate PR 153](https://github.com/aws-cloudformation/cloudformation-validate/pull/153) in 1.4.0-beta, fixing [issue 144](https://github.com/aws-cloudformation/cloudformation-validate/issues/144), the rule attributed nested deprecations to the parent property, so every distribution drew a bogus deprecation warning. CDK emits its origins as `S3OriginConfig` and `CustomOriginConfig` entries under `Origins`, never the deprecated leaves, so the rule is now correctly silent.

#### `E9004` — GetAtt attribute must exist
**Removed from** [`aws-ecs/test/util.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs/test/util.ts) and [`aws-ecs-patterns/test/util.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs-patterns/test/util.ts).

**Why.** Stale attribute data was regenerated in 1.3.0-beta ([issue 39](https://github.com/aws-cloudformation/cloudformation-validate/issues/39)), ending false positives on valid documented attributes.

#### `E1152` — AMI id format
**Removed from** [`aws-ecs-patterns/test/util.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs-patterns/test/util.ts).

**Why.** SSM-typed parameter defaults are now treated as deploy-time names rather than literal AMI values, fixed in 1.3.0-beta ([issue 34](https://github.com/aws-cloudformation/cloudformation-validate/issues/34)).

The entry was redundant regardless: [`testhelpers/jest-global-app-testhook.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts) applies to every `aws-cdk-lib` test and still acknowledges `E1152` with the reason "Invalid AMI IDs all over the place".

#### `F3003` — required property missing
**Removed from** [`aws-iam/test/escape-hatch.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-iam/test/escape-hatch.test.ts).

**Why.** The rule no longer fires a duplicate fatal alongside `E3045` for the same concern, fixed in 1.3.0-beta by [cloudformation-validate PR 83](https://github.com/aws-cloudformation/cloudformation-validate/pull/83) ([issue 54](https://github.com/aws-cloudformation/cloudformation-validate/issues/54)).


#### `E3702` — CodePipeline artifact counts
**Removed from** [`testhelpers/jest-global-app-testhook.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/testhelpers/jest-global-app-testhook.ts).

**Why.** Artifact-count bounds are now keyed on the full Owner, Category and Provider tuple instead of a collapsed category-only bound, so a `CHANGE_SET_EXECUTE` action with zero input artifacts is no longer flagged. Fixed in 1.3.0-beta by [cloudformation-validate PR 76](https://github.com/aws-cloudformation/cloudformation-validate/pull/76) ([issue 44](https://github.com/aws-cloudformation/cloudformation-validate/issues/44)).

### Suppression added

#### `F3034` — numeric value out of bounds

**Added to** the `with custom cloudmap namespace` and `with all properties set` tests in [`aws-ecs/test/fargate/fargate-service.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs/test/fargate/fargate-service.test.ts) and [`aws-ecs/test/ec2/ec2-service.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ecs/test/ec2/ec2-service.test.ts).

**Why.** Those tests set `failureThreshold: 20` on `cloudMapOptions`, and Cloud Map caps `HealthCheckCustomConfig.FailureThreshold` at 10. The rule reports this as a fatal. This is new detection rather than a behavior change: 1.5.1-beta reports nothing for the same template, and 1.6.0-beta reports the fatal, consistent with [cloudformation-validate PR 202](https://github.com/aws-cloudformation/cloudformation-validate/pull/202) fixing double and long numeric comparisons.

### Test fixture corrected

####  Lambda permission SourceArn account id

**Changed in** [`aws-lambda/test/function.test.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda/test/function.test.ts): the SQS queue ARN's account field went from ten digits to the valid twelve.

**Why.** No rule changed. `W3663` behaves identically on this input in 1.5.1-beta and 1.6.0-beta. What changed is that `W3663` was dropped from the `IGNORE_RULES` set in [`core/lib/validation/cloudformation-validate-plugin.ts`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts), where it carried the note that the rule did not seem to detect the account present in the ARN, citing [issue 183](https://github.com/aws-cloudformation/cloudformation-validate/issues/183).

### Upstream refactoring
`resourceId` field in a diagnostic was removed in favor of a struct that includes `logicalId`, type of entity (resource, output, codition, etc.) in [Issue 201](https://github.com/aws-cloudformation/cloudformation-validate/issues/201) and [PR 206](https://github.com/aws-cloudformation/cloudformation-validate/pull/206) so that diagnostics are more granular

## Describe any new or updated permissions being added

None

## Description of how you validated changes

Tests

## Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
