### PR TITLE
fix: node.addDependency between stacks is quadratic in number of resources

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/prepare-app.ts
+++ b/packages/aws-cdk-lib/core/lib/private/prepare-app.ts
@@ -2,11 +2,12 @@ import type { IConstruct } from 'constructs';
 import { Dependable } from 'constructs';
 import { resolveReferences } from './refs';
 import { CfnResource } from '../cfn-resource';
-import type { Stack } from '../stack';
+import { Stack } from '../stack';
 import { iterateDfsPostorder, iterateDfsPreorder } from './construct-iteration';
 import { writePropertyAssignmentMetadataForConstruct } from './resolve';
 import { debugModeEnabled } from '../debug';
 import { STACK_TYPE, stageOf } from './core-construct-finders';
+import { addDependency } from '../deps';
 
 function writePropertyAssignmentMetadata(root: IConstruct) {
   if (!debugModeEnabled()) return;
@@ -35,6 +36,25 @@ function writePropertyAssignmentMetadata(root: IConstruct) {
 export function prepareApp(root: IConstruct) {
   // apply dependencies between resources in depending subtrees
   for (const dependency of findTransitiveDeps(root)) {
+    const sourceTopLevelStack = topLevelStackOf(dependency.source);
+    const targetTopLevelStack = topLevelStackOf(dependency.target);
+
+    // Optimization: if source and target are under different top-level stacks,
+    // every resource pair in the Cartesian product will resolve to the same
+    // single assembly-level (stack-to-stack) dependency. Avoid the O(n*m)
+    // expansion and apply the dependency once using representative elements.
+    if (sourceTopLevelStack && targetTopLevelStack && sourceTopLevelStack !== targetTopLevelStack) {
+      const sourceRep = findFirstCfnResource(dependency.source);
+      const targetRep = findFirstCfnResource(dependency.target);
+      if (sourceRep && targetRep) {
+        addDependency(sourceRep, targetRep, `{${dependency.source.node.path}}.addDependency({${dependency.target.node.path}})`);
+      }
+      continue;
+    }
+
+    // Same top-level stack (or no stack found): expand to the Cartesian product
+    // of resources. addResourceDependency handles nested stack boundaries
+    // correctly via deps.ts (resourceInCommonStackFor).
     const targetCfnResources = findCfnResources(dependency.target);
 
     // Gets iterated multiple times so make the iterator concrete
@@ -121,6 +141,36 @@ function* findCfnResources(root: IConstruct): IterableIterator<CfnResource> {
     if (CfnResource.isCfnResource(node)) {
       yield node;
     }
+  }
+}
+
+/**
+ * Find the first CfnResource under a construct (used as a representative
+ * for cross-stack dependency resolution where all resources resolve to the
+ * same stack dependency).
+ */
+function findFirstCfnResource(root: IConstruct): CfnResource | undefined {
+  for (const node of iterateDfsPreorder(root)) {
+    if (CfnResource.isCfnResource(node)) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Return the top-level (non-nested) stack containing the given construct,
+ * or undefined if the construct is not in a stack.
+ */
+function topLevelStackOf(construct: IConstruct): Stack | undefined {
+  try {
+    let stack = Stack.of(construct);
+    while (stack.nestedStackParent) {
+      stack = stack.nestedStackParent;
+    }
+    return stack;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/aws-cdk-lib/core/lib/private/prepare-app.ts
+++ b/packages/aws-cdk-lib/core/lib/private/prepare-app.ts
@@ -39,10 +39,10 @@ export function prepareApp(root: IConstruct) {
     const sourceTopLevelStack = topLevelStackOf(dependency.source);
     const targetTopLevelStack = topLevelStackOf(dependency.target);
 
-    // Optimization: if source and target are under different top-level stacks,
+    // If source and target are under different top-level stacks,
     // every resource pair in the Cartesian product will resolve to the same
-    // single assembly-level (stack-to-stack) dependency. Avoid the O(n*m)
-    // expansion and apply the dependency once using representative elements.
+    // single assembly-level (stack-to-stack) dependency. We avoid the O(n*m)
+    // expansion and apply the dependency once using representative elements in this case.
     if (sourceTopLevelStack && targetTopLevelStack && sourceTopLevelStack !== targetTopLevelStack) {
       const sourceRep = findFirstCfnResource(dependency.source);
       const targetRep = findFirstCfnResource(dependency.target);

--- a/packages/aws-cdk-lib/core/test/deps.test.ts
+++ b/packages/aws-cdk-lib/core/test/deps.test.ts
@@ -166,5 +166,97 @@ describe('deps', () => {
         stack.resolve(nested.nestedStackResource!.logicalId),
       ].sort());
     });
+
+    test('cross-stack node.addDependency produces a stack-to-stack dependency without quadratic expansion', () => {
+      // Verify that the cross-stack short-circuit produces the correct assembly
+      // dependency and doesn't blow up with large stacks.
+      const app = new core.App();
+      const stackA = new core.Stack(app, 'StackA');
+      const stackB = new core.Stack(app, 'StackB');
+
+      // Create many resources in each stack
+      const resourceCount = 100;
+      for (let i = 0; i < resourceCount; i++) {
+        new core.CfnResource(stackA, `ResA${i}`, { type: 'Test::Resource::Fake' });
+        new core.CfnResource(stackB, `ResB${i}`, { type: 'Test::Resource::Fake' });
+      }
+
+      stackA.node.addDependency(stackB);
+      app.synth();
+
+      // Should produce exactly one stack dependency
+      expect(stackA.dependencies).toHaveLength(1);
+      expect(stackA.dependencies[0]).toBe(stackB);
+    });
+
+    test('cross-stack dependency works when source and target are in nested stacks under different top-level stacks', () => {
+      const app = new core.App();
+      const topA = new core.Stack(app, 'TopA');
+      const topB = new core.Stack(app, 'TopB');
+
+      const nestedA = new core.NestedStack(topA, 'NestedA');
+      const nestedB = new core.NestedStack(topB, 'NestedB');
+
+      const resA = new core.CfnResource(nestedA, 'ResA', { type: 'Test::Resource::Fake' });
+      new core.CfnResource(nestedB, 'ResB', { type: 'Test::Resource::Fake' });
+
+      resA.node.addDependency(nestedB);
+      app.synth();
+
+      // Should produce a top-level stack dependency
+      expect(topA.dependencies).toHaveLength(1);
+      expect(topA.dependencies[0]).toBe(topB);
+    });
+
+    test('nested stack resource does not get DependsOn entries referencing parent stack logical IDs', () => {
+      // https://github.com/aws/aws-cdk/issues/38406 (schahal scenario)
+      // A construct inside a nested stack depending on something in the parent
+      // must not produce DependsOn entries for logical IDs that only exist in
+      // the parent template.
+      const app = new core.App();
+      const stack = new core.Stack(app, 'TestStack');
+      const target = new core.CfnResource(stack, 'Target', { type: 'AWS::SNS::Topic' });
+
+      const nested = new core.NestedStack(stack, 'Nested');
+      const inner = new core.CfnResource(nested, 'Inner', { type: 'AWS::SNS::Topic' });
+      inner.node.addDependency(target);
+
+      const assembly = app.synth();
+      const parentTemplate = assembly.getStackByName(stack.stackName).template;
+
+      // Find the nested stack template from the assembly artifacts
+      const nestedArtifact = assembly.artifacts.find(
+        (a) => a.id !== stack.artifactId && a.manifest?.type === 'aws:cloudformation:stack',
+      );
+
+      // The parent template's nested stack resource should depend on Target
+      const nestedStackEntry = Object.entries(parentTemplate.Resources).find(
+        ([_, v]: [string, any]) => v.Type === 'AWS::CloudFormation::Stack',
+      );
+      expect(nestedStackEntry).toBeDefined();
+      expect((nestedStackEntry![1] as any).DependsOn).toContain('Target');
+
+      // If we can access the nested template, verify it doesn't reference Target
+      if (nestedArtifact) {
+        const nestedTemplate = (nestedArtifact as any).template;
+        if (nestedTemplate?.Resources?.Inner) {
+          expect(nestedTemplate.Resources.Inner.DependsOn).toBeUndefined();
+        }
+      }
+    });
+
+    test('node.addDependency on a construct with no resources is a no-op', () => {
+      const app = new core.App();
+      const stack = new core.Stack(app, 'TestStack');
+      const emptyConstruct = new Construct(stack, 'Empty');
+      const resource = new core.CfnResource(stack, 'Res', { type: 'Test::Resource::Fake' });
+
+      // Depend on empty construct — should not crash
+      resource.node.addDependency(emptyConstruct);
+
+      const template = app.synth().getStackByName(stack.stackName).template;
+      // Resource should have no DependsOn since the target has no resources
+      expect(template.Resources.Res.DependsOn).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
This pr is a reimplementation of https://github.com/aws/aws-cdk/pull/38314

Previously, `node.addDependency` between stacks expanded all resources on both sides into a Cartesian product, calling `addResourceDependency` for each pair, making it O(n*m) per dependency. Every pair ultimately resolved to the same single stack-to-stack dependency, making the work redundant.

This pr retains the lazy nature of dependency resolution. Before we go down the cartesian expansion, we add a check. If source and target are under different top-level stacks, we apply the dependency once between stacks using a representative resource from each side, skipping the cartesian product entirely. This makes the overall time complexity of cross-stack dependency resolution from quadratic to constant.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
