### PR TITLE
docs(cloudfront): document feature-flagged Function runtime default

### DIFF
--- a/packages/aws-cdk-lib/aws-cloudfront/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-cloudfront/lib/function.ts
@@ -135,7 +135,10 @@ export interface FunctionProps {
 
   /**
    * The runtime environment for the function.
-   * @default FunctionRuntime.JS_1_0 (unless `keyValueStore` is specified, then `FunctionRuntime.JS_2_0`)
+   *
+   * @default - FunctionRuntime.JS_2_0 if `keyValueStore` is specified or the
+   * `@aws-cdk/aws-cloudfront:defaultFunctionRuntimeV2_0` feature flag is enabled;
+   * otherwise, FunctionRuntime.JS_1_0.
    */
   readonly runtime?: FunctionRuntime;
 


### PR DESCRIPTION
### Issue # (if applicable)

Follow-up to #35941.

### Reason for this change

`FunctionProps.runtime` does not document the `defaultFunctionRuntimeV2_0` feature flag.

### Description of changes

Document the effective runtime default when the feature flag or `keyValueStore` is configured.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

`git diff --check` passed. The module build was unavailable because this checkout does not contain the `cdk-build` binary.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*