### PR TITLE
feat(glue-alpha): add warning for maxRetries when job run queuing is enabled

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
@@ -439,15 +439,6 @@ export interface JobProps {
   readonly glueVersion?: GlueVersion;
 
   /**
-   * Enables the collection of metrics for job profiling.
-   *
-   * @default - no profiling metrics emitted.
-   *
-   * @see https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html
-   */
-  readonly enableProfilingMetrics? :boolean;
-
-  /**
    * Enables continuous logging with the specified props.
    *
    * @default - continuous logging is enabled.

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
@@ -1,6 +1,7 @@
 import { CfnJob } from 'aws-cdk-lib/aws-glue';
 import type * as cdk from 'aws-cdk-lib/core';
-import { memoizedGetter } from 'aws-cdk-lib/core/lib/helpers-internal';
+import { Annotations } from 'aws-cdk-lib/core';
+import { lit, memoizedGetter } from 'aws-cdk-lib/core/lib/helpers-internal';
 import { addConstructMetadata } from 'aws-cdk-lib/core/lib/metadata-resource';
 import { propertyInjectable } from 'aws-cdk-lib/core/lib/prop-injectable';
 import type { Construct } from 'constructs';
@@ -98,6 +99,11 @@ export class PySparkEtlJob extends SparkJob {
       ...this.executableArguments(props),
       ...this.nonExecutableCommonArguments(props),
     };
+
+    if (props.jobRunQueuingEnabled === true && props.maxRetries !== undefined && props.maxRetries > 0) {
+      Annotations.of(this).addWarningV2(lit`GlueMaxRetriesQueuingEnabled`,
+        `maxRetries was set to ${props.maxRetries}. Overriding it to 0 with since job run queuing is enabled (service constraint)`);
+    }
 
     this.resource = new CfnJob(this, 'Resource', {
       name: props.jobName,

--- a/packages/@aws-cdk/aws-glue-alpha/test/pyspark-etl-jobs.test.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/test/pyspark-etl-jobs.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Template, Match, Annotations } from 'aws-cdk-lib/assertions';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -760,6 +760,68 @@ describe('Job', () => {
           '--enable-observability-metrics': 'true',
         }),
       });
+    });
+  });
+
+  describe('maxRetries warning with job run queuing enabled', () => {
+    const WARNING = Match.stringLikeRegexp('.*Overriding it to 0 with since job run queuing is enabled.*');
+
+    test('warns when job run queuing is enabled and maxRetries is greater than 0', () => {
+      new glue.PySparkEtlJob(stack, 'PySparkETLJob', {
+        role,
+        script,
+        jobName: 'PySparkETLJob',
+        jobRunQueuingEnabled: true,
+        maxRetries: 2,
+      });
+
+      Annotations.fromStack(stack).hasWarning('/Default/PySparkETLJob', WARNING);
+    });
+
+    test('does not warn when job run queuing is enabled and maxRetries is 0', () => {
+      new glue.PySparkEtlJob(stack, 'PySparkETLJob', {
+        role,
+        script,
+        jobName: 'PySparkETLJob',
+        jobRunQueuingEnabled: true,
+        maxRetries: 0,
+      });
+
+      Annotations.fromStack(stack).hasNoWarning('/Default/PySparkETLJob', WARNING);
+    });
+
+    test('does not warn when job run queuing is enabled and maxRetries is not set', () => {
+      new glue.PySparkEtlJob(stack, 'PySparkETLJob', {
+        role,
+        script,
+        jobName: 'PySparkETLJob',
+        jobRunQueuingEnabled: true,
+      });
+
+      Annotations.fromStack(stack).hasNoWarning('/Default/PySparkETLJob', WARNING);
+    });
+
+    test('does not warn when maxRetries is greater than 0 but job run queuing is disabled', () => {
+      new glue.PySparkEtlJob(stack, 'PySparkETLJob', {
+        role,
+        script,
+        jobName: 'PySparkETLJob',
+        jobRunQueuingEnabled: false,
+        maxRetries: 2,
+      });
+
+      Annotations.fromStack(stack).hasNoWarning('/Default/PySparkETLJob', WARNING);
+    });
+
+    test('does not warn when maxRetries is greater than 0 but job run queuing is not set', () => {
+      new glue.PySparkEtlJob(stack, 'PySparkETLJob', {
+        role,
+        script,
+        jobName: 'PySparkETLJob',
+        maxRetries: 2,
+      });
+
+      Annotations.fromStack(stack).hasNoWarning('/Default/PySparkETLJob', WARNING);
     });
   });
 


### PR DESCRIPTION
Also delete the `enableProfilingMetrics` prop, that is not used anywhere, and semantically overlaps with `SparkJobProps.enableMetrics`, with opposite default

BREAKING CHANGE: `SparkJobProps.enableMetrics` removed, which will cause a compilation error for any app using it. But there is no behavior change, since this is a dead prop.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
