### PR TITLE
fix: StateMachine timeout now applies to StringDefinitionBody

### DIFF
--- a/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/lib/state-machine.ts
@@ -795,7 +795,10 @@ export class FileDefinitionBody extends DefinitionBody {
     super();
   }
 
-  public bind(scope: Construct, _sfnPrincipal: iam.IPrincipal, _sfnProps: StateMachineProps, _graph?: StateGraph): DefinitionConfig {
+  public bind(scope: Construct, _sfnPrincipal: iam.IPrincipal, sfnProps: StateMachineProps, _graph?: StateGraph): DefinitionConfig {
+    if (sfnProps.timeout) {
+      throw new Error('timeout is not supported with FileDefinitionBody. Use StringDefinitionBody or ChainDefinitionBody instead.');
+    }
     const asset = new s3_assets.Asset(scope, 'DefinitionBody', {
       path: this.path,
       ...this.options,
@@ -814,9 +817,13 @@ export class StringDefinitionBody extends DefinitionBody {
     super();
   }
 
-  public bind(_scope: Construct, _sfnPrincipal: iam.IPrincipal, _sfnProps: StateMachineProps, _graph?: StateGraph): DefinitionConfig {
+  public bind(_scope: Construct, _sfnPrincipal: iam.IPrincipal, sfnProps: StateMachineProps, _graph?: StateGraph): DefinitionConfig {
+    const definition = JSON.parse(this.body);
+    if (sfnProps.timeout) {
+      definition.TimeoutSeconds = sfnProps.timeout.toSeconds();
+    }
     return {
-      definitionString: this.body,
+      definitionString: JSON.stringify(definition),
     };
   }
 }

--- a/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine.test.ts
+++ b/packages/aws-cdk-lib/aws-stepfunctions/test/state-machine.test.ts
@@ -1531,4 +1531,40 @@ describe('State Machine', () => {
       }),
     });
   });
+
+  test('Instantiate StateMachine with timeout using string definition', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new sfn.StateMachine(stack, 'MyStateMachine', {
+      stateMachineName: 'MyStateMachine',
+      definitionBody: sfn.DefinitionBody.fromString('{"StartAt":"Pass","States":{"Pass":{"Type":"Pass","End":true}}}'),
+      timeout: cdk.Duration.seconds(300),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::StepFunctions::StateMachine', {
+      StateMachineName: 'MyStateMachine',
+      DefinitionString: Match.stringLikeRegexp('.*"TimeoutSeconds":300.*'),
+    });
+  });
+
+  test('Instantiate StateMachine with timeout using chain definition', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+
+    // WHEN
+    new sfn.StateMachine(stack, 'MyStateMachine', {
+      stateMachineName: 'MyStateMachine',
+      definitionBody: sfn.DefinitionBody.fromChainable(sfn.Chain.start(new sfn.Pass(stack, 'Pass'))),
+      timeout: cdk.Duration.seconds(300),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::StepFunctions::StateMachine', {
+      StateMachineName: 'MyStateMachine',
+      DefinitionString: Match.stringLikeRegexp('.*"TimeoutSeconds":300.*'),
+    });
+  });
 });


### PR DESCRIPTION
Fixes #37150 - The timeout property was only being applied to ChainDefinitionBody, not to other definition body types like StringDefinitionBody. This caused unexpected behavior for users providing ASL definitions via string.

Changes:
- Modified StringDefinitionBody.bind() to inject TimeoutSeconds into the definition when timeout is specified
- Added validation to FileDefinitionBody to throw a clear error when timeout is specified (not supported due to file-based nature)
- Added regression tests for both StringDefinitionBody and ChainDefinitionBody with timeout

The timeout is a top-level ASL property (TimeoutSeconds) that controls the maximum execution time for the entire state machine, distinct from individual state timeouts.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
