### PR TITLE
fix(stepfunctions): scope grantRead resources to the documented values

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine-grants.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine-grants.ts
@@ -1,6 +1,7 @@
 import * as stepfunctions from './stepfunctions.generated';
 import * as iam from '../../aws-iam';
-import { Arn, ArnFormat, Stack } from '../../core';
+import { Arn, ArnFormat, FeatureFlags, Stack } from '../../core';
+import { STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES } from '../../cx-api';
 
 /**
  * Properties for StateMachineGrants
@@ -60,13 +61,43 @@ export class StateMachineGrants {
    * machine.
    */
   public read(grantee: iam.IGrantable): iam.Grant {
+    const stateMachineArn = stepfunctions.CfnStateMachine.arnForStateMachine(this.resource);
+    const hasCorrectResourceScopes = FeatureFlags.of(this.resource)
+      .isEnabled(STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES);
+
+    if (hasCorrectResourceScopes) {
+      // `states:ListStateMachines` has no resource type, so it only authorizes on '*'.
+      iam.Grant.addToPrincipal({
+        grantee: grantee,
+        actions: ['states:ListStateMachines'],
+        resourceArns: ['*'],
+      });
+      iam.Grant.addToPrincipal({
+        grantee: grantee,
+        actions: [
+          'states:ListExecutions',
+          'states:DescribeStateMachine',
+        ],
+        resourceArns: [stateMachineArn],
+      });
+      return iam.Grant.addToPrincipal({
+        grantee: grantee,
+        actions: [
+          'states:DescribeExecution',
+          'states:DescribeStateMachineForExecution',
+          'states:GetExecutionHistory',
+        ],
+        resourceArns: [this.executionArn() + ':*'],
+      });
+    }
+
     iam.Grant.addToPrincipal({
       grantee: grantee,
       actions: [
         'states:ListExecutions',
         'states:ListStateMachines',
       ],
-      resourceArns: [stepfunctions.CfnStateMachine.arnForStateMachine(this.resource)],
+      resourceArns: [stateMachineArn],
     });
     iam.Grant.addToPrincipal({
       grantee: grantee,

--- a/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine-resources.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine-resources.test.ts
@@ -4,6 +4,7 @@ import { Match, Template } from '../../assertions';
 import type * as cloudwatch from '../../aws-cloudwatch';
 import * as iam from '../../aws-iam';
 import * as cdk from '../../core';
+import { STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES } from '../../cx-api';
 import * as stepfunctions from '../lib';
 
 describe('State Machine Resources', () => {
@@ -412,6 +413,51 @@ describe('State Machine Resources', () => {
       },
     },
     );
+  }),
+
+  test('grantRead scopes DescribeStateMachine to the state machine and ListStateMachines to * when the feature flag is enabled', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    stack.node.setContext(STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES, true);
+    const task = new FakeTask(stack, 'Task');
+    const stateMachine = new stepfunctions.StateMachine(stack, 'StateMachine', {
+      definitionBody: stepfunctions.DefinitionBody.fromChainable(task),
+    });
+    const role = new iam.Role(stack, 'Role', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    // WHEN
+    stateMachine.grantRead(role);
+
+    // THEN
+    const statements = Template.fromStack(stack)
+      .findResources('AWS::IAM::Policy').RoleDefaultPolicy5FFB7DAB.Properties.PolicyDocument.Statement;
+
+    // `states:ListStateMachines` has no resource type, so it only authorizes on '*'
+    expect(statements).toContainEqual(expect.objectContaining({
+      Action: 'states:ListStateMachines',
+      Effect: 'Allow',
+      Resource: '*',
+    }));
+
+    // `states:DescribeStateMachine` supports a statemachine ARN, so it is no longer granted account-wide
+    expect(statements).toContainEqual(expect.objectContaining({
+      Action: ['states:ListExecutions', 'states:DescribeStateMachine'],
+      Effect: 'Allow',
+      Resource: { Ref: 'StateMachine2E01A3A5' },
+    }));
+
+    // no statement grants anything on '*' other than ListStateMachines
+    const wildcardActions = statements
+      .filter((s: any) => s.Resource === '*')
+      .flatMap((s: any) => [].concat(s.Action));
+    expect(wildcardActions).toEqual(['states:ListStateMachines']);
+
+    // activity actions are not granted by a state machine read grant at all
+    const allActions = statements.flatMap((s: any) => [].concat(s.Action));
+    expect(allActions).not.toContain('states:ListActivities');
+    expect(allActions).not.toContain('states:DescribeActivity');
   }),
 
   test('Created state machine can grant task response actions to the state machine', () => {

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -118,6 +118,7 @@ Flags come in three types:
 | [@aws-cdk/core:defaultCrossStackReferences](#aws-cdkcoredefaultcrossstackreferences) | Controls whether cross-region stack references are strong, weak, or both | 2.254.0 | config |
 | [@aws-cdk/aws-eks:defaultToAL2023](#aws-cdkaws-eksdefaulttoal2023) | Use AL2023 as the default AMI type for EKS managed node groups using non-GPU instance types instead of the deprecated AL2 | 2.259.0 | new default |
 | [@aws-cdk/core:validateAgainstDefaultRules](#aws-cdkcorevalidateagainstdefaultrules) | Treat CloudFormation Validate findings as errors | 2.262.0 | config |
+| [@aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes](#aws-cdkaws-stepfunctionsgrantreadcorrectresourcescopes) | Scope the resources granted by StateMachine.grantRead() to the documented values | V2NEXT | fix |
 
 <!-- END table -->
 
@@ -199,6 +200,7 @@ The following json shows the current recommended set of flags, as `cdk init` wou
     "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
     "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
     "@aws-cdk/aws-stepfunctions-tasks:fixRunEcsTaskPolicy": true,
+    "@aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes": true,
     "@aws-cdk/aws-stepfunctions:useDistributedMapResultWriterV2": true,
     "@aws-cdk/core:annotationsInValidationReport": true,
     "@aws-cdk/core:aspectPrioritiesMutating": true,
@@ -2551,6 +2553,38 @@ fail synthesis. When unconfigured, violations are reported as warnings only.
 | ----- | ----- | ----- |
 | (not in v1) |  |  |
 | 2.262.0 | `false` | `true` |
+
+
+### @aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes
+
+*Scope the resources granted by StateMachine.grantRead() to the documented values*
+
+Flag type: Backwards incompatible bugfix
+
+`StateMachine.grantRead()` scopes two actions to the opposite of what AWS
+documents in the Service Authorization Reference:
+
+- `states:DescribeStateMachine` supports a `statemachine` resource ARN, but is
+  granted on `*`. A grantee therefore reads the definition of *every* state
+  machine in the account, not just the one that was granted.
+- `states:ListStateMachines` has no resource type, so it must be granted on `*`.
+  It is scoped to the state machine ARN instead, where it never authorizes.
+
+When this flag is enabled, `states:DescribeStateMachine` is scoped to the state
+machine's ARN and `states:ListStateMachines` is granted on `*`. The activity
+actions `states:ListActivities` and `states:DescribeActivity` are no longer
+granted at all, since a state machine grant should not confer access to
+activities.
+
+When disabled, the previous permissions are emitted unchanged. This flag exists
+because enabling it narrows permissions, which can break a grantee that has come
+to depend on the broader `*` scope.
+
+
+| Since | Unset behaves like | Recommended value |
+| ----- | ----- | ----- |
+| (not in v1) |  |  |
+| V2NEXT | `false` | `true` |
 
 
 <!-- END details -->

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -158,6 +158,7 @@ export const EKS_DEFAULT_AL2023 = '@aws-cdk/aws-eks:defaultToAL2023';
 export const ANNOTATIONS_IN_VALIDATION_REPORT = '@aws-cdk/core:annotationsInValidationReport';
 export const DEFAULT_CROSS_STACK_REFERENCES = '@aws-cdk/core:defaultCrossStackReferences';
 export const VALIDATE_AGAINST_DEFAULT_RULES = '@aws-cdk/core:validateAgainstDefaultRules';
+export const STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES = '@aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1929,6 +1930,34 @@ export const FLAGS: Record<string, FlagInfo> = {
       When this flag is explicitly set to \`true\`, violations are treated as errors and will
       fail synthesis. When unconfigured, violations are reported as warnings only.`,
     introducedIn: { v2: '2.262.0' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES]: {
+    type: FlagType.BugFix,
+    summary: 'Scope the resources granted by StateMachine.grantRead() to the documented values',
+    detailsMd: `
+      \`StateMachine.grantRead()\` scopes two actions to the opposite of what AWS
+      documents in the Service Authorization Reference:
+
+      - \`states:DescribeStateMachine\` supports a \`statemachine\` resource ARN, but is
+        granted on \`*\`. A grantee therefore reads the definition of *every* state
+        machine in the account, not just the one that was granted.
+      - \`states:ListStateMachines\` has no resource type, so it must be granted on \`*\`.
+        It is scoped to the state machine ARN instead, where it never authorizes.
+
+      When this flag is enabled, \`states:DescribeStateMachine\` is scoped to the state
+      machine's ARN and \`states:ListStateMachines\` is granted on \`*\`. The activity
+      actions \`states:ListActivities\` and \`states:DescribeActivity\` are no longer
+      granted at all, since a state machine grant should not confer access to
+      activities.
+
+      When disabled, the previous permissions are emitted unchanged. This flag exists
+      because enabling it narrows permissions, which can break a grantee that has come
+      to depend on the broader \`*\` scope.`,
+    introducedIn: { v2: 'V2NEXT' },
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: false },
   },

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -52,6 +52,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.EKS_DEFAULT_AL2023]: false,
     [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
     [feats.VALIDATE_AGAINST_DEFAULT_RULES]: false,
+    [feats.STEPFUNCTIONS_GRANT_READ_CORRECT_RESOURCE_SCOPES]: false,
 
   });
 });

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -87,5 +87,6 @@
   "@aws-cdk/aws-eks:defaultToAL2023": true,
   "@aws-cdk/core:annotationsInValidationReport": true,
   "@aws-cdk/core:defaultCrossStackReferences": "weak",
-  "@aws-cdk/core:validateAgainstDefaultRules": true
+  "@aws-cdk/core:validateAgainstDefaultRules": true,
+  "@aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes": true
 }


### PR DESCRIPTION
### Issue # (if applicable)

fixes #25561

### Reason for this change

`StateMachine.grantRead()` scopes two actions to the opposite of what the [Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsstepfunctions.html) documents:

| action | AWS documents | CDK emits | consequence |
|---|---|---|---|
| `states:DescribeStateMachine` | supports a `statemachine` resource ARN | granted on `*` | grantee can describe **every state machine in the account** |
| `states:ListStateMachines` | no resource type — only authorizes on `*` | scoped to the state machine ARN | the grant **never authorizes** |

The security half is the one that matters: `DescribeStateMachine` returns the state machine's definition, so granting read on a *single* state machine lets the grantee read the ASL definition of *every* state machine in the account — including resource ARNs and whatever teams have inlined into their definitions.

The other half is a plain functional bug: `ListStateMachines` scoped to an ARN silently does nothing, because [AWS documents](https://docs.aws.amazon.com/step-functions/latest/dg/concept-create-iam-advanced.html) that actions with no resource type must be granted on `*`.

The grant additionally confers `states:ListActivities` and `states:DescribeActivity` on `*`. A *state machine's* read grant should not confer access to activities, which are a separate resource type.

This is the current output, straight from a synthesized template:

```
scoped to ARN      <- states:ListExecutions, states:ListStateMachines
scoped to ARN      <- states:DescribeExecution, states:DescribeStateMachineForExecution, states:GetExecutionHistory
ALL RESOURCES (*)  <- states:ListActivities, states:DescribeStateMachine, states:DescribeActivity
```

### Description of changes

Corrected the scopes, gated behind a new feature flag `@aws-cdk/aws-stepfunctions:grantReadCorrectResourceScopes` (`FlagType.BugFix`, `introducedIn: { v2: 'V2NEXT' }`, `recommendedValue: true`, `unconfiguredBehavesLike: { v2: false }`).

The flag is required because this **narrows** an existing permission. A grantee that has come to depend on the account-wide `*` scope would lose access, so existing apps must keep the old behaviour until they opt in.

With the flag enabled:

```
ALL RESOURCES (*)  <- states:ListStateMachines
scoped to ARN      <- states:ListExecutions, states:DescribeStateMachine
scoped to ARN      <- states:DescribeExecution, states:DescribeStateMachineForExecution, states:GetExecutionHistory
```

`ListActivities` / `DescribeActivity` are no longer granted at all, and the only `*` left is the one AWS requires.

### Describe any new or updated permissions being added

This PR only **reduces** permissions, and only when the flag is enabled:

- `states:DescribeStateMachine` moves from `*` to the state machine's ARN
- `states:ListActivities` and `states:DescribeActivity` are no longer granted
- `states:ListStateMachines` moves from an ARN to `*` — this is a *widening* in form, but the ARN-scoped version never authorized anything, so it grants no capability that previously worked

### Description of how you validated changes

Unit tests in `aws-stepfunctions/test/state-machine-resources.test.ts`. The flag-enabled test asserts positively (`ListStateMachines` on `*`, `DescribeStateMachine` on the ARN) and negatively — that the *only* wildcard action is `ListStateMachines`, and that no activity action is granted at all, so the assertion can't silently pass if something regresses.

Backwards compatibility is covered by the **pre-existing** test `Created state machine can grant read access to a role`, which asserts the old statements verbatim and is unmodified by this PR. It still passes, which is the evidence that the default path is byte-identical.

```
aws-stepfunctions   Test Suites: 81 passed, 81 total   Tests: 964 passed, 964 total
cx-api              Test Suites:  1 passed,  1 total   Tests: 122 passed, 122 total
```

I also verified end-to-end against a locally built `aws-cdk-lib`, synthesizing both flag states and printing the resulting policy statements — the two blocks quoted above are that output, not hand-written.

`FEATURE_FLAGS.md` and `recommended-feature-flags.json` are regenerated by the build from the flag definition and included in the commit.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
