### PR TITLE
chore(aspects): handle special case of ancestry

### DIFF
--- a/packages/aws-cdk-lib/core/test/aspect.prop.test.ts
+++ b/packages/aws-cdk-lib/core/test/aspect.prop.test.ts
@@ -276,6 +276,10 @@ function sameAspect(a: AspectVisit, b: AspectVisit) {
  * Returns whether `a` is an ancestor of `b` (or if they are the same construct)
  */
 function isAncestorOf(a: Construct, b: Construct) {
+  // The root construct has an empty path and is an ancestor of every construct.
+  // Guarding against it explicitly avoids the `'' + '/'` === '/' pitfall, which
+  // would otherwise make `startsWith` fail for every non-root descendant.
+  if (a.node.path === '') return true;
   return b.node.path === a.node.path || b.node.path.startsWith(a.node.path + '/');
 }
 


### PR DESCRIPTION
The path of the root of the construct tree is, by definition, the ancestor of every other path.

The current `isAncestorOf` returns false in this case. This was caught by accident when fact-check ran the tests with the seed -1286036690.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
