### PR TITLE
fix(ci): add environment for Atmosphere variables access

### DIFF
--- a/.github/workflows/integration-test-approval-deployment.yml
+++ b/.github/workflows/integration-test-approval-deployment.yml
@@ -139,13 +139,15 @@ jobs:
   # proceed to check it out and run it in a privileged context (CodeBuild
   # with Atmosphere).
   #
-  # Instead of gating this job with a GitHub Environment (like integration-test-deployment.yml),
+  # Instead of gating this job with a protected GitHub Environment (like integration-test-deployment.yml),
   # we rely solely on verify-approval.js to check whether the approval is valid and
-  # non-stale. This allows the workflow to run automatically without any manual
-  # interaction from the maintainer.
+  # non-stale. The environment here (post-approval-integ-test-deployment) has no
+  # protection rules — it exists only to scope the Atmosphere variables. This allows
+  # the workflow to run automatically without any manual interaction from the maintainer.
   deploy:
     needs: validate
     if: needs.validate.outputs.has_snapshots == 'true'
+    environment: post-approval-integ-test-deployment
     runs-on: codebuild-aws-cdk-github-actions-deployment-integ-runner-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 180
 


### PR DESCRIPTION
## Problem

The integration test approval deployment workflow (#38519) fails at the "Run integration tests" step with:

```
Error: CDK_ATMOSPHERE_ENDPOINT environment variable is required
```

The `CDK_ATMOSPHERE_*` variables are scoped to the `deployment-integ-test` GitHub Environment, which uses protection rules (required reviewers). Our workflow intentionally doesn't use that environment because approval gating is handled by `verify-approval.js` instead.

## Solution

Created a new GitHub Environment `post-approval-integ-test-deployment` with the same Atmosphere variables but no protection rules. This environment contains only non-secret variables (endpoint URLs, pool name, batch size, OIDC role ARN) — no secrets are stored in it. The deploy job now references this environment so it can access the variables while still running automatically after script-based approval.

## Changes

- Added `environment: post-approval-integ-test-deployment` to the deploy job
- Updated the comment explaining the environment decision

## Testing

- Previous run failed: https://github.com/aws/aws-cdk/actions/runs/32470703438/job/96736796076
- After this change, the deploy job will have access to `CDK_ATMOSPHERE_ENDPOINT`, `CDK_ATMOSPHERE_POOL`, `CDK_ATMOSPHERE_OIDC_ROLE`, and `CDK_ATMOSPHERE_BATCH_SIZE`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
