### PR TITLE
feat(route53): add `removalPolicy` to hosted zones

### DIFF
--- a/packages/aws-cdk-lib/aws-route53/README.md
+++ b/packages/aws-cdk-lib/aws-route53/README.md
@@ -24,6 +24,22 @@ const zone = new route53.PrivateHostedZone(this, 'HostedZone', {
 
 Additional VPCs can be added with `zone.addVpc()`.
 
+### Removal policy
+
+By default a hosted zone is deleted when it is removed from the stack or the
+stack is deleted. Because the name servers Route 53 assigns to a public hosted
+zone are chosen at creation time and cannot be recovered, a recreated zone gets
+different name servers that must be re-registered with the parent domain and
+propagated through DNS. To protect against accidental loss, set the
+`removalPolicy` to `RETAIN`:
+
+```ts
+new route53.PublicHostedZone(this, 'HostedZone', {
+  zoneName: 'fully.qualified.domain.com',
+  removalPolicy: RemovalPolicy.RETAIN,
+});
+```
+
 ## Adding Records
 
 To add a TXT record to your zone:

--- a/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
+++ b/packages/aws-cdk-lib/aws-route53/lib/hosted-zone.ts
@@ -18,7 +18,7 @@ import type * as ec2 from '../../aws-ec2';
 import * as iam from '../../aws-iam';
 import type * as kms from '../../aws-kms';
 import * as cxschema from '../../cloud-assembly-schema';
-import type { Duration } from '../../core';
+import type { Duration, RemovalPolicy } from '../../core';
 import { ContextProvider, Resource, Stack } from '../../core';
 import { ValidationError } from '../../core/lib/errors';
 import type { IArrayBox } from '../../core/lib/helpers-internal';
@@ -58,6 +58,20 @@ export interface CommonHostedZoneProps {
    * @default disabled
    */
   readonly queryLogsLogGroupArn?: string;
+
+  /**
+   * The removal policy to apply to the hosted zone.
+   *
+   * When set to `RemovalPolicy.RETAIN`, the hosted zone is preserved when it is
+   * removed from the stack or the stack is deleted. This protects against
+   * accidental loss of a hosted zone: the name servers Route 53 assigns to a
+   * public hosted zone are chosen at creation time and cannot be recovered once
+   * the zone is deleted, so a recreated zone gets different name servers that
+   * must be re-registered with the parent domain and propagated through DNS.
+   *
+   * @default RemovalPolicy.DESTROY - the hosted zone is deleted when it is removed from the stack
+   */
+  readonly removalPolicy?: RemovalPolicy;
 }
 
 /**
@@ -263,6 +277,10 @@ export class HostedZone extends Resource implements IHostedZone {
       queryLoggingConfig: props.queryLogsLogGroupArn ? { cloudWatchLogsLogGroupArn: props.queryLogsLogGroupArn } : undefined,
       vpcs: this._vpcs,
     });
+
+    if (props.removalPolicy !== undefined) {
+      resource.applyRemovalPolicy(props.removalPolicy);
+    }
 
     this.hostedZoneId = resource.ref;
     this.hostedZoneNameServers = resource.attrNameServers;

--- a/packages/aws-cdk-lib/aws-route53/test/hosted-zone.test.ts
+++ b/packages/aws-cdk-lib/aws-route53/test/hosted-zone.test.ts
@@ -788,3 +788,76 @@ describe('acceleratedRecoveryEnabled', () => {
     });
   });
 });
+
+describe('removalPolicy', () => {
+  test.each([
+    [cdk.RemovalPolicy.RETAIN, 'Retain'],
+    [cdk.RemovalPolicy.DESTROY, 'Delete'],
+  ])('removalPolicy=%p sets DeletionPolicy=%p on a PublicHostedZone', (removalPolicy, expected) => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new PublicHostedZone(stack, 'HostedZone', {
+      zoneName: 'testZone',
+      removalPolicy,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResource('AWS::Route53::HostedZone', {
+      DeletionPolicy: expected,
+      UpdateReplacePolicy: expected,
+    });
+  });
+
+  test('is not set on the template when removalPolicy is omitted', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new PublicHostedZone(stack, 'HostedZone', {
+      zoneName: 'testZone',
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResource('AWS::Route53::HostedZone', {
+      DeletionPolicy: Match.absent(),
+      UpdateReplacePolicy: Match.absent(),
+    });
+  });
+
+  test('is honored on the base HostedZone', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new HostedZone(stack, 'HostedZone', {
+      zoneName: 'testZone',
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResource('AWS::Route53::HostedZone', {
+      DeletionPolicy: 'Retain',
+      UpdateReplacePolicy: 'Retain',
+    });
+  });
+
+  test('is honored on a PrivateHostedZone', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new PrivateHostedZone(stack, 'HostedZone', {
+      zoneName: 'testZone',
+      vpc: new ec2.Vpc(stack, 'Vpc'),
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResource('AWS::Route53::HostedZone', {
+      DeletionPolicy: 'Retain',
+      UpdateReplacePolicy: 'Retain',
+    });
+  });
+});

--- a/packages/aws-cdk-lib/rosetta/aws_route53/default.ts-fixture
+++ b/packages/aws-cdk-lib/rosetta/aws_route53/default.ts-fixture
@@ -1,6 +1,6 @@
 // Fixture with packages imported, but nothing else
 import { Construct } from 'constructs';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as targets from 'aws-cdk-lib/aws-route53-targets';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';


### PR DESCRIPTION
Accidentally removing a hosted zone can be a headache to recover from. Add `removalPolicy` to the L2 API of `HostedZone`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
