### PR TITLE
fix(ec2): validate the CIDR mask instead of reporting a NaN address

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/network-util.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/network-util.ts
@@ -263,6 +263,28 @@ export class CidrBlock {
   }
 
   /**
+   * Extracts and validates the mask from a CIDR string
+   *
+   * Parsing stays `parseInt`-based so that any mask which resolves today keeps
+   * resolving to the same number; only masks that cannot yield a usable block
+   * are rejected. Without this check they flow into the address arithmetic and
+   * surface as an error naming an address the caller never wrote (e.g.
+   * `10.0.0.0` reports `NaN.NaN.NaN.NaN is not a valid IP Address`), or produce
+   * a silently nonsensical block (`10.0.0.0/33` yields `9.255.255.255/33`).
+   * @internal
+   */
+  private static parseMask(cidr: string): number {
+    const mask = parseInt(cidr.split('/')[1], 10);
+    if (!Number.isInteger(mask) || mask < 0 || mask > 32) {
+      throw new UnscopedValidationError(
+        lit`InvalidCidrMask`,
+        `invalid CIDR mask in ${JSON.stringify(cidr)}, expected an integer between 0 and 32 after a '/', e.g. '10.0.0.0/16'`,
+      );
+    }
+    return mask;
+  }
+
+  /**
    * The CIDR Block represented as a string e.g. '10.0.0.0/21'
    * @internal
    */
