### PR TITLE
chore(elbv2): add RFC 9151 (CNSA 1.0) SSL security policies for ALB and NLB

### DIFF
--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/enums.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/enums.ts
@@ -306,6 +306,80 @@ export enum SslPolicy {
   FIPS_TLS13_10_PQ = 'ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09',
 
   /**
+   * TLS 1.3 only, RFC 9151 (CNSA 1.0) strict policy. FIPS-compliant.
+   *
+   * Supports the single cipher TLS_AES_256_GCM_SHA384. Use a strict policy only when all
+   * clients can negotiate RFC 9151 algorithms.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_13 = 'ELBSecurityPolicy-TLS13-1-3-RFC9151-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) strict policy. FIPS-compliant.
+   *
+   * Adds the ECDHE-ECDSA and ECDHE-RSA AES256-GCM-SHA384 ciphers on top of
+   * {@link RFC9151_TLS13_13} for TLS 1.2 clients. Use a strict policy only when all clients
+   * can negotiate RFC 9151 algorithms.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12 = 'ELBSecurityPolicy-TLS13-1-2-RFC9151-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) strict policy. FIPS-compliant.
+   *
+   * Same as {@link RFC9151_TLS13_12} plus the non-ECDHE AES256-GCM-SHA384 cipher (extended
+   * cipher suite 0). Use a strict policy only when all clients can negotiate RFC 9151 algorithms.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12_EXT0 = 'ELBSecurityPolicy-TLS13-1-2-Ext0-RFC9151-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) interoperability policy. FIPS-compliant.
+   *
+   * Interop policies mix RFC 9151 and non-RFC 9151 ciphers so clients can transition gradually.
+   * This variant adds the AES128-GCM-SHA256 ciphers (TLS_AES_128_GCM_SHA256,
+   * ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-RSA-AES128-GCM-SHA256) to the RFC 9151 GCM ciphers.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12_INTEROP1 = 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP1-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) interoperability policy. FIPS-compliant.
+   *
+   * Extends {@link RFC9151_TLS13_12_INTEROP1} with the AES-SHA256 CBC ciphers
+   * (ECDHE-ECDSA/RSA-AES256-SHA384 and ECDHE-ECDSA/RSA-AES128-SHA256).
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12_INTEROP2 = 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP2-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) interoperability policy. FIPS-compliant.
+   *
+   * Adds the AES-SHA1 CBC ciphers (ECDHE-ECDSA/RSA-AES256-SHA and ECDHE-ECDSA/RSA-AES128-SHA)
+   * on top of the GCM and SHA256 ciphers, for the widest client compatibility of the interop
+   * policies.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12_INTEROP3 = 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP3-FIPS-2023-07',
+
+  /**
+   * TLS 1.2 and 1.3, RFC 9151 (CNSA 1.0) interoperability policy. FIPS-compliant.
+   *
+   * AWS recommends starting with this policy: it supports clients that negotiate classical
+   * TLS 1.3, TLS 1.2, or strict RFC 9151 algorithms, then move to a stricter policy as clients
+   * gain RFC 9151 support. Also used for backend connections when any listener uses an RFC 9151 policy.
+   *
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#rfc9151-security-policies
+   */
+  RFC9151_TLS13_12_INTEROP4 = 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP4-FIPS-2023-07',
+
+  /**
    * Strong foward secrecy ciphers and TLV1.2 only (2020 edition).
    * Same as FORWARD_SECRECY_TLS12_RES, but only supports GCM versions of the TLS ciphers
    */

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/listener.test.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/alb/listener.test.ts
@@ -2329,6 +2329,36 @@ describe('tests', () => {
       });
     });
   });
+
+  describe('RFC 9151 (CNSA 1.0) SSL policies', () => {
+    test.each([
+      [elbv2.SslPolicy.RFC9151_TLS13_13, 'ELBSecurityPolicy-TLS13-1-3-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_EXT0, 'ELBSecurityPolicy-TLS13-1-2-Ext0-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP1, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP1-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP2, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP2-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP3, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP3-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP4, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP4-FIPS-2023-07'],
+    ])('sets SslPolicy %s on an HTTPS listener', (sslPolicy, expected) => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const vpc = new ec2.Vpc(stack, 'VPC');
+      const lb = new elbv2.ApplicationLoadBalancer(stack, 'LB', { vpc });
+
+      // WHEN
+      lb.addListener('Listener', {
+        protocol: elbv2.ApplicationProtocol.HTTPS,
+        certificates: [importedCertificate(stack)],
+        sslPolicy,
+        defaultAction: elbv2.ListenerAction.fixedResponse(200),
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
+        SslPolicy: expected,
+      });
+    });
+  });
 });
 
 class ResourceWithLBDependency extends cdk.CfnResource {

--- a/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/nlb/listener.test.ts
+++ b/packages/aws-cdk-lib/aws-elasticloadbalancingv2/test/nlb/listener.test.ts
@@ -750,6 +750,40 @@ describe('tests', () => {
       });
     });
   });
