### PR TITLE
docs(cx-api): cleanupTemporaryDirectories example names a module that does not exist

### DIFF
--- a/packages/aws-cdk-lib/cx-api/lib/legacy-moved.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/legacy-moved.ts
@@ -189,7 +189,7 @@ export declare class CloudAssembly implements cxschema.ICloudAssembly {
    * ```js
    * module.exports = {
    *   // ...
-   *   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-cleanup'],
+   *   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
    * };
    * ```
    */

--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -40,6 +40,7 @@
       "ts-node ./scripts/verify-imports-resolve-same.ts",
       "ts-node ./scripts/verify-imports-shielded.ts",
       "ts-node ./scripts/verify-exports-exist.ts",
+      "ts-node ./scripts/verify-doc-examples-resolve.ts",
       "ts-node ./cx-api/build-tools/flag-report.ts",
       "check-peer-dependencies .",
       "env QUIET=1 lazify ."

--- a/packages/aws-cdk-lib/scripts/verify-doc-examples-resolve.ts
+++ b/packages/aws-cdk-lib/scripts/verify-doc-examples-resolve.ts
@@ -1,0 +1,116 @@
+/**
+ * Verify that every `aws-cdk-lib/<subpath>` specifier used in a documentation example is a
+ * subpath that package.json actually exports.
+ *
+ * Examples are meant to be copy-pasted, so a specifier naming a module we do not export leaves
+ * the reader with an import that cannot resolve. Rosetta compiles `ts` fences and would catch a
+ * bad `import` statement, but a specifier can also appear as a plain string -- a
+ * `setupFilesAfterEnv` entry, for instance -- and a string is not an import, so nothing checks it.
+ *
+ * What gets checked: fenced code blocks in `.md` files, and fenced code blocks inside doc
+ * comments in `.ts` sources. Anything outside a fence is left alone, because `@see` tags and
+ * prose legitimately mention jsii type names and repository file paths, neither of which is a
+ * module specifier.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SPECIFIER = /aws-cdk-lib\/[A-Za-z0-9._/-]+/g;
+const SKIP_DIRS = new Set(['node_modules', 'test', 'build-tools']);
+
+interface Mention {
+  readonly specifier: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+const pkgDir = path.resolve(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf-8'));
+const exportedSubpaths = new Set(Object.keys(pkg.exports ?? {}));
+
+function documentationFiles(dir: string, into: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) {
+        documentationFiles(full, into);
+      }
+    } else if (entry.isFile() && isDocumentationFile(entry.name)) {
+      into.push(full);
+    }
+  }
+  return into;
+}
+
+function isDocumentationFile(name: string): boolean {
+  if (name.endsWith('.md')) {
+    return true;
+  }
+  return name.endsWith('.ts') && !name.endsWith('.generated.ts') && !name.endsWith('.d.ts');
+}
+
+/**
+ * Collect the specifiers mentioned inside fenced code blocks.
+ *
+ * For markdown the whole file counts; for TypeScript only fences inside a doc comment do.
+ */
+function mentionsInExamples(file: string): Mention[] {
+  const markdown = file.endsWith('.md');
+  const mentions: Mention[] = [];
+
+  let inDocComment = markdown;
+  let inFence = false;
+
+  fs.readFileSync(file, 'utf-8').split('\n').forEach((text, index) => {
+    if (!markdown && text.includes('/**')) {
+      inDocComment = true;
+      inFence = false;
+    }
+
+    // A fence delimiter opens or closes a block and never carries a specifier itself. In a doc
+    // comment the delimiter is preceded by the comment's leading asterisk.
+    const isFenceDelimiter = markdown ? /^\s*```/.test(text) : /^\s*\*?\s*```/.test(text);
+
+    if (inDocComment && isFenceDelimiter) {
+      inFence = !inFence;
+    } else if (inDocComment && inFence) {
+      for (const match of text.matchAll(SPECIFIER)) {
+        mentions.push({
+          specifier: match[0].replace(/\.+$/, ''),
+          file: path.relative(pkgDir, file),
+          line: index + 1,
+        });
+      }
+    }
+
+    if (!markdown && text.includes('*/')) {
+      inDocComment = false;
+      inFence = false;
+    }
+  });
+
+  return mentions;
+}
+
+const mentions = documentationFiles(pkgDir).flatMap(mentionsInExamples);
+
+// A scan that matches nothing would report success no matter how broken the docs are, so treat
+// finding no specifiers at all as the scan itself being broken.
+if (mentions.length === 0) {
+  console.error('Found no `aws-cdk-lib/...` specifiers in any documentation example.');
+  console.error('That is not plausible -- this check is no longer looking in the right places.');
+  process.exitCode = 1;
+} else {
+  const dangling = mentions.filter((m) => !exportedSubpaths.has(`.${m.specifier.slice('aws-cdk-lib'.length)}`));
+
+  if (dangling.length > 0) {
+    console.error(`Found ${dangling.length} documentation example(s) naming a module that is not exported:\n`);
+    for (const m of dangling) {
+      console.error(`  ${m.file}:${m.line} -> ${m.specifier}`);
+    }
+    console.error('\nEither correct the specifier, or add the subpath to the "exports" map in package.json.');
+    process.exitCode = 1;
+  } else {
+    console.log(`All ${mentions.length} documentation example specifier(s) resolve to an exported subpath.`);
+  }
+}


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The doc comment on `CloudAssembly.cleanupTemporaryDirectories` tells the reader how to get temporary Cloud Assembly directories cleaned up under jest. It offers two equivalent ways to do it, and they name different modules:

```
$ npx jest --setupFilesAfterEnv aws-cdk-lib/testhelpers/jest-autoclean
```

```js
module.exports = {
  // ...
  setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-cleanup'],
};
```

The first one is right. The second names a module that does not exist and never has. Since `aws-cdk-lib` declares an `exports` map, that specifier does not merely fail to find a file — Node refuses to resolve it at all:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './testhelpers/jest-cleanup'
is not defined by "exports" in .../node_modules/aws-cdk-lib/package.json
```

What makes this worth fixing is the situation the reader is usually in when they find it. An `App` constructed without an `outdir` synthesizes into a fresh `mkdtemp` directory under `os.tmpdir()` and registers it for cleanup on process exit — and jest never fires Node's `exit` event ([jestjs/jest#10927](https://github.com/jestjs/jest/issues/10927)), which is exactly what this doc comment exists to explain. So a jest suite that synthesizes leaks one assembly directory per synthesis on a completely green, exit-0 run. On a suite of roughly 2,300 tests that came to 862 leftover directories and about 7,000 inodes.

That is a nasty thing to diagnose, because it exhausts inodes rather than bytes: `df -h` reports the filesystem nearly empty right up until every process that wants a temporary file starts failing with `ENOSPC`. Someone who works that out and reaches for the documented fix then copies the `jest.config.js` snippet and gets an unresolvable module.

### Description of changes

Two parts.

**The correction.** `jest-cleanup` → `jest-autoclean` in the `jest.config.js` example, so both examples in the doc comment name the module that actually ships.

**A check that would have caught it.** `packages/aws-cdk-lib/scripts/verify-doc-examples-resolve.ts`, wired into `cdk-build.post` beside the existing `verify-exports-exist.ts`. It asserts that every `aws-cdk-lib/<subpath>` specifier appearing in a fenced code block — in a markdown file, or in a doc comment — is a subpath the package exports. Rosetta compiles `ts` fences and would have caught a bad `import` statement, but this specifier is a plain string inside a config object rather than an import, so nothing verified it.

Happy to split these into two PRs if you'd prefer the docs fix on its own.

Alternatives considered and rejected:

- **Adding a `jest-cleanup` alias to the `exports` map** so the documented name resolves. Rejected because the name has never worked, so there is no existing usage to preserve. `testhelpers/jest-autoclean.ts` was created under that name in #36226 and has never been renamed, and this doc comment line is the only mention of `jest-cleanup` anywhere in the repository's history. Adding the alias would promote a typo to a permanent public subpath.
- **Checking every `aws-cdk-lib/...` string**, not just the ones inside fences. Rejected because it reports 17 false positives on current `main` — jsii type names (`aws-cdk-lib/aws-s3.CfnBucket`), repository paths (`aws-cdk-lib/core/lib/context-provider.ts`), file references (`aws-cdk-lib/README.md`). Silencing those needs an allowlist that would go stale. Restricting to fenced examples checks 803 specifiers with no false positives.
- **Asserting only that this one specifier resolves.** Rejected: it pins one string and catches nothing else.

One thing worth flagging: `legacy-moved.ts` re-declares these types and copies their doc comments from `@aws-cdk/cloud-assembly-api`, which lives in [aws/aws-cdk-cli](https://github.com/aws/aws-cdk-cli). Its copy of this doc comment has the same typo, so this PR fixes what `aws-cdk-lib` users see while the upstream copy still needs the same one-word change. Happy to raise that separately.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Wrote the check first and confirmed it fails on unmodified `main`, for the right reason:

```
$ ts-node ./scripts/verify-doc-examples-resolve.ts
Found 1 documentation example(s) naming a module that is not exported:

  cx-api/lib/legacy-moved.ts:192 -> aws-cdk-lib/testhelpers/jest-cleanup

Either correct the specifier, or add the subpath to the "exports" map in package.json.
$ echo $?
1
```

Then applied the correction:

```
$ ts-node ./scripts/verify-doc-examples-resolve.ts
All 803 documentation example specifier(s) resolve to an exported subpath.
$ echo $?
0
```

Three further checks on the check itself:

- **It is general, not pinned to this file.** Injecting a bogus specifier into a fenced doc comment in `aws-lambda/lib/function.ts` and into a fence in `aws-lambda/README.md` produced both findings, at the correct line numbers.
- **It cannot pass vacuously.** Blinding the specifier regex makes it report "found no specifiers at all" and exit 1, rather than reporting success over an empty scan.
- **The premise holds.** `require.resolve('aws-cdk-lib/testhelpers/jest-cleanup')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`; `require.resolve('aws-cdk-lib/testhelpers/jest-autoclean')` resolves to `testhelpers/jest-autoclean.js`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

*No issue was open for this; happy to file one if you would rather have it tracked.*
