### PR TITLE
fix(lambda-nodejs): local bundling fails under AllSigned PowerShell execution policy

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/bundling.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/bundling.ts
@@ -524,7 +524,7 @@ export class Bundling implements cdk.BundlingOptions {
           // Powershell.exe instead of cmd.exe because the quoting rules are saner.
           // See https://github.com/aws/aws-cdk/issues/37387
           if (isWindows) {
-            exec('powershell.exe', ['-NoProfile', '-Command', `& ${step.command.map(powershellEscape).join(' ')}`], {
+            exec('powershell.exe', ['-NoProfile', '-Command', powershellCommandLine(step.command)], {
               ...execOptions,
               cwd: step.cwd ?? cwd,
             });
@@ -683,6 +683,28 @@ function posixShellEscape(arg: string): string {
 
 function powershellEscape(arg: string): string {
   return "'" + arg.replace(/'/g, "''") + "'";
+}
+
+/**
+ * Build the PowerShell command line used to run a bundling spawn step on Windows.
+ *
+ * The executable is resolved with `Get-Command -CommandType Application` rather than
+ * being passed to the call operator directly. Given a bare command name such as `npm`,
+ * PowerShell's own command discovery can select the `npm.ps1` shim, and `.ps1` scripts
+ * are subject to the execution policy: under `AllSigned` (typically set at
+ * `MachinePolicy` scope via Group Policy, which overrides every other scope) the shim is
+ * refused and bundling fails. `-CommandType Application` only matches external programs
+ * such as `npm.cmd`, which the execution policy does not apply to.
+ *
+ * Arguments remain individually quoted, so this keeps the argument handling introduced
+ * to fix command injection in local bundling.
+ *
+ * See https://github.com/aws/aws-cdk/issues/38439
+ */
+function powershellCommandLine(command: string[]): string {
+  const [executable, ...args] = command;
+  const resolved = `(Get-Command ${powershellEscape(executable)} -CommandType Application)[0].Source`;
+  return ['&', resolved, ...args.map(powershellEscape)].join(' ');
 }
 
 /**

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/bundling.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/bundling.test.ts
@@ -1605,6 +1605,50 @@ test('Local bundling on Windows uses powershell for spawn steps', () => {
   expect(cmdString).toContain("'--bundle'");
   expect(cmdString).toContain("'--platform=node'");
 
+  // The executable is resolved to an Application so PowerShell cannot select the
+  // .ps1 shim, which the AllSigned execution policy refuses. See issue #38439.
+  expect(cmdString).toMatch(/^& \(Get-Command '[^']+' -CommandType Application\)\[0\]\.Source /);
+
+  spawnSyncMock.mockRestore();
+  osPlatformMock.mockRestore();
+});
+
+test('Local bundling on Windows resolves the spawned executable to an Application', () => {
+  // A bare command name passed to the PowerShell call operator can resolve to the
+  // .ps1 shim (e.g. npm.ps1), which is blocked under an AllSigned execution policy.
+  // Resolving with -CommandType Application only matches npm.cmd / npm.exe.
+  // See https://github.com/aws/aws-cdk/issues/38439
+  const osPlatformMock = jest.spyOn(os, 'platform').mockReturnValue('win32');
+  const spawnSyncMock = jest.spyOn(child_process, 'spawnSync').mockReturnValue(spawnSyncMockReturnValue);
+  jest.spyOn(fs, 'copyFileSync').mockReturnValue();
+  jest.spyOn(fs, 'writeFileSync').mockReturnValue();
+
+  const packageLock = path.join(__dirname, '..', 'package-lock.json');
+  const bundler = new Bundling(stack, {
+    entry: __filename,
+    projectRoot: path.dirname(packageLock),
+    depsLockFilePath: packageLock,
+    runtime: STANDARD_RUNTIME,
+    architecture: Architecture.X86_64,
+    nodeModules: ['delay'],
+  });
+
+  bundler.local?.tryBundle('/outdir', { image: STANDARD_RUNTIME.bundlingDockerImage });
+
+  const psCommands = spawnSyncMock.mock.calls
+    .filter(c => c[0] === 'powershell.exe')
+    .map(c => (c[1] as string[])[2]);
+  expect(psCommands.length).toBeGreaterThan(0);
+
+  for (const command of psCommands) {
+    // Every spawn resolves its executable rather than invoking a bare name.
+    expect(command).toMatch(/^& \(Get-Command '[^']+' -CommandType Application\)\[0\]\.Source/);
+    expect(command).not.toMatch(/^& '/);
+  }
+
+  // The npm install step is present and goes through the resolved form.
+  expect(psCommands.some(c => c.includes('-CommandType Application') && c.includes("'ci'"))).toEqual(true);
+
   spawnSyncMock.mockRestore();
   osPlatformMock.mockRestore();
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38439.

### Reason for this change

Local bundling on Windows runs `powershell.exe -NoProfile -Command "& 'npm' 'ci'"`. Because the call operator receives a bare command name, PowerShell's command discovery can select the `npm.ps1` shim over `npm.cmd`, and `.ps1` scripts are subject to the execution policy. Under `AllSigned` there is no developer-side workaround: `MachinePolicy` scope overrides the `Process` scope that `-ExecutionPolicy Bypass` would set.

### Description of changes

Resolve the executable with `Get-Command <name> -CommandType Application` before invoking it. `Application` matches only external programs (`.cmd`, `.exe`), so the `.ps1` shim is never a candidate.

Both prior fixes are preserved: the command name and all arguments are still individually quoted via `powershellEscape` (command injection fix), and spawn steps still route through PowerShell rather than spawning `.cmd` directly (`EINVAL` fix from #37412).

Behavior note: a missing executable now surfaces as PowerShell's `CommandNotFoundException` instead of a spawn failure. The message still names the command.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

The existing Windows spawn test now also asserts the resolved-application form, and a new test over a `nodeModules` install asserts every spawn resolves its executable, none uses the bare `& '...'` form, and the `npm ci` step is present. Both assertions fail against the current implementation and pass with the fix. Full `aws-lambda-nodejs` suite passes (154 tests); `docker.test.ts` was not run as it requires a Docker daemon.

I do not have a Windows machine with `MachinePolicy: AllSigned`, so the fix is verified by asserting the generated command line rather than by executing it. @jeham, if you are able to confirm on your environment that would be valuable.

No integration test: local bundling path, no template or deployable behavior change. Exemption Request will follow if the linter requires one.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
