### PR TITLE
fix(core): scope validation plugin acknowledgments (under feature flag)

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/collect-acknowledged-rule-ids.ts
+++ b/packages/aws-cdk-lib/core/lib/private/collect-acknowledged-rule-ids.ts
@@ -9,19 +9,21 @@ export interface AcknowledgedRule {
 
 /**
  * Collect all acknowledged rule IDs from construct metadata across the tree.
- * Returns a map from rule ID to acknowledgement details (reason, construct path, and stack trace).
+ * Returns a map from rule ID to all acknowledgement details (reason, construct path, and stack trace).
  */
-export function collectAcknowledgedRuleIds(root: IConstruct): Map<string, AcknowledgedRule> {
-  const rules = new Map<string, AcknowledgedRule>();
+export function collectAcknowledgedRuleIds(root: IConstruct): Map<string, AcknowledgedRule[]> {
+  const rules = new Map<string, AcknowledgedRule[]>();
   for (const construct of iterateDfsPreorder(root)) {
     for (const entry of construct.node.metadata) {
       if (entry.type === 'aws:cdk:acknowledged-rules' && entry.data) {
         for (const [id, reason] of Object.entries(entry.data as Record<string, string>)) {
-          rules.set(id, {
+          const acknowledgements = rules.get(id) ?? [];
+          acknowledgements.push({
             reason,
             constructPath: construct.node.path,
             stackTrace: entry.trace?.join('\n'),
           });
+          rules.set(id, acknowledgements);
         }
       }
     }

--- a/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import type * as private_cxapi from '@aws-cdk/cloud-assembly-api';
 import type { IConstruct } from 'constructs';
 import { AnnotationPlugin, collectAnnotationReport } from './annotation-plugin';
+import type { AcknowledgedRule } from './collect-acknowledged-rule-ids';
 import { collectAcknowledgedRuleIds } from './collect-acknowledged-rule-ids';
 import { lit } from './literal-string';
 import * as cxapi from '../../../cx-api';
@@ -13,7 +14,13 @@ import { _aspectTreeRevisionReader } from '../aspect';
 import { AssumptionError, UnscopedValidationError } from '../errors';
 import { FeatureFlags } from '../feature-flags';
 import type { Stage } from '../stage';
-import type { IPolicyValidationPlugin, PolicyValidationPluginReport, PolicyValidationStack } from '../validation';
+import type {
+  IPolicyValidationPlugin,
+  PolicyValidationPluginReport,
+  PolicyValidationStack,
+  PolicyViolation,
+  PolicyViolatingResource,
+} from '../validation';
 import { STAGE_TYPE } from './core-construct-finders';
 import { profileSpan } from './perf';
 import { CloudFormationValidatePlugin } from '../validation/cloudformation-validate-plugin';
@@ -63,9 +70,10 @@ export function validateTemplates(root: IConstruct, outdir: string, assembly: pr
     warningifiedAnyErrors = downgradeCfnValidateErrorsToWarnings(reports);
   }
 
-  const suppressedByReport: Map<number, SuppressedViolation[]> = collectSuppressions(root, reports);
+  const constructTree = new ConstructTree(root);
+  const suppressedByReport: Map<number, SuppressedViolation[]> = collectSuppressions(root, reports, constructTree);
 
-  const formatter = new PolicyValidationReportFormatter(new ConstructTree(root));
+  const formatter = new PolicyValidationReportFormatter(constructTree);
   const reportJson = formatter.formatJson(reports, assembly.version, suppressedByReport);
 
   // Always write validation report to disk
@@ -264,9 +272,10 @@ function downgradeCfnValidateErrorsToWarnings(reports: NamedValidationPluginRepo
  * spaces replaced by dashes. Users suppress with:
  *   Validations.of(x).acknowledge({ id: '<plugin-name>::<rule-id>' })
  */
-function collectSuppressions(root: App, reports: NamedValidationPluginReport[]) {
+function collectSuppressions(root: App, reports: NamedValidationPluginReport[], constructTree: ConstructTree) {
   const suppressedByReport: Map<number, SuppressedViolation[]> = new Map();
   const acknowledgedRules = collectAcknowledgedRuleIds(root);
+  const isScopedAcknowledgementEnabled = FeatureFlags.of(root).isEnabled(cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS);
 
   if (acknowledgedRules.size > 0) {
     for (let i = 0; i < reports.length; i++) {
@@ -294,7 +303,9 @@ function collectSuppressions(root: App, reports: NamedValidationPluginReport[]) 
           ackIds.push(`${pluginName}::${v.ruleName}`);
         }
 
-        const ack = firstThat(ackIds.map(hyphenify), id => acknowledgedRules.get(id));
+        const ack = isScopedAcknowledgementEnabled
+          ? findScopedAcknowledgement(ackIds.map(hyphenify), v, acknowledgedRules, constructTree, root.node.path)
+          : firstThat(ackIds.map(hyphenify), id => last(acknowledgedRules.get(id)));
 
         if (ack) {
           suppressed.push({
@@ -319,6 +330,66 @@ function collectSuppressions(root: App, reports: NamedValidationPluginReport[]) 
     }
   }
   return suppressedByReport;
+}
+
+function findScopedAcknowledgement(
+  acknowledgementIds: string[],
+  violation: PolicyViolation,
+  acknowledgedRules: Map<string, AcknowledgedRule[]>,
+  constructTree: ConstructTree,
+  rootPath: string,
+): { key: string; value: AcknowledgedRule } | undefined {
+  for (const id of acknowledgementIds) {
+    const acknowledgements = acknowledgedRules.get(id) ?? [];
+    for (let i = acknowledgements.length - 1; i >= 0; i--) {
+      const acknowledgement = acknowledgements[i];
+      if (violationIsWithinScope(violation, acknowledgement.constructPath, constructTree, rootPath)) {
+        return { key: id, value: acknowledgement };
+      }
+    }
+  }
+  return undefined;
+}
+
+function violationIsWithinScope(
+  violation: PolicyViolation,
+  acknowledgementPath: string,
+  constructTree: ConstructTree,
+  rootPath: string,
+): boolean {
+  if (acknowledgementPath === rootPath) {
+    return true;
+  }
+  if (violation.violatingResources.length === 0) {
+    return false;
+  }
+  // A violation can group multiple resources. Do not hide the finding unless
+  // one acknowledgement scope covers every resource involved.
+  return violation.violatingResources.every(resource => {
+    const constructPath = violatingConstructPath(resource, constructTree);
+    return constructPath !== undefined && isEqualOrDescendant(constructPath, acknowledgementPath);
+  });
+}
+
+function violatingConstructPath(resource: PolicyViolatingResource, constructTree: ConstructTree): string | undefined {
+  if (resource.constructPath !== undefined) {
+    return resource.constructPath.replace(/^\//, '');
+  }
+  if (resource.templatePath && resource.resourceLogicalId) {
+    return constructTree.getConstructByLogicalId(
+      path.basename(resource.templatePath),
+      resource.resourceLogicalId,
+    )?.node.path;
+  }
+  return undefined;
+}
+
+function isEqualOrDescendant(constructPath: string, scopePath: string): boolean {
+  return constructPath === scopePath || constructPath.startsWith(`${scopePath}/`);
+}
+
+function last<A>(xs: A[] | undefined): A | undefined {
+  return xs?.[xs.length - 1];
 }
 
 /**

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -1160,6 +1160,315 @@ describe('validations', () => {
       expect(output).not.toContain('S3_BUCKET_VERSIONING_ENABLED');
     });
 
+    test('plugin violation acknowledgments only apply to the acknowledged construct scope', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stackA = new core.Stack(app, 'StackA');
+      const resourceA = new core.CfnResource(stackA, 'Resource', {
+        type: 'AWS::S3::Bucket',
+      });
+      const stackB = new core.Stack(app, 'StackB');
+      const resourceB = new core.CfnResource(stackB, 'Resource', {
+        type: 'AWS::S3::Bucket',
+      });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [
+          {
+            description: 'S3 Bucket should have versioning enabled',
+            ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+            severity: 'error',
+            violatingResources: [{
+              locations: ['Properties/VersioningConfiguration'],
+              resourceLogicalId: stackA.getLogicalId(resourceA),
+              templatePath: 'StackA.template.json',
+            }],
+          },
+          {
+            description: 'S3 Bucket should have versioning enabled',
+            ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+            severity: 'error',
+            violatingResources: [{
+              locations: ['Properties/VersioningConfiguration'],
+              resourceLogicalId: stackB.getLogicalId(resourceB),
+              templatePath: 'StackB.template.json',
+            }],
+          },
+        ]),
+      );
+
+      core.Validations.of(resourceA).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for StackA only',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(1);
+      expect(report.pluginReports[0].violations[0].violatingConstructs[0].constructPath).toEqual('StackB/Resource');
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+      expect(report.pluginReports[0].suppressedViolations[0]).toEqual(expect.objectContaining({
+        acknowledgedAt: 'StackA/Resource',
+      }));
+    });
+
+    test('unconfigured scoped acknowledgments preserve app-wide rule suppression', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stackA = new core.Stack(app, 'StackA');
+      const resourceA = new core.CfnResource(stackA, 'Resource', {
+        type: 'AWS::S3::Bucket',
+      });
+      const stackB = new core.Stack(app, 'StackB');
+      const resourceB = new core.CfnResource(stackB, 'Resource', {
+        type: 'AWS::S3::Bucket',
+      });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [{
+          description: 'S3 Bucket should have versioning enabled',
+          ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+          severity: 'error',
+          violatingResources: [{
+            locations: ['Properties/VersioningConfiguration'],
+            resourceLogicalId: stackB.getLogicalId(resourceB),
+            templatePath: 'StackB.template.json',
+          }],
+        }]),
+      );
+
+      core.Validations.of(resourceA).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Legacy app-wide suppression',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(0);
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+      expect(report.pluginReports[0].suppressedViolations[0]).toEqual(expect.objectContaining({
+        acknowledgedAt: 'StackA/Resource',
+      }));
+    });
+
+    test('stack acknowledgment applies to descendants but not unrelated stacks', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stackA = new core.Stack(app, 'StackA');
+      const resourceA1 = new core.CfnResource(stackA, 'ResourceA1', { type: 'AWS::S3::Bucket' });
+      const resourceA2 = new core.CfnResource(stackA, 'ResourceA2', { type: 'AWS::S3::Bucket' });
+      const stackB = new core.Stack(app, 'StackB');
+      const resourceB = new core.CfnResource(stackB, 'ResourceB', { type: 'AWS::S3::Bucket' });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [
+          policyViolation(stackA.getLogicalId(resourceA1), 'StackA.template.json'),
+          policyViolation(stackA.getLogicalId(resourceA2), 'StackA.template.json'),
+          policyViolation(stackB.getLogicalId(resourceB), 'StackB.template.json'),
+        ]),
+      );
+      core.Validations.of(stackA).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for StackA',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(1);
+      expect(report.pluginReports[0].violations[0].violatingConstructs[0].constructPath).toEqual('StackB/ResourceB');
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(2);
+      expect(report.pluginReports[0].suppressedViolations).toEqual(expect.arrayContaining([
+        expect.objectContaining({ acknowledgedAt: 'StackA' }),
+      ]));
+    });
+
+    test('multiple acknowledgments for the same rule retain every scope', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stackA = new core.Stack(app, 'StackA');
+      const resourceA = new core.CfnResource(stackA, 'Resource', { type: 'AWS::S3::Bucket' });
+      const stackB = new core.Stack(app, 'StackB');
+      const resourceB = new core.CfnResource(stackB, 'Resource', { type: 'AWS::S3::Bucket' });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [
+          policyViolation(stackA.getLogicalId(resourceA), 'StackA.template.json'),
+          policyViolation(stackB.getLogicalId(resourceB), 'StackB.template.json'),
+        ]),
+      );
+      core.Validations.of(resourceA).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for StackA',
+      });
+      core.Validations.of(resourceB).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for StackB',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(0);
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(2);
+      expect(report.pluginReports[0].suppressedViolations
+        .map((violation: any) => violation.acknowledgedAt)
+        .sort()).toEqual(['StackA/Resource', 'StackB/Resource']);
+    });
+
+    test('partially acknowledged multi-resource violations remain active', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stackA = new core.Stack(app, 'StackA');
+      const resourceA = new core.CfnResource(stackA, 'Resource', { type: 'AWS::S3::Bucket' });
+      const stackB = new core.Stack(app, 'StackB');
+      const resourceB = new core.CfnResource(stackB, 'Resource', { type: 'AWS::S3::Bucket' });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [{
+          description: 'Related resources violate the rule',
+          ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+          severity: 'error',
+          violatingResources: [
+            {
+              locations: [],
+              resourceLogicalId: stackA.getLogicalId(resourceA),
+              templatePath: 'StackA.template.json',
+            },
+            {
+              locations: [],
+              resourceLogicalId: stackB.getLogicalId(resourceB),
+              templatePath: 'StackB.template.json',
+            },
+          ],
+        }]),
+      );
+      core.Validations.of(stackA).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for StackA',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(1);
+      expect(report.pluginReports[0].violations[0].violatingConstructs).toHaveLength(2);
+      expect(report.pluginReports[0].suppressedViolations).toBeUndefined();
+    });
+
+    test('construct path matching respects path segment boundaries', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stack = new core.Stack(app, 'Stack');
+      const resource = new Construct(stack, 'Resource');
+      new Construct(stack, 'ResourceSibling');
+
+      core.Validations.of(app).addPlugins(
+        new FakeNonBeta1Plugin('test-plugin', [
+          constructPolicyViolation('Stack/Resource'),
+          constructPolicyViolation('Stack/ResourceSibling'),
+        ]),
+      );
+      core.Validations.of(resource).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for Resource',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(1);
+      expect(report.pluginReports[0].violations[0].violatingConstructs[0].constructPath).toEqual('Stack/ResourceSibling');
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+    });
+
+    test('app acknowledgment suppresses violations whose resource cannot be resolved', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      new core.Stack(app);
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [policyViolation('UnknownResource', 'Default.template.json')]),
+      );
+      core.Validations.of(app).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for the app',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(0);
+      expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+    });
+
+    test('construct-scoped acknowledgments do not suppress violations without a construct path', () => {
+      const app = new NonStrictApp({
+        context: {
+          ...annotationReportContext,
+          [cxapi.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: true,
+          '@aws-cdk/core:failSynthOnValidationErrors': false,
+        },
+      });
+      const stack = new core.Stack(app);
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('test-plugin', [
+          policyViolation('UnknownResource', 'Default.template.json'),
+          {
+            description: 'Violation without resources',
+            ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+            severity: 'error',
+            violatingResources: [],
+          },
+        ]),
+      );
+      core.Validations.of(stack).acknowledge({
+        id: 'test-plugin::S3_BUCKET_VERSIONING_ENABLED',
+        reason: 'Accepted for this stack',
+      });
+
+      redactAsmDir(app.synth());
+
+      const report = loadJson(path.join(app.outdir, 'validation-report.json'));
+      expect(report.pluginReports[0].violations).toHaveLength(2);
+      expect(report.pluginReports[0].suppressedViolations).toBeUndefined();
+    });
+
     test('suppressed violations appear in validation-report.json', () => {
       const app = new NonStrictApp({
         context: {
@@ -1586,6 +1895,31 @@ describe('validations', () => {
     });
   });
 });
+
+function policyViolation(resourceLogicalId: string, templatePath: string): core.PolicyViolationBeta1 {
+  return {
+    description: 'S3 Bucket should have versioning enabled',
+    ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+    severity: 'error',
+    violatingResources: [{
+      locations: ['Properties/VersioningConfiguration'],
+      resourceLogicalId,
+      templatePath,
+    }],
+  };
+}
+
+function constructPolicyViolation(constructPath: string): core.PolicyViolation {
+  return {
+    description: 'S3 Bucket should have versioning enabled',
+    ruleName: 'S3_BUCKET_VERSIONING_ENABLED',
+    severity: 'error',
+    violatingResources: [{
+      constructPath,
+      locations: [],
+    }],
+  };
+}
 
 class FakePlugin implements core.IPolicyValidationPluginBeta1 {
   constructor(

--- a/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
+++ b/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md
@@ -118,6 +118,7 @@ Flags come in three types:
 | [@aws-cdk/core:defaultCrossStackReferences](#aws-cdkcoredefaultcrossstackreferences) | Controls whether cross-stack references are strong, weak, or both | 2.254.0 | config |
 | [@aws-cdk/aws-eks:defaultToAL2023](#aws-cdkaws-eksdefaulttoal2023) | Use AL2023 as the default AMI type for EKS managed node groups using non-GPU instance types instead of the deprecated AL2 | 2.259.0 | new default |
 | [@aws-cdk/core:validateAgainstDefaultRules](#aws-cdkcorevalidateagainstdefaultrules) | Treat CloudFormation Validate findings as errors | 2.262.0 | config |
+| [@aws-cdk/core:scopedValidationPluginAcknowledgments](#aws-cdkcorescopedvalidationpluginacknowledgments) | Scope validation plugin acknowledgments to the construct where they are declared | V2NEXT | fix |
 
 <!-- END table -->
 
@@ -209,6 +210,7 @@ The following json shows the current recommended set of flags, as `cdk init` wou
     "@aws-cdk/core:enablePartitionLiterals": true,
     "@aws-cdk/core:explicitStackTags": true,
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/core:scopedValidationPluginAcknowledgments": true,
     "@aws-cdk/core:target-partitions": [
       "aws",
       "aws-cn"
@@ -2549,6 +2551,27 @@ fail synthesis. When unconfigured, violations are reported as warnings only.
 | ----- | ----- | ----- |
 | (not in v1) |  |  |
 | 2.262.0 | `false` | `true` |
+
+
+### @aws-cdk/core:scopedValidationPluginAcknowledgments
+
+*Scope validation plugin acknowledgments to the construct where they are declared*
+
+Flag type: Backwards incompatible bugfix
+
+When enabled, validation plugin violations are suppressed only when every violating resource
+is the acknowledged construct or one of its descendants. Acknowledging a rule on one construct
+no longer suppresses violations of the same rule on unrelated constructs or stacks.
+
+When disabled, acknowledgments continue to suppress matching rule IDs across the entire app.
+
+
+| Since | Unset behaves like | Recommended value |
+| ----- | ----- | ----- |
+| (not in v1) |  |  |
+| V2NEXT | `false` | `true` |
+
+**Compatibility with old behavior:** Disable this feature flag to suppress validation plugin violations by rule ID across the entire app.
 
 
 <!-- END details -->

--- a/packages/aws-cdk-lib/cx-api/README.md
+++ b/packages/aws-cdk-lib/cx-api/README.md
@@ -794,3 +794,21 @@ _cdk.json_
   }
 }
 ```
+
+* `@aws-cdk/core:scopedValidationPluginAcknowledgments`
+
+When enabled, validation plugin acknowledgments only suppress violations when every violating resource is the
+acknowledged construct or one of its descendants. Acknowledging a rule on one construct no longer suppresses
+violations of the same rule on unrelated constructs or stacks.
+
+When disabled, acknowledgments suppress matching rule IDs across the entire app to preserve the previous behavior.
+
+_cdk.json_
+
+```json
+{
+  "context": {
+    "@aws-cdk/core:scopedValidationPluginAcknowledgments": true
+  }
+}
+```

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -158,6 +158,7 @@ export const EKS_DEFAULT_AL2023 = '@aws-cdk/aws-eks:defaultToAL2023';
 export const ANNOTATIONS_IN_VALIDATION_REPORT = '@aws-cdk/core:annotationsInValidationReport';
 export const DEFAULT_CROSS_STACK_REFERENCES = '@aws-cdk/core:defaultCrossStackReferences';
 export const VALIDATE_AGAINST_DEFAULT_RULES = '@aws-cdk/core:validateAgainstDefaultRules';
+export const SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS = '@aws-cdk/core:scopedValidationPluginAcknowledgments';
 
 export const FLAGS: Record<string, FlagInfo> = {
   //////////////////////////////////////////////////////////////////////
@@ -1929,6 +1930,22 @@ export const FLAGS: Record<string, FlagInfo> = {
     introducedIn: { v2: '2.262.0' },
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: false },
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: {
+    type: FlagType.BugFix,
+    summary: 'Scope validation plugin acknowledgments to the construct where they are declared',
+    detailsMd: `
+      When enabled, validation plugin violations are suppressed only when every violating resource
+      is the acknowledged construct or one of its descendants. Acknowledging a rule on one construct
+      no longer suppresses violations of the same rule on unrelated constructs or stacks.
+
+      When disabled, acknowledgments continue to suppress matching rule IDs across the entire app.`,
+    introducedIn: { v2: 'V2NEXT' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
+    compatibilityWithOldBehaviorMd: 'Disable this feature flag to suppress validation plugin violations by rule ID across the entire app.',
   },
 };
 

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -52,6 +52,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.EKS_DEFAULT_AL2023]: false,
     [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
     [feats.VALIDATE_AGAINST_DEFAULT_RULES]: false,
+    [feats.SCOPED_VALIDATION_PLUGIN_ACKNOWLEDGMENTS]: false,
 
   });
 });

--- a/packages/aws-cdk-lib/recommended-feature-flags.json
+++ b/packages/aws-cdk-lib/recommended-feature-flags.json
@@ -87,5 +87,6 @@
   "@aws-cdk/aws-eks:defaultToAL2023": true,
   "@aws-cdk/core:annotationsInValidationReport": true,
   "@aws-cdk/core:defaultCrossStackReferences": "weak",
-  "@aws-cdk/core:validateAgainstDefaultRules": true
+  "@aws-cdk/core:validateAgainstDefaultRules": true,
+  "@aws-cdk/core:scopedValidationPluginAcknowledgments": true
 }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38495.

### Reason for this change

`Validations.of(scope).acknowledge()` records the construct where an acknowledgment is declared, but plugin violations were suppressed by rule ID alone. As a result, acknowledging a rule on one construct could also hide findings for unrelated constructs or stacks.

Acknowledgments for the same rule were also stored as a single map entry, so declarations at different scopes overwrote one another.

### Description of changes

This change keeps all acknowledgment scopes for each rule and resolves each violating resource back to a construct path through `ConstructTree`. With the new behavior enabled, a finding is suppressed only when every violating resource is the acknowledged construct or one of its descendants.

The implementation also handles a few related cases:

- App-level acknowledgments remain App-wide.
- Construct-scoped acknowledgments do not suppress findings whose resources cannot be resolved.
- Path matching observes segment boundaries, so `Resource` does not match `ResourceSibling`.
- Findings involving multiple resources require one acknowledgment scope to cover all of them. The report currently records a single `acknowledgedAt`, reason, and stack trace, so combining several unrelated acknowledgments would make the reporting semantics unclear.

The corrected behavior is gated by `@aws-cdk/core:scopedValidationPluginAcknowledgments`. I followed the repository's feature flag convention: it is recommended for new apps, while unconfigured existing apps retain the previous behavior. If the team prefers a different upgrade default, I can adjust that in review.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added regression coverage for:

- acknowledgments not crossing stack boundaries;
- legacy behavior when the feature flag is unconfigured;
- stack scopes covering descendants but not unrelated stacks;
- multiple acknowledgments for the same rule;
- partially acknowledged multi-resource findings;
- construct path segment boundaries;
- App-level acknowledgment of unresolved resources;
- construct-scoped acknowledgments with unresolved or resource-less findings.

Validation performed:

- 8 targeted validation regression tests;
- 122 feature flag tests;
- `aws-cdk-lib` build, including TypeScript/jsii compilation and lint checks;
- generated feature flag documentation verification;
- `git diff --check`.

No integration test was added because this only changes synthesis-time validation filtering and does not change CloudFormation templates or deployed AWS resources.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
