### PR TITLE
fix(dynamodb): `TableGrantsProps` deprecation warnings in TableV2

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-dynamodb/test/integ.table-v2-grants.js.snapshot/integ.table-v2-grants.expected.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-dynamodb/test/integ.table-v2-grants.js.snapshot/integ.table-v2-grants.expected.json
@@ -1,0 +1,73 @@
+{
+  "Resources": {
+    "TableKey9B9C2A0B": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "EnableKeyRotation": true,
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "Role4F2DE1E8",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    },
+    "TableB2F666ED": {
+      "Type": "AWS::DynamoDB::GlobalTable",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "pk",
+            "AttributeType": "S"
+          }
+        ],
+        "Replicas": [
+          {
+            "Region": {
+              "Ref": "AWS::Region"
+            }
+          }
+        ],
+        "SSESpecification": {
+          "SSEType": "KMS",
+          "KMSMasterKeyId": {
+            "Fn::GetAtt": [
+              "TableKey9B9C2A0B",
+              "Arn"
+            ]
+          }
+        },
+        "StreamSpecification": {
+          "StreamViewType": "NEW_AND_OLD_IMAGES"
+        }
+      }
+    },
+    "Role4F2DE1E8": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-dynamodb/test/integ.table-v2-grants.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-dynamodb/test/integ.table-v2-grants.ts
@@ -1,0 +1,32 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { IntegTest } from '@aws-cdk/integ-tests-alpha';
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'TableV2GrantsStack', {
+  env: { account: '123456789012', region: 'us-east-1' },
+});
+
+const key = new kms.Key(stack, 'TableKey', {
+  enableKeyRotation: true,
+});
+
+const table = new dynamodb.TableV2(stack, 'Table', {
+  partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+  encryption: dynamodb.TableEncryptionV2.customerManagedKey(key),
+});
+
+const role = new iam.Role(stack, 'Role', {
+  assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+});
+
+table.grantReadData(role);
+table.grantWriteData(role);
+
+new IntegTest(app, 'TableV2GrantsInteg', {
+  testCases: [stack],
+});
+
+app.synth();

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -880,8 +880,6 @@ export class TableV2 extends TableBaseV2 {
     this.grants = new TableGrants({
       table: this,
       regions: Array.from(this.replicaTables.keys()),
-      encryptedResource: this.encryptionKey ? this : undefined,
-      policyResource: this,
     });
 
     if (props.tableName) {

--- a/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
@@ -4848,7 +4848,16 @@ test('grantReadData on encrypted table grants KMS permissions via auto-discovery
             'kms:DescribeKey',
           ]),
           Principal: {
-            AWS: 'arn:aws:iam::111111111111:root',
+            AWS: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  { Ref: 'AWS::Partition' },
+                  ':iam::111111111111:root',
+                ],
+              ],
+            },
           },
         }),
       ]),

--- a/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/test/table-v2.test.ts
@@ -4828,6 +4828,34 @@ test('addToStreamResourcePolicy on primary table', () => {
   });
 });
 
+test('grantReadData on encrypted table grants KMS permissions via auto-discovery', () => {
+  const stack = new Stack(undefined, 'Stack', { env: { account: '111111111111', region: 'us-east-1' } });
+  const key = new Key(stack, 'Key');
+  const table = new TableV2(stack, 'Table', {
+    partitionKey: { name: 'pk', type: AttributeType.STRING },
+    encryption: TableEncryptionV2.customerManagedKey(key),
+  });
+
+  const principal = new iam.AccountRootPrincipal();
+  table.grantReadData(principal);
+
+  Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
+    KeyPolicy: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: Match.arrayWith([
+            'kms:Decrypt',
+            'kms:DescribeKey',
+          ]),
+          Principal: {
+            AWS: 'arn:aws:iam::111111111111:root',
+          },
+        }),
+      ]),
+    },
+  });
+});
+
 test('no stream resource policy by default', () => {
   // GIVEN
   const stack = new Stack(undefined, 'Stack');


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37221.

### Reason for this change

Removes internal usage of the deprecated `encryptedResource` and `policyResource` properties from `TableGrants` instantiation inside `TableV2` and `GlobalTable`.

### Description of changes

Replaced the deprecated property usage.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Synthesized templates are unaffected.

### Checklist
- [x] My code adheres to the CONTRIBUTING GUIDE and DESIGN GUIDELINES

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*