### PR TITLE
fix(aws-events): update dlq policy to handle encrypted messages

### DIFF
--- a/packages/aws-cdk-lib/aws-events-targets/lib/util.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/lib/util.ts
@@ -121,8 +121,26 @@ export function addToDeadLetterQueueResourcePolicy(rule: events.IRuleRef, queue:
   // There is no way to add a target onto an imported rule, so we can assume we will run the following code only
   // in the account where the rule is created.
   if (sameEnvDimension(rule.env.account, queue.env.account)) {
-    const policyStatementId = `AllowEventRule${Names.nodeUniqueId(rule.node)}`;
+    if (queue.encryptionMasterKey) {
+      const policyStatementIdEncrypted = `AllowEncryptedEventRule${Names.nodeUniqueId(rule.node)}`;
+      queue.addToResourcePolicy(new iam.PolicyStatement({
+        sid: policyStatementIdEncrypted,
+        principals: [new iam.ServicePrincipal('events.amazonaws.com')],
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'kms:Decrypt',
+          'kms:GenerateDataKey',
+        ],
+        resources: [queue.encryptionMasterKey.keyArn],
+        conditions: {
+          ArnEquals: {
+            'aws:SourceArn': events.CfnRule.arnForRule(rule),
+          },
+        },
+      }));
+    }
 
+    const policyStatementId = `AllowEventRule${Names.nodeUniqueId(rule.node)}`;
     queue.addToResourcePolicy(new iam.PolicyStatement({
       sid: policyStatementId,
       principals: [new iam.ServicePrincipal('events.amazonaws.com')],

--- a/packages/aws-cdk-lib/aws-events-targets/test/sqs/sqs.test.ts
+++ b/packages/aws-cdk-lib/aws-events-targets/test/sqs/sqs.test.ts
@@ -461,3 +461,103 @@ test('dead letter queue is imported', () => {
     ],
   });
 });
+
+test('encrypted dead letter queue is configured correctly', () => {
+  const stack = new Stack();
+  const kmsKey = new kms.Key(stack, 'MyKey');
+  const queue = new sqs.Queue(stack, 'MyQueue', {
+    fifo: true,
+    encryption: sqs.QueueEncryption.KMS_MANAGED,
+    encryptionMasterKey: kmsKey,
+  });
+  const deadLetterQueue = new sqs.Queue(stack, 'MyDeadLetterQueue', {
+    encryptionMasterKey: kmsKey,
+    encryption: sqs.QueueEncryption.KMS_MANAGED,
+  });
+  const rule = new events.Rule(stack, 'MyRule', {
+    schedule: events.Schedule.rate(Duration.hours(1)),
+  });
+  // WHEN
+  rule.addTarget(new targets.SqsQueue(queue, {
+    deadLetterQueue,
+  }));
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+    ScheduleExpression: 'rate(1 hour)',
+    State: 'ENABLED',
+    Targets: [
+      {
+        Arn: {
+          'Fn::GetAtt': [
+            'MyQueueE6CA6235',
+            'Arn',
+          ],
+        },
+        Id: 'Target0',
+        DeadLetterConfig: {
+          Arn: {
+            'Fn::GetAtt': ['MyDeadLetterQueueD997968A', 'Arn'],
+          },
+        },
+      },
+    ],
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::SQS::QueuePolicy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            'kms:Decrypt',
+            'kms:GenerateDataKey',
+          ],
+          Condition: {
+            ArnEquals: {
+              'aws:SourceArn': {
+                'Fn::GetAtt': [
+                  'MyRuleA44AB831',
+                  'Arn',
+                ],
+              },
+            },
+          },
+          Effect: 'Allow',
+          Principal: {
+            Service: 'events.amazonaws.com',
+          },
+          Resource: {
+            'Fn::GetAtt': [
+              'MyKey6AB29FA6',
+              'Arn',
+            ],
+          },
+          Sid: 'AllowEncryptedEventRuleMyRule',
+        },
+        {
+          Action: 'sqs:SendMessage',
+          Condition: {
+            ArnEquals: {
+              'aws:SourceArn': {
+                'Fn::GetAtt': [
+                  'MyRuleA44AB831',
+                  'Arn',
+                ],
+              },
+            },
+          },
+          Effect: 'Allow',
+          Principal: {
+            Service: 'events.amazonaws.com',
+          },
+          Resource: {
+            'Fn::GetAtt': [
+              'MyDeadLetterQueueD997968A',
+              'Arn',
+            ],
+          },
+          Sid: 'AllowEventRuleMyRule',
+        },
+      ],
+    },
+  });
+});


### PR DESCRIPTION
### Issue #33169 

Closes #33169 

### Reason for this change

Fix the DLQ policy for encrypted Event Bridge Target


### Describe any new or updated permissions being added

- Granting Decrypt and GenerateDataKey to the DLQ 


### Description of how you validated changes
Unit Test Added

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