+
+  describe('RFC 9151 (CNSA 1.0) SSL policies', () => {
+    test.each([
+      [elbv2.SslPolicy.RFC9151_TLS13_13, 'ELBSecurityPolicy-TLS13-1-3-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_EXT0, 'ELBSecurityPolicy-TLS13-1-2-Ext0-RFC9151-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP1, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP1-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP2, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP2-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP3, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP3-FIPS-2023-07'],
+      [elbv2.SslPolicy.RFC9151_TLS13_12_INTEROP4, 'ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP4-FIPS-2023-07'],
+    ])('sets SslPolicy %s on a TLS listener', (sslPolicy, expected) => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const vpc = new ec2.Vpc(stack, 'VPC');
+      const lb = new elbv2.NetworkLoadBalancer(stack, 'LB', { vpc });
+      const cert = new acm.Certificate(stack, 'Certificate', {
+        domainName: 'example.com',
+      });
+
+      // WHEN
+      lb.addListener('Listener', {
+        port: 443,
+        protocol: elbv2.Protocol.TLS,
+        certificates: [elbv2.ListenerCertificate.fromCertificateManager(cert)],
+        sslPolicy,
+        defaultTargetGroups: [new elbv2.NetworkTargetGroup(stack, 'Group', { vpc, port: 80 })],
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
+        SslPolicy: expected,
+      });
+    });
+  });
 });
 
 class ResourceWithLBDependency extends cdk.CfnResource {


### PR DESCRIPTION
### Issue # (if applicable)

Relates to #38666.

### Reason for this change

AWS added TLS-based security policies for Application Load Balancer (HTTPS listeners) and Network Load Balancer (TLS listeners) that comply with RFC 9151 for the Commercial National Security Algorithm (CNSA) 1.0 suite: [AWS Application and Network Load Balancers now support RFC 9151 compliant security policies](https://aws.amazon.com/about-aws/whats-new/2026/08/aws-application-network/) from August 2026. 

The CDK `SslPolicy` enum did not expose these policies yet, so users had to workaround via mixin or  fall back to the L1 escape hatch to select them. Let's change this.

### Description of changes

Added the 7 RFC 9151 (CNSA 1.0) security policies to the shared `SslPolicy` enum (used by both ALB and NLB listeners):

- Strict policies (enforce full RFC 9151 requirements):
  - `RFC9151_TLS13_13` → `ELBSecurityPolicy-TLS13-1-3-RFC9151-FIPS-2023-07`
  - `RFC9151_TLS13_12` → `ELBSecurityPolicy-TLS13-1-2-RFC9151-FIPS-2023-07`
  - `RFC9151_TLS13_12_EXT0` → `ELBSecurityPolicy-TLS13-1-2-Ext0-RFC9151-FIPS-2023-07`
- Interop policies (mix RFC 9151 and non-RFC 9151 ciphers for gradual transition):
  - `RFC9151_TLS13_12_INTEROP1` → `ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP1-FIPS-2023-07`
  - `RFC9151_TLS13_12_INTEROP2` → `ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP2-FIPS-2023-07`
  - `RFC9151_TLS13_12_INTEROP3` → `ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP3-FIPS-2023-07`
  - `RFC9151_TLS13_12_INTEROP4` → `ELBSecurityPolicy-TLS13-1-2-RFC9151-INTEROP4-FIPS-2023-07`

No behavior or default changes: the CloudFormation default (`ELBSecurityPolicy-2016-08`) is unchanged, and no feature flag is introduced. `SslPolicy` is a free-form string in the CloudFormation `AWS::ElasticLoadBalancingV2::Listener` spec (no `AllowedValues` constraint), so the value is passed through to the ELBv2 API at deploy time. Each enum member documents the supported TLS versions and ciphers and links to the AWS documentation.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- Updated unit tests for both ALB HTTPS and NLB TLS listeners asserting that each new policy resolves to the correct `SslPolicy` value. All of them passed.
- Verified the policy names against the live ELBv2 API using `aws elbv2 describe-ssl-policies`. The API returns exactly these 7 `RFC9151` policy names. This is the same API CloudFormation forwards `SslPolicy` to at deploy time.
- Cross-checked the names against the AWS ELB `describe-ssl-policies` documentation for [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html) and [NLB](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/describe-ssl-policies.html)


### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
