### PR TITLE
chore(lambda): ephemeral storage validation error shows [object Object]

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function.ts
@@ -1108,7 +1108,7 @@ export class Function extends FunctionBase {
 
     if (props.ephemeralStorageSize && !props.ephemeralStorageSize.isUnresolved()
       && (props.ephemeralStorageSize.toMebibytes() < 512 || props.ephemeralStorageSize.toMebibytes() > 10240)) {
-      throw new ValidationError(lit`EphemeralStorageOutOfRange`, `Ephemeral storage size must be between 512 and 10240 MB, received ${props.ephemeralStorageSize}.`, this);
+      throw new ValidationError(lit`EphemeralStorageOutOfRange`, `Ephemeral storage size must be between 512 and 10240 MB, received ${props.ephemeralStorageSize.toMebibytes()} MiB.`, this);
     }
 
     const effectiveRuntime = props.runtime === Runtime.NODEJS_LATEST ? determineLatestNodeRuntime(this) : props.runtime;

--- a/packages/aws-cdk-lib/aws-lambda/lib/function.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/function.ts
@@ -1108,7 +1108,7 @@ export class Function extends FunctionBase {
 
     if (props.ephemeralStorageSize && !props.ephemeralStorageSize.isUnresolved()
       && (props.ephemeralStorageSize.toMebibytes() < 512 || props.ephemeralStorageSize.toMebibytes() > 10240)) {
-      throw new ValidationError(lit`EphemeralStorageOutOfRange`, `Ephemeral storage size must be between 512 and 10240 MB, received ${props.ephemeralStorageSize.toMebibytes()} MiB.`, this);
+      throw new ValidationError(lit`EphemeralStorageOutOfRange`, `Ephemeral storage size must be between 512 and 10240 MB, received ${props.ephemeralStorageSize.toMebibytes()} MB.`, this);
     }
 
     const effectiveRuntime = props.runtime === Runtime.NODEJS_LATEST ? determineLatestNodeRuntime(this) : props.runtime;

--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -4416,7 +4416,17 @@ test('throws if ephemeral storage size is out of bound', () => {
     handler: 'bar',
     runtime: lambda.Runtime.NODEJS_LATEST,
     ephemeralStorageSize: Size.mebibytes(511),
-  })).toThrow(/Ephemeral storage size must be between 512 and 10240 MB/);
+  })).toThrow(/Ephemeral storage size must be between 512 and 10240 MB, received 511 MiB/);
+});
+
+test('throws with the received size in MiB if ephemeral storage size is specified in another unit', () => {
+  const stack = new cdk.Stack();
+  expect(() => new lambda.Function(stack, 'MyLambda', {
+    code: new lambda.InlineCode('foo'),
+    handler: 'bar',
+    runtime: lambda.Runtime.NODEJS_LATEST,
+    ephemeralStorageSize: Size.gibibytes(11),
+  })).toThrow(/Ephemeral storage size must be between 512 and 10240 MB, received 11264 MiB/);
 });
 
 test('set ephemeral storage to desired size', () => {

--- a/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda/test/function.test.ts
@@ -4426,7 +4426,7 @@ test('throws with the received size in MiB if ephemeral storage size is specifie
     handler: 'bar',
     runtime: lambda.Runtime.NODEJS_LATEST,
     ephemeralStorageSize: Size.gibibytes(11),
-  })).toThrow(/Ephemeral storage size must be between 512 and 10240 MB, received 11264 MiB/);
+  })).toThrow(/Ephemeral storage size must be between 512 and 10240 MB, received 11264 MB/);
 });
 
 test('set ephemeral storage to desired size', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38621.

### Reason for this change

When `ephemeralStorageSize` is out of the allowed range, the validation error interpolates the `Size` object straight into the message. `Size` has no `toString()`, so the value renders as `[object Object]` and users cannot tell which value they actually passed:

```
«EphemeralStorageOutOfRange» Ephemeral storage size must be between 512 and 10240 MB, received [object Object].
```

Reproduction:

```ts
new lambda.Function(this, 'Fn', {
  runtime: lambda.Runtime.NODEJS_20_X,
  handler: 'index.handler',
  code: lambda.Code.fromInline('exports.handler = async () => {};'),
  ephemeralStorageSize: cdk.Size.mebibytes(100), // below the 512 MiB minimum
});
```

### Description of changes

`aws-lambda/lib/function.ts` now calls `.toMebibytes()` on the size when building the message and states the unit explicitly, so the error reads:

```
Ephemeral storage size must be between 512 and 10240 MB, received 100 MiB.
```

Notes on why this is safe:

- The surrounding range check already calls `.toMebibytes()` on the very same value, so this adds no new conversion failure path — a `Size` that cannot be converted into whole mebibytes already throws before reaching this line.
- The value is guaranteed to be resolved here, because the condition guards on `!props.ephemeralStorageSize.isUnresolved()`.

Alternative considered and not taken here: adding `toString()` to `Size` in `core` (`Duration` already has one, so `Size` is the odd one out). That would address this class of problem globally, but it adds public API to core and deserves its own discussion. As far as I could find, this is the only place in `aws-cdk-lib` today where a `Size`-typed value is interpolated into a message, so a local fix is sufficient for this bug.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Unit tests in `aws-lambda/test/function.test.ts`:

- Strengthened the existing `throws if ephemeral storage size is out of bound` case to assert the reported value (`received 511 MiB`) rather than only the prefix.
- Added a case passing `Size.gibibytes(11)` to confirm the size is reported normalized to MiB (`received 11264 MiB`).

Both cases fail on `main` with `received [object Object].` and pass with this change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
