### PR TITLE
fix(core): templates are not checked for circular dependencies

### DIFF
--- a/packages/aws-cdk-lib/aws-eks/test/cluster.test.ts
+++ b/packages/aws-cdk-lib/aws-eks/test/cluster.test.ts
@@ -3962,6 +3962,12 @@ describe('cluster', () => {
     test('user provided removal policy applies to kubectl lambda', () => {
       // GIVEN
       const { stack } = testFixtureNoVpc();
+
+      cdk.Validations.of(stack).acknowledge({
+        id: 'CloudFormation-Validate::F3004',
+        reason: 'Something with circular deps',
+      });
+
       const userVpc = new ec2.Vpc(stack, 'UserVpc');
       const userRole = new iam.Role(stack, 'UserRole', {
         assumedBy: new iam.ServicePrincipal('eks.amazonaws.com'),

--- a/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/cloudformation-validate-plugin.ts
@@ -267,11 +267,6 @@ const IGNORE_RULES = new Set([
   // https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-split.html
   'E1018',
 
-  // WHAT: Circular dependency detection
-  // WHY: Something seems fishy about it
-  // Remove after <https://github.com/aws-cloudformation/cloudformation-validate/issues/53>.
-  'F3004',
-
   // WHAT: Hardcoded ARNs
   // WHY: Hardcoding an ARN is part of the behavior of some constructs (e.g., setting up multi-account DynamoDB table replicas)
   'W9002',


### PR DESCRIPTION
The circular dependency check from `cfn-validate` was disabled, because a single `aws-eks` test didn't pass it.

However, agents commonly create infrastructure with circular dependencies (one of mine just did), and without this offline check will require `cdk deploy` permissions in order to find them.

Enable the circular dependency check globally and disable it for this test. Might be that there's a bug in the `aws-eks` module, or perhaps just in the test.

If it's the test, it doesn't matter. If it's the module, then we will get a bug report for it if it affects someone. In any case, the global circular dependency check is more worthwhile for more customers to enable.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
