### PR TITLE
fix(core): synth crashes with EISDIR on cloud-placeholder directories in cdk.out

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
@@ -459,9 +459,20 @@ function collectFilePaths(dir: string): string[] {
         // through symlinks (avoids following links out of the cloud assembly / cycles).
         walk(full);
       } else if (entry.isFile() || entry.isSymbolicLink()) {
-        // Collect regular files and symlinks (including symlink-to-directory). The
-        // symlink is hashed by its target path in hashFile(), never dereferenced.
-        results.push(full);
+        // On Windows, readdir classifies every reparse point as a symlink, but lstat only
+        // agrees for the tags libuv can readlink() (regular symlinks, junctions with a
+        // drive-letter target, WSL/AppExec links). Cloud placeholders (OneDrive/Dropbox
+        // IO_REPARSE_TAG_CLOUD_*), ProjFS, dedup, WCI, and volume-GUID junctions come
+        // back from lstat as plain directories: there is nothing to hash and a
+        // validation plugin cannot meaningfully "modify" one, so skip them. Enumerating
+        // reparse tags is not viable — the tag namespace is vendor-defined and
+        // open-ended — so we gate on what lstat says the entry actually is.
+        const st = fs.lstatSync(full);
+        if (st.isFile() || st.isSymbolicLink()) {
+          // Regular files and real symlinks (including symlink-to-directory). The
+          // symlink is hashed by its target path in hashFile(), never dereferenced.
+          results.push(full);
+        }
       }
     }
   }

--- a/packages/aws-cdk-lib/core/test/validation/synthesis-validation-symlink.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/synthesis-validation-symlink.test.ts
@@ -61,3 +61,106 @@ describe('policy validation plugins tolerate symlinks in the cloud assembly (#38
     expect(fs.lstatSync(seedLink).isSymbolicLink()).toBe(true);
   });
 });
+
+/**
+ * Regression test for https://github.com/aws/aws-cdk/issues/38653
+ *
+ * On Windows, `cdk.out` can contain **directory reparse points** whose tag libuv
+ * cannot `readlink()` — Cloud Files placeholders (OneDrive/Dropbox,
+ * IO_REPARSE_TAG_CLOUD_*), ProjFS, dedup, WCI, volume-GUID junctions, etc. For
+ * these, libuv's `fs__scandir` classifies the entry as a symlink in
+ * `readdirSync({ withFileTypes: true })` (because it checks
+ * FILE_ATTRIBUTE_REPARSE_POINT before FILE_ATTRIBUTE_DIRECTORY), but
+ * `fs__readlink_handle` refuses the tag and `fs__stat_impl` retries with
+ * do_lstat = 0, so `lstatSync()` reports it as an ordinary directory.
+ *
+ * `hashFile()` in `synthesis-validation.ts` then calls `readFileSync()` on what
+ * is really a directory and throws `EISDIR`, crashing `cdk synth`. The prior
+ * fix in #38299 only covers real symlinks-to-directory on POSIX; it does not
+ * cover this case because it structurally relies on `lstat` reporting the path
+ * as a symlink, which it never does for these tags.
+ *
+ * We can't easily manufacture a real reparse point on POSIX CI (would need
+ * `mountvol` on Windows, or a cloud sync engine). So we capture the invariant
+ * with a mock: force `readdirSync({ withFileTypes: true })` to report a real
+ * directory as a symbolic-link entry, leave `lstatSync` honest, and assert
+ * `app.synth()` no longer crashes.
+ */
+describe('policy validation plugins tolerate readdir/lstat disagreement (#38653)', () => {
+  let outdir: string;
+  let originalReaddirSync: typeof fs.readdirSync | undefined;
+
+  beforeEach(() => {
+    outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-reparse-asm-'));
+  });
+
+  afterEach(() => {
+    if (originalReaddirSync) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('fs').readdirSync = originalReaddirSync;
+      originalReaddirSync = undefined;
+    }
+    fs.rmSync(outdir, { recursive: true, force: true });
+  });
+
+  test('synth succeeds when readdir classifies a directory as a symlink (Windows reparse-point behavior)', () => {
+    const app = new App({
+      outdir,
+      policyValidationBeta1: [
+        { name: 'noop', validate: () => ({ success: true, violations: [] }) },
+      ],
+    });
+    const stack = new Stack(app, 'Stack');
+    new CfnResource(stack, 'Res', {
+      type: 'Test::Resource::Fake',
+      properties: { result: 'success' },
+    });
+
+    // Seed a real directory that the pre-plugin snapshot in snapshotFileHashes()
+    // will walk. We give it a child so its Dirent survives readdir.
+    const reparseLookalike = path.join(outdir, 'reparse-lookalike');
+    fs.mkdirSync(reparseLookalike);
+    fs.writeFileSync(path.join(reparseLookalike, 'child.txt'), 'inside');
+
+    // Force libuv-on-Windows behavior for this one entry: readdir says "symlink",
+    // lstat (untouched) says "directory". Any other readdir call — different
+    // path, no withFileTypes option — passes through unchanged. jest.spyOn on
+    // the fs module doesn't work in Node 20 (readdirSync is exposed via a
+    // non-configurable getter on the ES-module namespace), so we mutate the
+    // underlying CommonJS module.exports directly and restore in afterEach.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fsMutable: any = require('fs');
+    originalReaddirSync = fsMutable.readdirSync;
+    const passthrough = originalReaddirSync;
+    fsMutable.readdirSync = ((...args: any[]) => {
+      const [dirPath, options] = args;
+      const entries = (passthrough as any).apply(fsMutable, args);
+      const wantsFileTypes = options && typeof options === 'object' && options.withFileTypes;
+      if (!wantsFileTypes || typeof dirPath !== 'string' || path.resolve(dirPath) !== path.resolve(outdir)) {
+        return entries;
+      }
+      return (entries as fs.Dirent[]).map((entry) => {
+        if (entry.name !== 'reparse-lookalike') return entry;
+        // Match what libuv reports for a directory reparse point whose tag
+        // it cannot readlink(): isSymbolicLink() === true, isDirectory() === false.
+        const proxy = Object.create(entry);
+        proxy.isSymbolicLink = () => true;
+        proxy.isDirectory = () => false;
+        proxy.isFile = () => false;
+        return proxy;
+      });
+    }) as typeof fs.readdirSync;
+
+    // Before the fix this threw "EISDIR: illegal operation on a directory, read"
+    // because hashFile() reached readFileSync() on the seeded directory.
+    expect(() => app.synth()).not.toThrow();
+
+    // Guard against a vacuous pass: the invariant that triggers the bug must
+    // still hold — readdir reports "symlink", lstat reports "directory".
+    const spoofedEntry = (fs.readdirSync(outdir, { withFileTypes: true }) as fs.Dirent[])
+      .find((e) => e.name === 'reparse-lookalike');
+    expect(spoofedEntry?.isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(reparseLookalike).isDirectory()).toBe(true);
+    expect(fs.lstatSync(reparseLookalike).isSymbolicLink()).toBe(false);
+  });
+});


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38653.

