### PR TITLE
feat(secretsmanager): support blockPublicPolicy in L2 constructs

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-secretsmanager/test/integ.secret.lit.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-secretsmanager/test/integ.secret.lit.ts
@@ -11,7 +11,14 @@ class SecretsManagerStack extends cdk.Stack {
 
     /// !show
     // Default secret
-    const secret = new secretsmanager.Secret(this, 'Secret');
+    const secret = new secretsmanager.Secret(this, 'Secret', {
+      blockPublicPolicy: true,
+    });
+    secret.addToResourcePolicy(new iam.PolicyStatement({
+      actions: ['secretsmanager:GetSecretValue'],
+      principals: [new iam.AnyPrincipal()],
+      resources: ['*'],
+    }));
     secret.grantRead(role);
 
     const user = new iam.User(this, 'User', {

--- a/packages/aws-cdk-lib/aws-secretsmanager/README.md
+++ b/packages/aws-cdk-lib/aws-secretsmanager/README.md
@@ -70,6 +70,20 @@ secret.grantRead(role);
 secret.grantWrite(role);
 ```
 
+## Block public resource policies
+
+To ask Secrets Manager to reject resource policies that grant public access,
+set `blockPublicPolicy` when creating a secret or a standalone resource policy:
+
+```ts
+const secret = new secretsmanager.Secret(this, 'Secret', {
+  blockPublicPolicy: true,
+});
+```
+
+When the secret creates its resource policy lazily, the setting is forwarded to
+`AWS::SecretsManager::ResourcePolicy`.
+
 If, as in the following example, your secret was created with a KMS key:
 
 ```ts

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/policy.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/policy.ts
@@ -14,6 +14,13 @@ export interface ResourcePolicyProps {
    * The secret to attach a resource-based permissions policy
    */
   readonly secret: ISecret;
+
+  /**
+   * Specifies whether to block resource-based policies that allow broad access to the secret.
+   *
+   * @default - AWS Secrets Manager default
+   */
+  readonly blockPublicPolicy?: boolean;
 }
 
 /**
@@ -47,6 +54,7 @@ export class ResourcePolicy extends Resource {
     new CfnResourcePolicy(this, 'Resource', {
       resourcePolicy: this.document,
       secretId: props.secret.secretArn,
+      blockPublicPolicy: props.blockPublicPolicy,
     });
   }
 }

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
@@ -127,6 +127,13 @@ export interface SecretProps {
   readonly description?: string;
 
   /**
+   * Specifies whether to block resource-based policies that allow broad access to the secret.
+   *
+   * @default - AWS Secrets Manager default
+   */
+  readonly blockPublicPolicy?: boolean;
+
+  /**
    * The customer-managed encryption key to use for encrypting the secret value.
    *
    * @default - A default KMS key for the account and region is used.
@@ -359,9 +366,11 @@ abstract class SecretBase extends Resource implements ISecret {
 
   private policy?: ResourcePolicy;
   private _arnForPolicies: string;
+  private readonly blockPublicPolicy?: boolean;
 
-  constructor(scope: Construct, id: string, props: ResourceProps = {}) {
+  constructor(scope: Construct, id: string, props: ResourceProps = {}, blockPublicPolicy?: boolean) {
     super(scope, id, props);
+    this.blockPublicPolicy = blockPublicPolicy;
     // eslint-disable-next-line no-restricted-syntax
     this._arnForPolicies = Lazy.uncachedString({
       produce: (context: IResolveContext) => {
@@ -484,7 +493,10 @@ abstract class SecretBase extends Resource implements ISecret {
 
   public addToResourcePolicy(statement: iam.PolicyStatement): iam.AddToResourcePolicyResult {
     if (!this.policy && this.autoCreatePolicy) {
-      this.policy = new ResourcePolicy(this, 'Policy', { secret: this });
+      this.policy = new ResourcePolicy(this, 'Policy', {
+        secret: this,
+        blockPublicPolicy: this.blockPublicPolicy,
+      });
     }
 
     if (this.policy) {
@@ -676,7 +688,7 @@ export class Secret extends SecretBase {
   constructor(scope: Construct, id: string, props: SecretProps = {}) {
     super(scope, id, {
       physicalName: props.secretName,
-    });
+    }, props.blockPublicPolicy);
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 

--- a/packages/aws-cdk-lib/aws-secretsmanager/test/policy.test.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/test/policy.test.ts
@@ -42,3 +42,18 @@ describe.each([
     Template.fromStack(stack).resourceCountIs('AWS::SecretsManager::ResourcePolicy', expectedResourcePolicyCount);
   });
 });
+
+test('passes blockPublicPolicy to the L1 resource policy', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app);
+  const secret = new secretsmanager.Secret(stack, 'Secret');
+
+  new secretsmanager.ResourcePolicy(stack, 'Policy', {
+    secret,
+    blockPublicPolicy: true,
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+    BlockPublicPolicy: true,
+  });
+});

--- a/packages/aws-cdk-lib/aws-secretsmanager/test/secret.test.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/test/secret.test.ts
@@ -23,6 +23,22 @@ test('default secret', () => {
   });
 });
 
+test('secret with blockPublicPolicy passes it to the resource policy', () => {
+  const secret = new secretsmanager.Secret(stack, 'Secret', {
+    blockPublicPolicy: true,
+  });
+
+  secret.addToResourcePolicy(new iam.PolicyStatement({
+    actions: ['secretsmanager:GetSecretValue'],
+    principals: [new iam.AccountRootPrincipal()],
+    resources: ['*'],
+  }));
+
+  Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+    BlockPublicPolicy: true,
+  });
+});
+
 test('secret without replica regions omits ReplicaRegions', () => {
   // WHEN
   new secretsmanager.Secret(stack, 'Secret');


### PR DESCRIPTION
### Issue # (if applicable)

Fixes #33913.

## Description of changes

Adds the CloudFormation `blockPublicPolicy` option to the Secrets Manager L2 API:

- `ResourcePolicyProps.blockPublicPolicy` forwards to `CfnResourcePolicy`.
- `SecretProps.blockPublicPolicy` is preserved until the lazily-created resource policy is synthesized.
- Unit coverage verifies both direct `ResourcePolicy` use and `Secret` policy creation.
- The README now documents the option, and the Secrets Manager integration fixture exercises a public policy with the option enabled.

## Verification

- `git diff --check` passes.
- The Windows checkout is sparse and does not contain the full workspace package graph. A dependency install therefore could not resolve the local `0.0.0` workspace packages, so the Jest suite and generated integration snapshot could not be regenerated locally.
- The generated L1 construct was not edited.

## AI disclosure

AI assistance was used to inspect the existing construct and tests and prepare this focused patch. The final changes and verification limits were reviewed before submission.