### PR TITLE
fix(eks): `Nodegroup` IPv6 grant hardcodes the 'aws' partition

### DIFF
--- a/packages/aws-cdk-lib/aws-eks-v2/lib/managed-nodegroup.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/lib/managed-nodegroup.ts
@@ -9,7 +9,7 @@ import { CfnNodegroup } from '../../aws-eks';
 import type { IRole } from '../../aws-iam';
 import { ManagedPolicy, PolicyStatement, Role, ServicePrincipal } from '../../aws-iam';
 import type { IResource, RemovalPolicy } from '../../core';
-import { Resource, Annotations, withResolved, FeatureFlags, ValidationError, RemovalPolicies, UnscopedValidationError } from '../../core';
+import { Resource, Annotations, withResolved, FeatureFlags, ValidationError, RemovalPolicies, UnscopedValidationError, Stack, ArnFormat } from '../../core';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
 import { addConstructMetadata } from '../../core/lib/metadata-resource';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
@@ -518,8 +518,14 @@ export class Nodegroup extends Resource implements INodegroup {
       // https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html
       if (props.cluster.ipFamily == IpFamily.IP_V6) {
         ngRole.addToPrincipalPolicy(new PolicyStatement({
-          // eslint-disable-next-line @cdklabs/no-literal-partition
-          resources: ['arn:aws:ec2:*:*:network-interface/*'],
+          resources: [Stack.of(this).formatArn({
+            service: 'ec2',
+            region: '*',
+            account: '*',
+            resource: 'network-interface',
+            resourceName: '*',
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+          })],
           actions: [
             'ec2:AssignIpv6Addresses',
             'ec2:UnassignIpv6Addresses',

--- a/packages/aws-cdk-lib/aws-eks-v2/test/nodegroup.test.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/test/nodegroup.test.ts
@@ -1757,6 +1757,80 @@ describe('node group', () => {
     // THEN
     expect(() => cluster.addNodegroupCapacity('ng', { maxUnavailablePercentage: 101 })).toThrow(/maxUnavailablePercentage must be between 1 and 100/);
   });
+
+  test('IPv6 cluster grants IPv6 address permissions scoped to the stack partition', () => {
+    // GIVEN
+    const { stack, vpc } = testFixture();
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      ...commonProps,
+      ipFamily: eks.IpFamily.IP_V6,
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([{
+          Action: ['ec2:AssignIpv6Addresses', 'ec2:UnassignIpv6Addresses'],
+          Effect: 'Allow',
+          Resource: {
+            'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, ':ec2:*:*:network-interface/*']],
+          },
+        }]),
+        Version: '2012-10-17',
+      },
+    });
+  });
+
+  test('IPv6 address permissions use the deployment partition outside aws', () => {
+    // GIVEN — partition literals enabled, so the partition is resolved at synth time
+    const app = new cdk.App({ context: { [cxapi.ENABLE_PARTITION_LITERALS]: true } });
+    const stack = new cdk.Stack(app, 'Stack', { env: { account: '123456789012', region: 'us-gov-west-1' } });
+    const vpc = new ec2.Vpc(stack, 'VPC');
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      ...commonProps,
+      ipFamily: eks.IpFamily.IP_V6,
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN — an 'aws' partition ARN would never match a resource in aws-us-gov
+    const policies = Template.fromStack(stack).findResources('AWS::IAM::Policy');
+    const statements = Object.values(policies)
+      .flatMap((policy: any) => policy.Properties.PolicyDocument.Statement)
+      .filter((statement: any) => JSON.stringify(statement).includes('AssignIpv6Addresses'));
+
+    expect(statements).toEqual([{
+      Action: ['ec2:AssignIpv6Addresses', 'ec2:UnassignIpv6Addresses'],
+      Effect: 'Allow',
+      Resource: 'arn:aws-us-gov:ec2:*:*:network-interface/*',
+    }]);
+  });
+
+  test('IPv4 cluster does not grant IPv6 address permissions', () => {
+    // GIVEN
+    const { stack, vpc } = testFixture();
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      ...commonProps,
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN
+    const policies = Template.fromStack(stack).findResources('AWS::IAM::Policy');
+    const statements = Object.values(policies)
+      .flatMap((policy: any) => policy.Properties.PolicyDocument.Statement)
+      .filter((statement: any) => JSON.stringify(statement).includes('AssignIpv6Addresses'));
+
+    expect(statements).toEqual([]);
+  });
 });
 
 describe('isGpuInstanceType', () => {

--- a/packages/aws-cdk-lib/aws-eks/lib/managed-nodegroup.ts
+++ b/packages/aws-cdk-lib/aws-eks/lib/managed-nodegroup.ts
@@ -9,7 +9,7 @@ import { InstanceType, InstanceArchitecture, InstanceClass, InstanceSize } from 
 import type { IRole } from '../../aws-iam';
 import { ManagedPolicy, PolicyStatement, Role, ServicePrincipal } from '../../aws-iam';
 import type { IResource, RemovalPolicy } from '../../core';
-import { Resource, Annotations, withResolved, FeatureFlags, ValidationError, RemovalPolicies } from '../../core';
+import { Resource, Annotations, withResolved, FeatureFlags, ValidationError, RemovalPolicies, Stack, ArnFormat } from '../../core';
 import * as cxapi from '../../cx-api';
 import { isGpuInstanceType } from './private/nodegroup';
 import { memoizedGetter } from '../../core/lib/helpers-internal';
@@ -542,8 +542,14 @@ export class Nodegroup extends Resource implements INodegroup {
       // https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html
       if (props.cluster.ipFamily == IpFamily.IP_V6) {
         ngRole.addToPrincipalPolicy(new PolicyStatement({
-          // eslint-disable-next-line @cdklabs/no-literal-partition
-          resources: ['arn:aws:ec2:*:*:network-interface/*'],
+          resources: [Stack.of(this).formatArn({
+            service: 'ec2',
+            region: '*',
+            account: '*',
+            resource: 'network-interface',
+            resourceName: '*',
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+          })],
           actions: [
             'ec2:AssignIpv6Addresses',
             'ec2:UnassignIpv6Addresses',

--- a/packages/aws-cdk-lib/aws-eks/test/nodegroup.test.ts
+++ b/packages/aws-cdk-lib/aws-eks/test/nodegroup.test.ts
@@ -2013,6 +2013,86 @@ describe('node group', () => {
       DeletionPolicy: 'Retain',
     });
   });
+
+  test('IPv6 cluster grants IPv6 address permissions scoped to the stack partition', () => {
+    // GIVEN
+    const { stack, vpc } = testFixture();
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      defaultCapacity: 0,
+      version: CLUSTER_VERSION,
+      ipFamily: eks.IpFamily.IP_V6,
+      kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([{
+          Action: ['ec2:AssignIpv6Addresses', 'ec2:UnassignIpv6Addresses'],
+          Effect: 'Allow',
+          Resource: {
+            'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, ':ec2:*:*:network-interface/*']],
+          },
+        }]),
+        Version: '2012-10-17',
+      },
+    });
+  });
+
+  test('IPv6 address permissions use the deployment partition outside aws', () => {
+    // GIVEN — partition literals enabled, so the partition is resolved at synth time
+    const app = new cdk.App({ context: { [cxapi.ENABLE_PARTITION_LITERALS]: true } });
+    const stack = new cdk.Stack(app, 'Stack', { env: { account: '123456789012', region: 'us-gov-west-1' } });
+    const vpc = new ec2.Vpc(stack, 'VPC');
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      defaultCapacity: 0,
+      version: CLUSTER_VERSION,
+      ipFamily: eks.IpFamily.IP_V6,
+      kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN — an 'aws' partition ARN would never match a resource in aws-us-gov
+    const policies = Template.fromStack(stack).findResources('AWS::IAM::Policy');
+    const statements = Object.values(policies)
+      .flatMap((policy: any) => policy.Properties.PolicyDocument.Statement)
+      .filter((statement: any) => JSON.stringify(statement).includes('AssignIpv6Addresses'));
+
+    expect(statements).toEqual([{
+      Action: ['ec2:AssignIpv6Addresses', 'ec2:UnassignIpv6Addresses'],
+      Effect: 'Allow',
+      Resource: 'arn:aws-us-gov:ec2:*:*:network-interface/*',
+    }]);
+  });
+
+  test('IPv4 cluster does not grant IPv6 address permissions', () => {
+    // GIVEN
+    const { stack, vpc } = testFixture();
+    const cluster = new eks.Cluster(stack, 'Cluster', {
+      vpc,
+      defaultCapacity: 0,
+      version: CLUSTER_VERSION,
+      kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+    });
+
+    // WHEN
+    cluster.addNodegroupCapacity('ng', {});
+
+    // THEN
+    const policies = Template.fromStack(stack).findResources('AWS::IAM::Policy');
+    const statements = Object.values(policies)
+      .flatMap((policy: any) => policy.Properties.PolicyDocument.Statement)
+      .filter((statement: any) => JSON.stringify(statement).includes('AssignIpv6Addresses'));
+
+    expect(statements).toEqual([]);
+  });
 });
 
 describe('isGpuInstanceType', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38552.

### Reason for this change

When a nodegroup is created for an IPv6 cluster, `Nodegroup` grants the node role `ec2:AssignIpv6Addresses` / `ec2:UnassignIpv6Addresses` — the permissions the VPC CNI needs to hand IPv6 addresses to pods. The resource ARN for that statement was a hardcoded literal in the `aws` partition, with the `@cdklabs/no-literal-partition` lint rule suppressed directly above it:

```ts
// eslint-disable-next-line @cdklabs/no-literal-partition
resources: ['arn:aws:ec2:*:*:network-interface/*'],
```

An ARN naming the `aws` partition can never match a resource in `aws-us-gov` or `aws-cn`, so in those partitions the statement grants nothing. Synthesizing the same app into `us-east-1`, `us-gov-west-1` and `cn-north-1` produced the identical literal every time, while CDK's own managed-policy ARNs in the same template resolved per partition. Nothing warns at synth or deploy time — the nodes come up and pods simply fail to get addresses.

AWS docs state that `ipv6` cannot be specified for clusters in China Regions, so the reachable impact today is GovCloud (US), which carries no such restriction.

### Description of changes

Replaced the hardcoded ARN with `Stack.of(this).formatArn(...)` in both `aws-eks` and `aws-eks-v2` (the block is duplicated verbatim in the two modules), and removed the now-unnecessary `eslint-disable`.

This follows [AGENTS.md § ARN Construction](https://github.com/aws/aws-cdk/blob/main/AGENTS.md) ("Use `Stack.of(scope).formatArn()` — never hardcode ARN strings"). `aws-eks/lib/alb-controller.ts` already solves the same problem for the ALB controller policy by rewriting `arn:aws:` to `arn:${Aws.PARTITION}:`; using `formatArn` here keeps the ARN construction declarative rather than string-rewritten.

No feature flag: in the `aws` partition the grant is semantically unchanged, and in other partitions the previous ARN granted nothing at all, so no working configuration changes behaviour.

### Describe any new or updated permissions being added

None. The same two actions are granted; only the resource ARN's partition changes, from a hardcoded `aws` to the partition the stack deploys into.

### Description of how you validated changes

- Added three unit tests to each of `aws-eks/test/nodegroup.test.ts` and `aws-eks-v2/test/nodegroup.test.ts`:
  - an IPv6 cluster renders the resource as `arn:${AWS::Partition}:ec2:*:*:network-interface/*`,
  - an IPv6 cluster in `us-gov-west-1` with `@aws-cdk/core:enablePartitionLiterals` renders the literal `arn:aws-us-gov:ec2:*:*:network-interface/*` (this is the case that was broken),
  - an IPv4 cluster grants no IPv6 statement at all (guarding the unchanged branch).
- `npx jest aws-eks/test/nodegroup.test.ts aws-eks-v2/test/nodegroup.test.ts` — 149 passed.
- `npx eslint` on the four changed files — clean.
- `yarn integ test/aws-eks/test/integ.eks-cluster-ipv6.js --dry-run` — **UNCHANGED**, so no snapshot update is included. That is expected rather than a missed update: `framework-integ` runs with partition literals enabled and a concrete region, so `formatArn` resolves to the same `arn:aws:ec2:*:*:network-interface/*` string the snapshot already contains. I verified this by logging the resolved ARN during the runner's synth, and by hand-editing the snapshot to the `Fn::Join` form and confirming the runner then reports CHANGED.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
