### PR TITLE
feat(ecs): allow specifying whether an imported task definition ARN includes a revision

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-events-targets/test/ecs/integ.ecs-imported-task-def.js.snapshot/IntegEcsImportedTaskDefStack.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-events-targets/test/ecs/integ.ecs-imported-task-def.js.snapshot/IntegEcsImportedTaskDefStack.template.json
@@ -606,7 +606,7 @@
           {
            "Ref": "AWS::AccountId"
           },
-          ":task-definition/TaskDefinitionA"
+          ":task-definition/TaskDefinitionA:*"
          ]
         ]
        }

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-events-targets/test/ecs/integ.ecs-imported-task-def.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-events-targets/test/ecs/integ.ecs-imported-task-def.ts
@@ -26,10 +26,15 @@ taskDefinition.addContainer('web', {
   ],
 });
 
+// The ARN is built from tokens (region/account), so it is unresolved at synth time and its
+// revision cannot be inferred from the string. `taskDefinitionArnIncludesRevision: false` records
+// that this family-only ARN has no revision, so the generated `ecs:RunTask` permission is scoped
+// with a `:*` revision wildcard.
 const importedTaskDef = FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'TaskDefImport', {
   taskDefinitionArn: `arn:aws:ecs:${Aws.REGION}:${Aws.ACCOUNT_ID}:task-definition/${taskDefFamily}`,
   taskRole: taskRole,
   networkMode: NetworkMode.AWS_VPC,
+  taskDefinitionArnIncludesRevision: false,
 });
 
 const eventRule = new Rule(stack, 'Rule', {

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/_imported-task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/_imported-task-definition.ts
@@ -48,6 +48,14 @@ export interface ImportedTaskDefinitionProps {
    * @default - undefined
    */
   readonly executionRole?: IRole;
+
+  /**
+   * Whether the imported task definition ARN includes a specific revision.
+   *
+   * @default - the presence of a revision is inferred from the ARN string when it is a concrete
+   * (fully-resolved) value, and assumed to be included otherwise
+   */
+  readonly taskDefinitionArnIncludesRevision?: boolean;
 }
 
 /**
@@ -82,6 +90,11 @@ export class ImportedTaskDefinition extends Resource implements IEc2TaskDefiniti
    */
   readonly _taskRole?: IRole;
 
+  /**
+   * Whether the imported task definition ARN includes a specific revision.
+   */
+  readonly taskDefinitionArnIncludesRevision?: boolean;
+
   constructor(scope: Construct, id: string, props: ImportedTaskDefinitionProps) {
     super(scope, id);
     // Enhanced CDK Analytics Telemetry
@@ -92,6 +105,7 @@ export class ImportedTaskDefinition extends Resource implements IEc2TaskDefiniti
     this.executionRole = props.executionRole;
     this._taskRole = props.taskRole;
     this._networkMode = props.networkMode;
+    this.taskDefinitionArnIncludesRevision = props.taskDefinitionArnIncludesRevision;
   }
 
   public get networkMode(): NetworkMode {

--- a/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts
@@ -71,6 +71,19 @@ export interface ITaskDefinition extends IResource, ITaskDefinitionRef {
    * The name of the IAM role that grants containers in the task permission to call AWS APIs on your behalf.
    */
   readonly taskRole: iam.IRole;
+
+  /**
+   * Whether the task definition ARN includes a specific revision (e.g. `family:1`) as opposed to
+   * referring to the family only (e.g. `family`).
+   *
+   * This is used, for example, by EventBridge targets when scoping down the `ecs:RunTask`
+   * permission: an ARN without a revision must be granted with a `:*` wildcard, whereas an ARN
+   * that already pins a revision is granted as-is.
+   *
+   * @default - the presence of a revision is inferred from the ARN string when it is a concrete
+   * (fully-resolved) value, and assumed to be included otherwise
+   */
+  readonly taskDefinitionArnIncludesRevision?: boolean;
 }
 
 /**
@@ -289,6 +302,21 @@ export interface CommonTaskDefinitionAttributes {
    * @default - undefined
    */
   readonly executionRole?: iam.IRole;
+
+  /**
+   * Whether the imported task definition ARN includes a specific revision (e.g.
+   * `arn:aws:ecs:region:account:task-definition/family:1`) or refers to the family only (e.g.
+   * `arn:aws:ecs:region:account:task-definition/family`).
+   *
+   * Set this when the ARN is only known at deploy time (for example, when it is passed in as a
+   * CloudFormation parameter or resolved via `Fn.importValue`) and its revision cannot be
+   * inferred by inspecting the string. It lets consumers such as EventBridge targets decide
+   * whether the `ecs:RunTask` permission must be scoped with a `:*` revision wildcard.
+   *
+   * @default - the presence of a revision is inferred from the ARN string when it is a concrete
+   * (fully-resolved) value, and assumed to be included otherwise
+   */
+  readonly taskDefinitionArnIncludesRevision?: boolean;
 }
 
 /**
@@ -377,6 +405,7 @@ export class TaskDefinition extends TaskDefinitionBase {
       networkMode: attrs.networkMode,
       taskRole: attrs.taskRole,
       executionRole: attrs.executionRole,
+      taskDefinitionArnIncludesRevision: attrs.taskDefinitionArnIncludesRevision,
     });
   }
 

--- a/packages/aws-cdk-lib/aws-ecs/lib/ec2/ec2-task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/ec2/ec2-task-definition.ts
@@ -119,6 +119,7 @@ export class Ec2TaskDefinition extends TaskDefinition implements IEc2TaskDefinit
       networkMode: attrs.networkMode,
       taskRole: attrs.taskRole,
       executionRole: attrs.executionRole,
+      taskDefinitionArnIncludesRevision: attrs.taskDefinitionArnIncludesRevision,
     });
   }
 

--- a/packages/aws-cdk-lib/aws-ecs/lib/fargate/fargate-task-definition.ts
+++ b/packages/aws-cdk-lib/aws-ecs/lib/fargate/fargate-task-definition.ts
@@ -152,6 +152,7 @@ export class FargateTaskDefinition extends TaskDefinition implements IFargateTas
       networkMode: attrs.networkMode,
       taskRole: attrs.taskRole,
       executionRole: attrs.executionRole,
+      taskDefinitionArnIncludesRevision: attrs.taskDefinitionArnIncludesRevision,
     });
   }
 

--- a/packages/aws-cdk-lib/aws-ecs/test/fargate/fargate-task-definition.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs/test/fargate/fargate-task-definition.test.ts
@@ -310,6 +310,30 @@ describe('fargate task definition', () => {
       expect(taskDefinition.executionRole).toEqual(expectExecutionRole);
     });
 
+    test('records taskDefinitionArnIncludesRevision when provided', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      acknowledgeTestValidationRules(stack);
+
+      // WHEN
+      const withRevision = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'WithRevision', {
+        taskDefinitionArn: 'TD_ARN',
+        taskDefinitionArnIncludesRevision: true,
+      });
+      const withoutRevision = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'WithoutRevision', {
+        taskDefinitionArn: 'TD_ARN',
+        taskDefinitionArnIncludesRevision: false,
+      });
+      const unset = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'Unset', {
+        taskDefinitionArn: 'TD_ARN',
+      });
+
+      // THEN
+      expect(withRevision.taskDefinitionArnIncludesRevision).toEqual(true);
+      expect(withoutRevision.taskDefinitionArnIncludesRevision).toEqual(false);
+      expect(unset.taskDefinitionArnIncludesRevision).toBeUndefined();
+    });
+
     test('returns a Fargate TaskDefinition that will throw an error when trying to access its networkMode but its networkMode is undefined', () => {
       // GIVEN
       const stack = new cdk.Stack();

--- a/packages/aws-cdk-lib/aws-events-targets/README.md
+++ b/packages/aws-cdk-lib/aws-events-targets/README.md
@@ -23,6 +23,7 @@ Currently supported are:
   - [Run an ECS Task](#run-an-ecs-task)
     - [Tagging Tasks](#tagging-tasks)
     - [Launch type for ECS Task](#launch-type-for-ecs-task)
+    - [Imported Task Definitions without a revision](#imported-task-definitions-without-a-revision)
     - [Assign public IP addresses to tasks](#assign-public-ip-addresses-to-tasks)
     - [Enable Amazon ECS Exec for ECS Task](#enable-amazon-ecs-exec-for-ecs-task)
   - [Run a Redshift query](#schedule-a-redshift-query-serverless-or-cluster)
@@ -611,6 +612,44 @@ rule.addTarget(new targets.EcsTask({
   cluster,
   taskDefinition,
   launchType: ecs.LaunchType.FARGATE,
+}));
+```
+
+### Imported Task Definitions without a revision
+
+When an `EcsTask` target grants the EventBridge rule role permission to call `ecs:RunTask`, the
+resource is scoped to the task definition ARN. If the ARN does not pin a specific revision (e.g.
+`arn:aws:ecs:region:account:task-definition/family`), the permission must be scoped with a `:*`
+revision wildcard so that the latest active revision can be run.
+
+When the ARN is a concrete string, whether it includes a revision is inferred automatically. When
+the ARN is only known at deploy time (for example, when it is imported via `Fn.importValue` or
+passed in as a CloudFormation parameter), its revision cannot be inferred from the string. In that
+case, set `taskDefinitionArnIncludesRevision` on the imported task definition's attributes to record
+whether the ARN includes a revision, so the correct `ecs:RunTask` permission is generated.
+
+```ts
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+declare const cluster: ecs.ICluster;
+
+// The ARN is resolved at deploy time and does not include a revision, so the generated
+// `ecs:RunTask` permission is scoped with a `:*` wildcard.
+const importedTaskDefinition = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(this, 'ImportedTaskDef', {
+  taskDefinitionArn: cdk.Fn.importValue('MyTaskDefinitionArn'),
+  networkMode: ecs.NetworkMode.AWS_VPC,
+  taskRole: iam.Role.fromRoleArn(this, 'TaskRole', 'arn:aws:iam::012345678901:role/MyTaskRole'),
+  taskDefinitionArnIncludesRevision: false,
+});
+
+const rule = new events.Rule(this, 'Rule', {
+  schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+});
+
+rule.addTarget(new targets.EcsTask({
+  cluster,
+  taskDefinition: importedTaskDefinition,
 }));
 ```
 

--- a/packages/aws-cdk-lib/aws-events-targets/lib/ecs-task.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/lib/ecs-task.ts
@@ -351,9 +351,18 @@ export class EcsTask implements events.IRuleTarget {
   }
 
   private createEventRolePolicyStatements(): iam.PolicyStatement[] {
-    // check if there is a taskdefinition revision (arn will end with : followed by digits) included in the arn already
+    // Decide whether the `ecs:RunTask` resource ARN must be scoped with a `:*` revision wildcard.
+    // An ARN that already pins a revision (e.g. `family:1`) is granted as-is, while an ARN that
+    // only refers to the family (e.g. `family`) needs the `:*` wildcard.
     let needsRevisionWildcard = false;
-    if (!cdk.Token.isUnresolved(this.taskDefinition.taskDefinitionArn)) {
+    if (this.taskDefinition.taskDefinitionArnIncludesRevision !== undefined) {
+      // The caller told us explicitly whether the imported ARN includes a revision. This is the
+      // only reliable signal when the ARN is a token (e.g. a CloudFormation parameter or an
+      // `Fn.importValue` result) whose revision cannot be inferred from the string.
+      needsRevisionWildcard = !this.taskDefinition.taskDefinitionArnIncludesRevision;
+    } else if (!cdk.Token.isUnresolved(this.taskDefinition.taskDefinitionArn)) {
+      // Fall back to inspecting the concrete ARN: it ends with `:` followed by digits when a
+      // revision is included.
       const revisionAtEndPattern = /:[0-9]+$/;
       const hasRevision = revisionAtEndPattern.test(this.taskDefinition.taskDefinitionArn);
       needsRevisionWildcard = !hasRevision;

--- a/packages/aws-cdk-lib/aws-events-targets/test/ecs/event-rule-target.test.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/test/ecs/event-rule-target.test.ts
@@ -1194,6 +1194,113 @@ test('Imported task definition with revision uses original arn for policy resour
   template.hasResource('AWS::IAM::Policy', { Properties: policyMatch });
 });
 
+test('Imported task definition with a tokenized ARN and taskDefinitionArnIncludesRevision=false adds wildcard to policy resource', () => {
+  // The ARN is only known at deploy time (e.g. an Fn.importValue), so its revision cannot be
+  // inferred from the string. The explicit flag tells us it does not include a revision.
+  const importedArn = cdk.Fn.importValue('MyTaskDefArn');
+  const taskDefinition = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'TaskDefImport', {
+    taskDefinitionArn: importedArn,
+    taskRole: iam.Role.fromRoleArn(stack, 'RoleImport', 'arn:aws:iam::012345678901:role/MyTaskRole'),
+    networkMode: ecs.NetworkMode.AWS_VPC,
+    taskDefinitionArnIncludesRevision: false,
+  });
+
+  const rule = new events.Rule(stack, 'Rule', {
+    schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+  });
+
+  rule.addTarget(
+    new EcsTask({
+      cluster: cluster,
+      taskDefinition: taskDefinition,
+    }),
+  );
+
+  const policyMatch = Match.objectLike({
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'ecs:RunTask',
+          Resource: {
+            'Fn::Join': ['', [{ 'Fn::ImportValue': 'MyTaskDefArn' }, ':*']],
+          },
+        }),
+      ]),
+    },
+  });
+  const template = Template.fromStack(stack);
+  template.hasResource('AWS::IAM::Policy', { Properties: policyMatch });
+});
+
+test('Imported task definition with a tokenized ARN and taskDefinitionArnIncludesRevision=true uses the ARN as-is', () => {
+  const importedArn = cdk.Fn.importValue('MyTaskDefArn');
+  const taskDefinition = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'TaskDefImport', {
+    taskDefinitionArn: importedArn,
+    taskRole: iam.Role.fromRoleArn(stack, 'RoleImport', 'arn:aws:iam::012345678901:role/MyTaskRole'),
+    networkMode: ecs.NetworkMode.AWS_VPC,
+    taskDefinitionArnIncludesRevision: true,
+  });
+
+  const rule = new events.Rule(stack, 'Rule', {
+    schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+  });
+
+  rule.addTarget(
+    new EcsTask({
+      cluster: cluster,
+      taskDefinition: taskDefinition,
+    }),
+  );
+
+  const policyMatch = Match.objectLike({
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'ecs:RunTask',
+          Resource: { 'Fn::ImportValue': 'MyTaskDefArn' },
+        }),
+      ]),
+    },
+  });
+  const template = Template.fromStack(stack);
+  template.hasResource('AWS::IAM::Policy', { Properties: policyMatch });
+});
+
+test('taskDefinitionArnIncludesRevision overrides the inferred revision when the ARN is a concrete string', () => {
+  // The concrete ARN ends with `:1` (would normally be treated as revision-included), but the
+  // explicit flag forces the `:*` wildcard to be appended.
+  const taskDefinition = ecs.FargateTaskDefinition.fromFargateTaskDefinitionAttributes(stack, 'TaskDefImport', {
+    taskDefinitionArn: 'arn:aws:ecs:us-west-2:012345678901:task-definition/MyTask',
+    taskRole: iam.Role.fromRoleArn(stack, 'RoleImport', 'arn:aws:iam::012345678901:role/MyTaskRole'),
+    networkMode: ecs.NetworkMode.AWS_VPC,
+    taskDefinitionArnIncludesRevision: true,
+  });
+
+  const rule = new events.Rule(stack, 'Rule', {
+    schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+  });
+
+  rule.addTarget(
+    new EcsTask({
+      cluster: cluster,
+      taskDefinition: taskDefinition,
+    }),
+  );
+
+  const policyMatch = Match.objectLike({
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'ecs:RunTask',
+          Resource: taskDefinition.taskDefinitionArn,
+        }),
+      ]),
+    },
+  });
+  const template = Template.fromStack(stack);
+  template.hasResource('AWS::IAM::Policy', { Properties: policyMatch });
+});
+
 test.each([
   [10, 'less than minimum'],
   [201, 'greater than maximum'],


### PR DESCRIPTION
### Issue # (if applicable)

Closes #32485.

### Reason for this change

`fromFargateTaskDefinitionAttributes` / `fromEc2TaskDefinitionAttributes` / `fromTaskDefinitionAttributes` cannot record whether an imported task definition ARN is fully-qualified (`...:task-definition/family:123`) or revision-less (`...:task-definition/family`).

When an `EcsTask` EventBridge target scopes down its `ecs:RunTask` permission (the case from #30390 / #31615), it must grant the exact ARN when a revision is present, or append a `:*` revision wildcard when it is not. Today that decision is made by string-inspecting the ARN:

```ts
if (!cdk.Token.isUnresolved(this.taskDefinition.taskDefinitionArn)) {
  const hasRevision = /:[0-9]+$/.test(this.taskDefinition.taskDefinitionArn);
  needsRevisionWildcard = !hasRevision;
}
```

This breaks when the ARN is only known at deploy time (e.g. `Fn.importValue`, or a CloudFormation parameter): the ARN is an unresolved token, so no revision can be inferred, and the `:*` wildcard is silently omitted even for a revision-less ARN. The maintainer (@ashishdhingra) confirmed this is a valid extension of #30390 / #31615.

### Description of changes

- Added an optional, documented, jsii-friendly `taskDefinitionArnIncludesRevision?: boolean` to `CommonTaskDefinitionAttributes` (so `TaskDefinitionAttributes`, `FargateTaskDefinitionAttributes`, and `Ec2TaskDefinitionAttributes` all inherit it) in `packages/aws-cdk-lib/aws-ecs/lib/base/task-definition.ts`.
- Exposed it as an optional readonly property on the `ITaskDefinition` interface and threaded it through `ImportedTaskDefinition` and all three `from*TaskDefinitionAttributes` import methods.
- Consumed it in `createEventRolePolicyStatements()` in `packages/aws-cdk-lib/aws-events-targets/lib/ecs-task.ts`: when the flag is set it authoritatively decides whether the `:*` wildcard is needed; otherwise it falls back to the existing token/string inspection, so **the default behavior is unchanged**.

**Public API shape**

Per my note on the issue, the preferred shape wasn't specified, so I went with a **boolean flag** (`taskDefinitionArnIncludesRevision`) rather than a separate no-revision ARN field, because it maps directly onto the single decision the grant logic makes and keeps the import surface minimal. I'm happy to **rename it** or switch to a separate field if a maintainer prefers a different shape — feedback welcome.

### Describe any new or updated permissions being added

No new permissions. This changes how the *resource scope* of the existing `ecs:RunTask` permission is computed for the EventBridge `EcsTask` target: a revision-less imported ARN whose value is a deploy-time token is now correctly scoped with a `:*` revision wildcard when `taskDefinitionArnIncludesRevision: false` is supplied.

### Description of how you validated changes

- **Unit tests** — added 3 tests in `aws-events-targets/test/ecs/event-rule-target.test.ts` (tokenized ARN + `false` -> `:*` wildcard; tokenized ARN + `true` -> ARN as-is; concrete ARN with explicit override) and 1 test in `aws-ecs/test/fargate/fargate-task-definition.test.ts` (attribute is recorded / defaults to `undefined`). Full suites pass: 39/39 (events-targets ecs) and 67/67 (ecs task-definition).
- **Integ test** — updated `integ.ecs-imported-task-def` (which imports a family-only ARN built from region/account tokens) to set `taskDefinitionArnIncludesRevision: false`, and regenerated the snapshot. The only functional snapshot change is the `ecs:RunTask` resource going from `.../task-definition/TaskDefinitionA` to `.../task-definition/TaskDefinitionA:*`.
- **Build** — `tsc` compiles the affected packages with 0 errors.
- **README** — documented the new attribute under "Run an ECS Task" in `aws-events-targets/README.md`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