### Reason for this change

Since `aws-cdk-lib` v2.262.0, `cdk synth` crashes with

```
Error: EISDIR: illegal operation on a directory, read
    at hashFile (.../core/lib/private/synthesis-validation.ts)
    at snapshotFileHashes (...)
    at doInvokeValidationPlugins (...)
    at validateTemplates (...)
```

on any project whose `cdk.out` contains a **directory reparse point that libuv cannot `readlink()`** — most commonly Windows Cloud Files placeholders (`IO_REPARSE_TAG_CLOUD_*`, e.g. `0x9000201A`) that OneDrive/Dropbox stamp onto stale `asset.<hash>/` directories, but also ProjFS, dedup, WCI, and volume-GUID junctions. Because CDK never cleans `cdk.out`, long-lived projects accumulate stale `asset.<hash>/` dirs for years, so this presents as "only my old projects are broken."

On Windows, `readdirSync(..., { withFileTypes: true })` and `lstatSync()` disagree about these paths:

* `readdirSync` — libuv's `fs__scandir` checks `FILE_ATTRIBUTE_REPARSE_POINT` **before** `FILE_ATTRIBUTE_DIRECTORY`, so the entry is reported as `isSymbolicLink() === true`, `isDirectory() === false`. It is never recursed into, and lands in the file-or-symlink branch.
* `lstatSync` — libuv's `fs__readlink_handle` only resolves four tags (`IO_REPARSE_TAG_SYMLINK`, `IO_REPARSE_TAG_LX_SYMLINK`, `IO_REPARSE_TAG_MOUNT_POINT` with a drive-letter target, `IO_REPARSE_TAG_APPEXECLINK`). Everything else sets `ERROR_SYMLINK_NOT_SUPPORTED`, and `fs__stat_impl` retries with `do_lstat = 0`, so the path is reported as an ordinary directory with `isSymbolicLink() === false`.

readdir says "link", lstat says "directory", and `hashFile()` hands the directory to `fs.readFileSync()` → `EISDIR`.

The prior fix in #38299 (be0fdc4c8) only covers **real** symlinks-to-directory, where lstat agrees the entry is a symlink. It does not help here, and enumerating the reparse tags libuv *can* resolve structurally excludes cloud placeholders and the other tags above.

### Description of changes

`collectFilePaths()` is the sole producer of the paths that reach `hashFile()`. It now gates on what `lstat()` says the entry **is**, rather than on what readdir says it **is not**:

```ts
} else if (entry.isFile() || entry.isSymbolicLink()) {
  const st = fs.lstatSync(full);
  if (st.isFile() || st.isSymbolicLink()) {
    results.push(full);
  }
}
```

`hashFile()` already calls `lstat` on the same paths, so this is one extra `lstat` per real file, not a design change. Filtering at the sole producer fixes both the initial `snapshotFileHashes()` snapshot and the `hasModifiedPreExistingFiles()` re-hash. `fileOrSymlinkExists()` already tolerates these entries.

**Alternatives rejected:**

* **Reparse-tag allowlist.** The set of tags libuv cannot resolve is vendor-defined and open-ended (cloud engines, dedup variants, WCI, ProjFS, custom filters), so any allowlist keeps producing this bug as new tags ship.
* **`try/catch` around `hashFile()` alone.** Works as defence-in-depth, but leaves `hasModifiedPreExistingFiles()` re-hashing a path that never round-trips and can misreport stale reparse entries as "modified by a validation plugin." Filtering at collection is the cleaner primary fix.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added a regression test in `core/test/validation/synthesis-validation-symlink.test.ts`. Reproducing a real reparse point on POSIX CI would need `mountvol` (Windows, elevated) or a cloud sync engine, so the test captures the unit-level invariant from the issue: it mocks `readdirSync({ withFileTypes: true })` to report a real directory as a symbolic-link entry (matching what libuv reports for `IO_REPARSE_TAG_CLOUD_2`), leaves `lstat` honest, and asserts `app.synth()` no longer throws. A vacuous-pass guard asserts the readdir/lstat disagreement still holds.

* The new test **fails on current `main`** with the exact `EISDIR: illegal operation on a directory, read` from the issue, and **passes with this change**.
* Full `core/test/validation/` suite green:

```
Test Suites: 4 passed, 4 total
Tests:       76 passed, 76 total
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