@@ -301,7 +323,7 @@ export class CidrBlock {
   constructor(ipAddress: number, mask: number);
   constructor(ipAddressOrCidr: string | number, mask?: number) {
     if (typeof ipAddressOrCidr === 'string') {
-      this.mask = parseInt(ipAddressOrCidr.split('/')[1], 10);
+      this.mask = CidrBlock.parseMask(ipAddressOrCidr);
       this.networkAddress = NetworkUtils.ipToNum(ipAddressOrCidr.split('/')[0]) +
         CidrBlock.calculateNetsize(this.mask) - 1;
     } else {

--- a/packages/aws-cdk-lib/aws-ec2/test/network-utils.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/network-utils.test.ts
@@ -90,6 +90,35 @@ describe('network utils', () => {
       const netmask = CidrBlock.calculateNetmask(27);
       expect(netmask).toEqual('255.255.255.224');
     });
+    test.each([
+      ['10.0.0.0', 'no mask at all'],
+      ['10.0.0.0/', 'empty mask'],
+      ['10.0.0.0/abc', 'non-numeric mask'],
+    ])('fails with a mask-specific error for %s (%s)', (cidr: string) => {
+      // These already threw, but the unvalidated mask flowed into the address
+      // arithmetic first, so the error named an address the caller never wrote:
+      // 'NaN.NaN.NaN.NaN is not a valid IP Address'.
+      expect(() => new CidrBlock(cidr)).toThrow(/invalid CIDR mask/);
+      expect(() => new CidrBlock(cidr)).not.toThrow(/NaN/);
+    });
+    test.each([
+      ['10.0.0.0/33', 'mask above 32'],
+      ['10.0.0.0/-1', 'negative mask'],
+    ])('fails instead of building a nonsensical block for %s (%s)', (cidr: string) => {
+      // Previously silent: '10.0.0.0/33' produced '9.255.255.255/33', which
+      // CloudFormation rejects at deploy time.
+      expect(() => new CidrBlock(cidr)).toThrow(/invalid CIDR mask/);
+    });
+    test('accepts the full range of valid masks', () => {
+      expect(new CidrBlock('0.0.0.0/0').cidr).toEqual('0.0.0.0/0');
+      expect(new CidrBlock('10.0.0.0/16').cidr).toEqual('10.0.0.0/16');
+      expect(new CidrBlock('10.0.0.1/32').cidr).toEqual('10.0.0.1/32');
+    });
+    test('keeps resolving masks that already resolved', () => {
+      // parseInt semantics are preserved so no app that synthesizes today breaks
+      expect(new CidrBlock('10.0.0.0/16abc').cidr).toEqual('10.0.0.0/16');
+      expect(new CidrBlock('10.0.0.0/16.5').cidr).toEqual('10.0.0.0/16');
+    });
   });
   describe('NetworkBuilder', () => {
     test('allows you to carve subnets our of CIDR network', () => {


### PR DESCRIPTION
### Issue # (if applicable)

fixes #38523

### Reason for this change

An invalid or missing CIDR mask was never validated, so it flowed into the address arithmetic in `CidrBlock` and surfaced as an error naming an address the caller never wrote:

```
ec2.IpAddresses.cidr('10.0.0.0')
  -> Error: NaN.NaN.NaN.NaN is not a valid IP Address
```

Nothing in that message points at the missing `/16`. `parseInt(undefined, 10)` is `NaN`, so `calculateNetsize` returns `2 ** (32 - NaN)` = `NaN`, and `numToIp` is the first thing to notice.

A mask above 32 was worse — it produced **no error at all**. `calculateNetsize(33)` returns `0.5`, so the block silently resolves one address low:

```
new CidrBlock('10.0.0.0/33').cidr   // '9.255.255.255/33'
```

Synthesis continues with an address outside the range the caller asked for, and the failure only shows up later as a confusing downstream error (`1 of /24 exceeds remaining space of 9.255.255.255/33`) or as a CloudFormation rejection at deploy time.

### Description of changes

Validate the mask in the `CidrBlock` constructor, before it reaches the arithmetic, and throw an `UnscopedValidationError` naming the mask and the accepted range:

```
invalid CIDR mask in "10.0.0.0", expected an integer between 0 and 32 after a '/', e.g. '10.0.0.0/16'
```

**Parsing deliberately stays `parseInt`-based.** `'10.0.0.0/16abc'` and `'10.0.0.0/16.5'` resolve to `16` today and synthesize successfully, so tightening the *parse* (e.g. to `Number()`) would reject input that currently deploys. Only masks that cannot yield a usable block — `NaN`, `< 0`, `> 32` — are rejected.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Unit tests added to `aws-ec2/test/network-utils.test.ts`, covering the three groups that matter:

- masks that already threw, asserting the message now names the mask and no longer contains `NaN`
- masks that were previously silent (`/33`, `/-1`), asserting they now fail
- **backwards compatibility** — `/16abc` and `/16.5` still resolve to `10.0.0.0/16`, and `0.0.0.0/0`, `/16`, `/32` are unaffected

Full before/after across every input I could think of:

| input | before | after |
|---|---|---|
| `10.0.0.0/16` | `10.0.0.0/16` | `10.0.0.0/16` |
| `0.0.0.0/0` | `0.0.0.0/0` | `0.0.0.0/0` |
| `10.0.0.1/32` | `10.0.0.1/32` | `10.0.0.1/32` |
| `10.0.0.0/16abc` | `10.0.0.0/16` | `10.0.0.0/16` |
| `10.0.0.0/16.5` | `10.0.0.0/16` | `10.0.0.0/16` |
| `10.0.0.0/33` | `9.255.255.255/33` (silent) | clear error |
| `10.0.0.0/-1` | `512.0.0.0 is not a valid IP Address` | clear error |
| `10.0.0.0` | `NaN.NaN.NaN.NaN is not a valid IP Address` | clear error |
| `10.0.0.0/` | `NaN.NaN.NaN.NaN is not a valid IP Address` | clear error |
| `10.0.0.0/abc` | `NaN.NaN.NaN.NaN is not a valid IP Address` | clear error |

Every row that changes either already failed, or produced a block the service rejects. Nothing that synthesizes today changes behaviour, so **no feature flag is required** under the contributing guidance for validation changes ("input that was accepted by synth but always failed at deploy time → feature flag NOT required; fail-fast synth-time validation is preferred").

I also checked the two other string-CIDR call sites: `IpAddresses.cidr()` (user input) and `ClientVpnEndpoint` (`props.cidr`, plus `props.vpc.vpcCidrBlock` which is already behind a `Token.isUnresolved` guard). And I grepped every CIDR literal in `aws-ec2/test/` — 68 of them — and confirmed none uses a mask the new check rejects, so no existing test changes behaviour.

**On local verification, to be straightforward:** I was not able to run the repo's jest suite — `yarn install` on the monorepo wasn't feasible in my environment, and `git-lfs` isn't installed here either (I cloned with the LFS filter disabled). I verified two ways instead: type-checked the modified test file in isolation against a stubbed `network-util` (clean, with and without jest types), and reproduced the exact before/after arithmetic in a standalone script that mirrors `parseMask`/`calculateNetsize`/`minAddress`/`numToIp` line for line. The "before" column above was also confirmed against published `aws-cdk-lib@2.263.0`. CI will be the first real run of the jest suite.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
