### PR TITLE
fix(rds): propagate retain-on-update policy

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/cluster.ts
@@ -198,7 +198,7 @@ interface DatabaseClusterBaseProps {
   /**
    * Indicates whether the DB cluster should have deletion protection enabled.
    *
-   * @default - true if `removalPolicy` is RETAIN, `undefined` otherwise, which will not enable deletion protection.
+   * @default - true if `removalPolicy` is RETAIN or RETAIN_ON_UPDATE_OR_DELETE, `undefined` otherwise, which will not enable deletion protection.
    * To disable deletion protection after it has been enabled, you must explicitly set this value to `false`.
    */
   readonly deletionProtection?: boolean;

--- a/packages/aws-cdk-lib/aws-rds/lib/instance.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance.ts
@@ -723,7 +723,7 @@ export interface DatabaseInstanceNewProps {
   /**
    * Indicates whether the DB instance should have deletion protection enabled.
    *
-   * @default - true if ``removalPolicy`` is RETAIN, false otherwise
+   * @default - true if ``removalPolicy`` is RETAIN or RETAIN_ON_UPDATE_OR_DELETE, false otherwise
    */
   readonly deletionProtection?: boolean;
 

--- a/packages/aws-cdk-lib/aws-rds/lib/private/util.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/private/util.ts
@@ -78,10 +78,14 @@ export function engineDescription(engine: IEngine) {
 
 /**
  * By default, deletion protection is disabled.
- * Enable if explicitly provided or if the RemovalPolicy has been set to RETAIN
+ * Enable if explicitly provided or if the RemovalPolicy retains the resource on deletion
  */
 export function defaultDeletionProtection(deletionProtection?: boolean, removalPolicy?: RemovalPolicy): boolean | undefined {
-  return deletionProtection ?? (removalPolicy === RemovalPolicy.RETAIN ? true : undefined);
+  return deletionProtection ?? (
+    removalPolicy === RemovalPolicy.RETAIN || removalPolicy === RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE
+      ? true
+      : undefined
+  );
 }
 
 /**
@@ -193,12 +197,13 @@ export function renderSnapshotCredentials(scope: Construct, credentials?: Snapsh
  * If the basePolicy is:
  *
  *  DESTROY or SNAPSHOT -> DESTROY (snapshot is good enough to recreate)
- *  RETAIN              -> RETAIN  (anything else will lose data or fail to deploy)
- *  (undefined)         -> DESTROY (base policy is assumed to be SNAPSHOT)
+ *  RETAIN                       -> RETAIN  (anything else will lose data or fail to deploy)
+ *  RETAIN_ON_UPDATE_OR_DELETE   -> RETAIN_ON_UPDATE_OR_DELETE
+ *  (undefined)                  -> DESTROY (base policy is assumed to be SNAPSHOT)
  */
 export function helperRemovalPolicy(basePolicy?: RemovalPolicy): RemovalPolicy {
-  return basePolicy === RemovalPolicy.RETAIN
-    ? RemovalPolicy.RETAIN
+  return basePolicy === RemovalPolicy.RETAIN || basePolicy === RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE
+    ? basePolicy
     : RemovalPolicy.DESTROY;
 }
 

--- a/packages/aws-cdk-lib/aws-rds/lib/serverless-cluster.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/serverless-cluster.ts
@@ -4,7 +4,7 @@ import { DatabaseSecret } from './database-secret';
 import { Endpoint } from './endpoint';
 import type { IParameterGroup } from './parameter-group';
 import { DATA_API_ACTIONS } from './perms';
-import { applyDefaultRotationOptions, defaultDeletionProtection, renderCredentials } from './private/util';
+import { applyDefaultRotationOptions, defaultDeletionProtection, helperRemovalPolicy, renderCredentials, renderUnless } from './private/util';
 import type { Credentials, RotationMultiUserOptions, RotationSingleUserOptions, SnapshotCredentials } from './props';
 import type { CfnDBClusterProps } from './rds.generated';
 import { CfnDBCluster } from './rds.generated';
@@ -109,7 +109,7 @@ interface ServerlessClusterNewProps {
   /**
    * Indicates whether the DB cluster should have deletion protection enabled.
    *
-   * @default - true if removalPolicy is RETAIN, false otherwise
+   * @default - true if removalPolicy is RETAIN or RETAIN_ON_UPDATE_OR_DELETE, false otherwise
    */
   readonly deletionProtection?: boolean;
 
@@ -472,7 +472,7 @@ abstract class ServerlessClusterNew extends ServerlessClusterBase {
         description: `Subnets for ${id} database`,
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets,
-        removalPolicy: props.removalPolicy === RemovalPolicy.RETAIN ? props.removalPolicy : undefined,
+        removalPolicy: renderUnless(helperRemovalPolicy(props.removalPolicy), RemovalPolicy.DESTROY),
       });
 
       this.securityGroups = props.securityGroups ?? [

--- a/packages/aws-cdk-lib/aws-rds/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/cluster.test.ts
@@ -2529,7 +2529,10 @@ describe('cluster', () => {
     });
   });
 
-  test("sets the retention policy of the SubnetGroup to 'Retain' if the Cluster is created with 'Retain'", () => {
+  test.each([
+    [RemovalPolicy.RETAIN, 'Retain', 'Retain'],
+    [RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE, 'RetainExceptOnCreate', 'Retain'],
+  ])('propagates Cluster RemovalPolicy \'%s\' to its helper resources', (removalPolicy, deletionPolicy, updateReplacePolicy) => {
     const stack = new cdk.Stack();
     const vpc = new ec2.Vpc(stack, 'Vpc');
 
@@ -2540,12 +2543,19 @@ describe('cluster', () => {
         instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.LARGE),
         vpc,
       },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy,
     });
 
     Template.fromStack(stack).hasResource('AWS::RDS::DBSubnetGroup', {
-      DeletionPolicy: 'Retain',
-      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: deletionPolicy,
+      UpdateReplacePolicy: updateReplacePolicy,
+    });
+    Template.fromStack(stack).allResources('AWS::RDS::DBInstance', {
+      DeletionPolicy: deletionPolicy,
+      UpdateReplacePolicy: updateReplacePolicy,
+    });
+    Template.fromStack(stack).hasResourceProperties('AWS::RDS::DBCluster', {
+      DeletionProtection: true,
     });
   });
 

--- a/packages/aws-cdk-lib/aws-rds/test/instance.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/instance.test.ts
@@ -2654,10 +2654,11 @@ describe('instance', () => {
 });
 
 test.each([
-  [cdk.RemovalPolicy.RETAIN, 'Retain', 'Retain'],
-  [cdk.RemovalPolicy.SNAPSHOT, 'Snapshot', Match.absent()],
-  [cdk.RemovalPolicy.DESTROY, 'Delete', Match.absent()],
-])('if Instance RemovalPolicy is \'%s\', the instance has DeletionPolicy \'%s\' and the DBSubnetGroup has \'%s\'', (instanceRemovalPolicy, instanceValue, subnetValue) => {
+  [cdk.RemovalPolicy.RETAIN, 'Retain', 'Retain', 'Retain', 'Retain', true],
+  [cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE, 'RetainExceptOnCreate', 'Retain', 'RetainExceptOnCreate', 'Retain', true],
+  [cdk.RemovalPolicy.SNAPSHOT, 'Snapshot', 'Snapshot', Match.absent(), Match.absent(), Match.absent()],
+  [cdk.RemovalPolicy.DESTROY, 'Delete', 'Delete', Match.absent(), Match.absent(), Match.absent()],
+])('propagates Instance RemovalPolicy \'%s\' to its DBSubnetGroup', (instanceRemovalPolicy, instanceDeletionPolicy, instanceUpdateReplacePolicy, subnetDeletionPolicy, subnetUpdateReplacePolicy, deletionProtection) => {
   // GIVEN
   stack = new cdk.Stack();
   vpc = new ec2.Vpc(stack, 'VPC');
@@ -2674,13 +2675,16 @@ test.each([
 
   // THEN
   Template.fromStack(stack).hasResource('AWS::RDS::DBInstance', {
-    DeletionPolicy: instanceValue,
-    UpdateReplacePolicy: instanceValue,
+    Properties: {
+      DeletionProtection: deletionProtection,
+    },
+    DeletionPolicy: instanceDeletionPolicy,
+    UpdateReplacePolicy: instanceUpdateReplacePolicy,
   });
 
   Template.fromStack(stack).hasResource('AWS::RDS::DBSubnetGroup', {
-    DeletionPolicy: subnetValue,
-    UpdateReplacePolicy: subnetValue,
+    DeletionPolicy: subnetDeletionPolicy,
+    UpdateReplacePolicy: subnetUpdateReplacePolicy,
   });
 });
 

--- a/packages/aws-cdk-lib/aws-rds/test/serverless-cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/serverless-cluster.test.ts
@@ -140,19 +140,25 @@ describe('serverless cluster', () => {
     });
   });
 
-  test("sets the retention policy of the SubnetGroup to 'Retain' if the Serverless Cluster is created with 'Retain'", () => {
+  test.each([
+    [cdk.RemovalPolicy.RETAIN, 'Retain', 'Retain'],
+    [cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE, 'RetainExceptOnCreate', 'Retain'],
+  ])('propagates Serverless Cluster RemovalPolicy \'%s\' to its SubnetGroup', (removalPolicy, deletionPolicy, updateReplacePolicy) => {
     const stack = new cdk.Stack();
     const vpc = new ec2.Vpc(stack, 'Vpc');
 
     new ServerlessCluster(stack, 'Cluster', {
       engine: DatabaseClusterEngine.AURORA_MYSQL,
       vpc,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy,
     });
 
     Template.fromStack(stack).hasResource('AWS::RDS::DBSubnetGroup', {
-      DeletionPolicy: 'Retain',
-      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: deletionPolicy,
+      UpdateReplacePolicy: updateReplacePolicy,
+    });
+    Template.fromStack(stack).hasResourceProperties('AWS::RDS::DBCluster', {
+      DeletionProtection: true,
     });
   });
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #37780.

### Reason for this change

`RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE` is applied to the primary RDS resource but currently falls through to `DESTROY` for helper subnet groups and cluster instances. It also does not enable the same default deletion protection as `RETAIN`. This leaves related resources with inconsistent lifecycle behavior.

### Description of changes

- preserve `RETAIN_ON_UPDATE_OR_DELETE` in the shared helper-removal-policy calculation
- enable default deletion protection for both retaining removal policies
- use the shared helper logic for `ServerlessCluster` subnet groups
- update the public deletion-protection defaults
- cover database instances, database clusters, and serverless clusters, including both CloudFormation policy fields

The existing `DESTROY`, `SNAPSHOT`, and `RETAIN` behavior remains covered and unchanged.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- `tsc -p tsconfig.json --noEmit --pretty false` in `packages/aws-cdk-lib`
- ESLint on all seven modified source and test files
- focused removal-policy regression tests: 8 passed across `instance.test.ts`, `cluster.test.ts`, and `serverless-cluster.test.ts`
- full `cluster.test.ts`: 254 passed
- full `instance.test.ts` and `serverless-cluster.test.ts`: 207 passed
- `git diff --check`

The local full jsii assembly reached model generation after compiling the package, then the jsii compiler exited with `Maximum call stack size exceeded`; the TypeScript check, lint, and targeted Jest suites above completed successfully.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
