### PR TITLE
docs(s3,kms): replace object-literal IResourceWithPolicyV2 example with named class

### DIFF
--- a/packages/aws-cdk-lib/aws-kms/README.md
+++ b/packages/aws-cdk-lib/aws-kms/README.md
@@ -293,20 +293,31 @@ for the `AWS::KMS::Key` CloudFormation type:
 
 ```ts nofixture
 import { CfnResource } from 'aws-cdk-lib';
-import { IResourcePolicyFactory, IResourceWithPolicyV2, PolicyStatement, ResourceWithPolicies } from 'aws-cdk-lib/aws-iam';
-import { Construct, IConstruct } from 'constructs';
+import { AddToResourcePolicyResult, IResourcePolicyFactory, IResourceWithPolicyV2, PolicyStatement, ResourceWithPolicies } from 'aws-cdk-lib/aws-iam';
+import { ResourceEnvironment } from 'aws-cdk-lib/interfaces';
+import { Construct } from 'constructs';
 
 
 declare const scope: Construct;
+
+class MyResourceWithPolicy implements IResourceWithPolicyV2 {
+  public readonly env: ResourceEnvironment;
+  private readonly resource: CfnResource;
+
+  constructor(resource: CfnResource) {
+    this.resource = resource;
+    this.env = resource.env;
+  }
+
+  public addToResourcePolicy(statement: PolicyStatement): AddToResourcePolicyResult {
+    // custom implementation to add the statement to the resource policy
+    return { statementAdded: true, policyDependable: this.resource };
+  }
+}
+
 class MyFactory implements IResourcePolicyFactory {
-  forResource(resource: CfnResource): IResourceWithPolicyV2 {
-    return {
-      env: resource.env,
-      addToResourcePolicy(statement: PolicyStatement) {
-        // custom implementation to add the statement to the resource policy
-        return { statementAdded: true, policyDependable: resource };
-      }
-    }
+  public forResource(resource: CfnResource): IResourceWithPolicyV2 {
+    return new MyResourceWithPolicy(resource);
   }
 }
 

--- a/packages/aws-cdk-lib/aws-s3/README.md
+++ b/packages/aws-cdk-lib/aws-s3/README.md
@@ -194,19 +194,30 @@ for the `AWS::S3::Bucket` CloudFormation type:
 
 ```ts nofixture
 import { CfnResource } from 'aws-cdk-lib';
-import { IResourcePolicyFactory, IResourceWithPolicyV2, PolicyStatement, ResourceWithPolicies } from 'aws-cdk-lib/aws-iam';
-import { Construct, IConstruct } from 'constructs';
+import { AddToResourcePolicyResult, IResourcePolicyFactory, IResourceWithPolicyV2, PolicyStatement, ResourceWithPolicies } from 'aws-cdk-lib/aws-iam';
+import { ResourceEnvironment } from 'aws-cdk-lib/interfaces';
+import { Construct } from 'constructs';
 
 declare const scope: Construct;
+
+class MyResourceWithPolicy implements IResourceWithPolicyV2 {
+  public readonly env: ResourceEnvironment;
+  private readonly resource: CfnResource;
+
+  constructor(resource: CfnResource) {
+    this.resource = resource;
+    this.env = resource.env;
+  }
+
+  public addToResourcePolicy(statement: PolicyStatement): AddToResourcePolicyResult {
+    // custom implementation to add the statement to the resource policy
+    return { statementAdded: true, policyDependable: this.resource };
+  }
+}
+
 class MyFactory implements IResourcePolicyFactory {
-  forResource(resource: CfnResource): IResourceWithPolicyV2 {
-    return {
-      env: resource.env,
-      addToResourcePolicy(statement: PolicyStatement) {
-        // custom implementation to add the statement to the resource policy
-        return { statementAdded: true, policyDependable: resource };
-      }
-    }
+  public forResource(resource: CfnResource): IResourceWithPolicyV2 {
+    return new MyResourceWithPolicy(resource);
   }
 }
 


### PR DESCRIPTION
## Description

```markdown
The object-literal pattern with inline methods in the `forResource()` return
value does not translate across jsii/rosetta to non-TypeScript languages
(Ruby, Python, Java, C#, Go).

Replace it with a proper `MyResourceWithPolicy` class that implements
`IResourceWithPolicyV2`, matching the existing `CfnBucketWithPolicy` and
`CfnKeyWithPolicy` patterns in `default-traits.ts`.

closes #38452

### Issue # (if applicable)

Closes #38452

### Reason for this change

The `IResourcePolicyFactory` / `IResourceWithPolicyV2` usage example in the S3
and KMS READMEs used a TypeScript object-literal-with-inline-method pattern
for the return value of `forResource()`:

```ts
return {
  env: resource.env,
  addToResourcePolicy(statement) { ... }
};
```

While this satisfies the structural interface in TypeScript, jsii/Rosetta
cannot translate anonymous objects with methods to other languages. The
generated Ruby docs showed an inline `def` inside a hash, Python had raw
function bodies inside dicts, and Java produced `Map.of()` with a broken
method body. See the full breakdown in #38452.

### Description of changes

Updated the `nofixture` code blocks in both READMEs to use a proper named
class `MyResourceWithPolicy` that explicitly implements `IResourceWithPolicyV2`:

- `packages/aws-cdk-lib/aws-s3/README.md` — replaced object-literal with
  `MyResourceWithPolicy` class
- `packages/aws-cdk-lib/aws-kms/README.md` — identical fix, adapted for
  `AWS::KMS::Key`

Both now follow the same class-based pattern as `CfnBucketWithPolicy` and
`CfnKeyWithPolicy` in their respective `default-traits.ts` source files.

Additional imports added: `AddToResourcePolicyResult` (from
`aws-cdk-lib/aws-iam`) and `ResourceEnvironment` (from
`aws-cdk-lib/interfaces`). Removed unused `IConstruct` import.

**Note: this is NOT the full fix for #38452.** This PR only addresses the
README examples. The Rosetta transpiler itself still has bugs in the C#,
Golang, and Java targets (e.g. `resource = resource;` self-assignment in C#,
incorrect pointer usage in Go, missing `getEnv()` in Java) that will need a
separate PR in the Rosetta codebase. See @omarqureshi's analysis in the issue
for details on those remaining transpiler issues.

### Describe any new or updated permissions being added

None — documentation-only change.

### Description of how you validated changes

- Verified the new class structure matches the existing `CfnBucketWithPolicy`
  and `CfnKeyWithPolicy` implementations in `default-traits.ts` exactly
- Confirmed all imported types (`AddToResourcePolicyResult`,
  `ResourceEnvironment`, `IResourceWithPolicyV2`, `IResourcePolicyFactory`,
  `PolicyStatement`, `ResourceWithPolicies`) are exported from their
  respective modules
- Confirmed the issue author's Rosetta translation output shows clean,
  idiomatic Ruby, Python, and Java for the class-based pattern
- Full Rosetta extraction (`yarn rosetta:extract --strict`) should be run
  on a machine with ≥16GB RAM to verify cross-language translation before
  merge

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
```