### PR TITLE
chore(ecs): import existing services example is not compiled

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs/README.md
+++ b/packages/aws-cdk-lib/aws-ecs/README.md
@@ -1140,26 +1140,26 @@ Since AWS has changed the [ARN format for ECS](https://docs.aws.amazon.com/Amazo
 feature flag `@aws-cdk/aws-ecs:arnFormatIncludesClusterName` must be enabled to use the new ARN format.
 The feature flag changes behavior for the entire CDK project. Therefore it is not possible to mix the old and the new format in one CDK project.
 
-```tss
+```ts
 declare const cluster: ecs.Cluster;
 
 // Import service from EC2 service attributes
-const service = ecs.Ec2Service.fromEc2ServiceAttributes(this, 'EcsService', {
+const ec2ServiceFromAttributes = ecs.Ec2Service.fromEc2ServiceAttributes(this, 'Ec2ServiceFromAttributes', {
   serviceArn: 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service',
   cluster,
 });
 
 // Import service from EC2 service ARN
-const service = ecs.Ec2Service.fromEc2ServiceArn(this, 'EcsService', 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
+const ec2ServiceFromArn = ecs.Ec2Service.fromEc2ServiceArn(this, 'Ec2ServiceFromArn', 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
 
 // Import service from Fargate service attributes
-const service = ecs.FargateService.fromFargateServiceAttributes(this, 'EcsService', {
+const fargateServiceFromAttributes = ecs.FargateService.fromFargateServiceAttributes(this, 'FargateServiceFromAttributes', {
   serviceArn: 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service',
   cluster,
 });
 
 // Import service from Fargate service ARN
-const service = ecs.FargateService.fromFargateServiceArn(this, 'EcsService', 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
+const fargateServiceFromArn = ecs.FargateService.fromFargateServiceArn(this, 'FargateServiceFromArn', 'arn:aws:ecs:us-west-2:123456789012:service/my-http-service');
 ```
 
 ### Availability Zone rebalancing


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The example showing how to import existing EC2 and Fargate services in the aws-ecs README is fenced as ```` ```tss ```` rather than ```` ```ts ````. Rosetta only picks up `ts` blocks, so this one was silently skipped: it was never compiled, and it was never transliterated. Readers of the API reference in Python, Java, C# or Go see the raw TypeScript instead of an example in their own language.

Correcting the fence alone would break the build, because the example does not actually compile. It declares `const service` four times in the same scope, which TypeScript rejects as a redeclared block-scoped variable, and it passes the same `EcsService` construct id to all four imports, which would collide at synth time if anyone copied the snippet as written. The bad fence is what allowed both problems to go unnoticed for as long as they did, so fixing the fence and fixing the example belong together.

### Description of changes

Changed the fence from `tss` to `ts` so Rosetta compiles and translates the block.

Gave each of the four imports its own variable name and its own construct id, derived from which factory method it demonstrates (`ec2ServiceFromAttributes`, `ec2ServiceFromArn`, `fargateServiceFromAttributes`, `fargateServiceFromArn`). Distinct names are required for the snippet to compile at all, and naming them after the factory method keeps the example readable, since the whole point of the block is to contrast the four ways of importing a service. Distinct construct ids make the snippet correct if a reader copies it verbatim.

No source or behaviour changes; this is documentation only.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Type-checked the snippet by expanding it into the `rosetta/aws_ecs/default.ts-fixture` and compiling the result against `aws-cdk-lib`, mirroring what Rosetta does. To confirm the check was actually meaningful rather than vacuously passing, I ran the same harness against the original snippet first: it reports `TS2451: Cannot redeclare block-scoped variable 'service'` twice. The updated snippet reports no errors.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
