### PR TITLE
chore(ec2): add VPC interface endpoints for EventBridge Scheduler

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts
@@ -766,6 +766,8 @@ export class InterfaceVpcEndpointAwsService implements IInterfaceVpcEndpointServ
   public static readonly SAGEMAKER_RUNTIME = new InterfaceVpcEndpointAwsService('sagemaker.runtime');
   public static readonly SAGEMAKER_RUNTIME_FIPS = new InterfaceVpcEndpointAwsService('sagemaker.runtime-fips');
   public static readonly SAGEMAKER_STUDIO = new InterfaceVpcEndpointAwsService('studio', 'aws.sagemaker');
+  public static readonly SCHEDULER = new InterfaceVpcEndpointAwsService('scheduler');
+  public static readonly SCHEDULER_FIPS = new InterfaceVpcEndpointAwsService('scheduler-fips');
   public static readonly SECRETS_MANAGER = new InterfaceVpcEndpointAwsService('secretsmanager');
   public static readonly SECURITYHUB = new InterfaceVpcEndpointAwsService('securityhub');
   public static readonly SECURITYLAKE = new InterfaceVpcEndpointAwsService('securitylake');

--- a/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
+++ b/packages/aws-cdk-lib/aws-ec2/test/vpc-endpoint.test.ts
@@ -757,6 +757,22 @@ describe('vpc endpoint', () => {
         ServiceName: 'com.amazonaws.cn-northwest-1.glue',
       });
     });
+    test.each([
+      ['scheduler', InterfaceVpcEndpointAwsService.SCHEDULER],
+      ['scheduler-fips', InterfaceVpcEndpointAwsService.SCHEDULER_FIPS],
+    ])('test vpc interface endpoint for %s can be created correctly', (name: string, given: InterfaceVpcEndpointAwsService) => {
+      // GIVEN
+      const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'us-east-1' } });
+      const vpc = new Vpc(stack, 'VPC');
+
+      // WHEN
+      vpc.addInterfaceEndpoint('Endpoint', { service: given });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+        ServiceName: `com.amazonaws.us-east-1.${name}`,
+      });
+    });
     test('test vpc interface endpoint for transcribe can be created correctly in non-china regions', () => {
       // GIVEN
       const stack = new Stack(undefined, 'TestStack', { env: { account: '123456789012', region: 'us-east-1' } });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38588

### Reason for this change

EventBridge Scheduler supports interface VPC endpoints, but they are currently missing from `InterfaceVpcEndpointAwsService`. Users must construct the service manually via `new InterfaceVpcEndpointAwsService('scheduler')`, which is inconsistent with other services and creates a surprise since `EVENTBRIDGE` points at `events` (a different service).

### Description of changes

Add interface VPC endpoints to `packages/aws-cdk-lib/aws-ec2/lib/vpc-endpoint.ts`:

- `SCHEDULER` → `com.amazonaws.<region>.scheduler`
- `SCHEDULER_FIPS` → `com.amazonaws.<region>.scheduler-fips`

Endpoint availability confirmed via AWS docs: https://docs.aws.amazon.com/general/latest/gr/eventbridgescheduler.html (FIPS endpoints available in US, GovCloud, and Canada regions).

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Confirmed both endpoints exist per the AWS General Reference endpoints table for EventBridge Scheduler. Change mirrors the pattern used for other services (e.g., `SAGEMAKER_RUNTIME` / `SAGEMAKER_RUNTIME_FIPS`, `COGNITO_IDENTITY` / `COGNITO_IDENTITY_FIPS`).

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*