### PR TITLE
fix(ses): `DedicatedIpPool` rejects a tokenized pool name

### DIFF
--- a/packages/aws-cdk-lib/aws-ses/lib/dedicated-ip-pool.ts
+++ b/packages/aws-cdk-lib/aws-ses/lib/dedicated-ip-pool.ts
@@ -1,7 +1,7 @@
 import type { Construct } from 'constructs';
 import { CfnDedicatedIpPool } from './ses.generated';
 import type { IResource } from '../../core';
-import { Resource, ValidationError } from '../../core';
+import { Resource, Token, ValidationError } from '../../core';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
@@ -101,7 +101,11 @@ export class DedicatedIpPool extends Resource implements IDedicatedIpPool {
     // Enhanced CDK Analytics Telemetry
     addConstructMetadata(this, props);
 
-    if (props.dedicatedIpPoolName && !/^[a-z0-9_-]{0,64}$/.test(props.dedicatedIpPoolName)) {
+    // Only checkable when the name is known at synthesis time. A tokenized name
+    // (Fn::ImportValue, a CfnParameter, another resource's attribute) is a placeholder
+    // like "${Token[TOKEN.123]}" here, which no valid-name pattern can match.
+    if (props.dedicatedIpPoolName && !Token.isUnresolved(props.dedicatedIpPoolName) &&
+        !/^[a-z0-9_-]{0,64}$/.test(props.dedicatedIpPoolName)) {
       throw new ValidationError(lit`InvalidDedicatedIpPoolName`, `Invalid dedicatedIpPoolName "${props.dedicatedIpPoolName}". The name must only include lowercase letters, numbers, underscores, hyphens, and must not exceed 64 characters.`, this);
     }
 

--- a/packages/aws-cdk-lib/aws-ses/test/dedicated-ip-pool.test.ts
+++ b/packages/aws-cdk-lib/aws-ses/test/dedicated-ip-pool.test.ts
@@ -1,5 +1,5 @@
 import { Template, Match } from '../../assertions';
-import { Stack } from '../../core';
+import { CfnParameter, Fn, Stack } from '../../core';
 import { DedicatedIpPool, ScalingMode } from '../lib';
 
 let stack: Stack;
@@ -33,4 +33,31 @@ test('dedicated IP pool with invalid name', () => {
   expect(() => new DedicatedIpPool(stack, 'Pool', {
     dedicatedIpPoolName: 'invalidName',
   })).toThrow('Invalid dedicatedIpPoolName "invalidName". The name must only include lowercase letters, numbers, underscores, hyphens, and must not exceed 64 characters.');
+});
+
+test('dedicated IP pool name from Fn::ImportValue', () => {
+  // WHEN
+  new DedicatedIpPool(stack, 'Pool', {
+    dedicatedIpPoolName: Fn.importValue('SharedPoolName'),
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::SES::DedicatedIpPool', {
+    PoolName: { 'Fn::ImportValue': 'SharedPoolName' },
+  });
+});
+
+test('dedicated IP pool name from a CfnParameter', () => {
+  // GIVEN
+  const poolName = new CfnParameter(stack, 'PoolName', { type: 'String' });
+
+  // WHEN
+  new DedicatedIpPool(stack, 'Pool', {
+    dedicatedIpPoolName: poolName.valueAsString,
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::SES::DedicatedIpPool', {
+    PoolName: { Ref: 'PoolName' },
+  });
 });


### PR DESCRIPTION
### Issue # (if applicable)

fixes #38536

### Reason for this change

`DedicatedIpPool` validated `dedicatedIpPoolName` with a regex without first checking `Token.isUnresolved()`. A name that comes from `Fn.importValue()`, a `CfnParameter`, or another resource's attribute is still an unresolved token at construction time and renders as `${Token[TOKEN.123]}`, which cannot match `/^[a-z0-9_-]{0,64}$/`. Synthesis therefore threw for values that CloudFormation would have resolved to a perfectly valid pool name:

```
Invalid dedicatedIpPoolName "${Token[TOKEN.1222]}". The name must only include lowercase
letters, numbers, underscores, hyphens, and must not exceed 64 characters.
```

The message printing the token placeholder is the tell — the check was inspecting a placeholder, not a name. There was no workaround short of hardcoding the name.

`AGENTS.md` § Token Safety calls out this exact requirement:

> Check `Token.isUnresolved()` before any validation on tokenized values

### Description of changes

Guarded the name check with `Token.isUnresolved()`:

```ts
if (props.dedicatedIpPoolName && !Token.isUnresolved(props.dedicatedIpPoolName) &&
    !/^[a-z0-9_-]{0,64}$/.test(props.dedicatedIpPoolName)) {
  throw new ValidationError(...);
}
```

Literal names are validated exactly as before. Only values that could never have been checked correctly now skip the check.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added two unit tests to `aws-ses/test/dedicated-ip-pool.test.ts` covering a name from `Fn.importValue` and from a `CfnParameter`, asserting the token reaches the template:

```ts
Template.fromStack(stack).hasResourceProperties('AWS::SES::DedicatedIpPool', {
  PoolName: { 'Fn::ImportValue': 'SharedPoolName' },
});
```

Both fail on `main` with `InvalidDedicatedIpPoolName` and pass with this change. The existing `dedicated IP pool with invalid name` test is untouched and still passes, so validation of literal names is unchanged.

```
npx jest aws-ses/test/dedicated-ip-pool.test.ts
  ✓ default dedicated IP pool
  ✓ dedicated IP pool with scailingMode
  ✓ dedicated IP pool with invalid name
  ✓ dedicated IP pool name from Fn::ImportValue
  ✓ dedicated IP pool name from a CfnParameter
Tests: 5 passed, 5 total
```

Full module suite: `npx jest aws-ses/test` → **8 suites, 57 tests, all passing.**

No integration test or snapshot update is included: this changes only synth-time validation, not any synthesized resource for existing (literal-name) usage, so no existing snapshot changes.

### Backwards compatibility

This only *removes* a throw for input that previously could not synthesize at all. No app that synthesizes today changes behavior, so no feature flag is required.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
