### PR TITLE
chore(rds): add MySQL engine version 8.4.11

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/instance-engine.ts
@@ -1168,6 +1168,8 @@ export class MysqlEngineVersion {
   public static readonly VER_8_4_9 = MysqlEngineVersion.of('8.4.9', '8.4');
   /** Version "8.4.10". */
   public static readonly VER_8_4_10 = MysqlEngineVersion.of('8.4.10', '8.4');
+  /** Version "8.4.11". */
+  public static readonly VER_8_4_11 = MysqlEngineVersion.of('8.4.11', '8.4');
 
   /**
    * Create a new MysqlEngineVersion with an arbitrary version.


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38737.

### Reason for this change

Amazon RDS for MySQL now supports minor version 8.4.11. The latest built-in CDK constant was version 8.4.10, requiring users to construct 8.4.11 manually.

### Description of changes

Adds `MysqlEngineVersion.VER_8_4_11` using the existing MySQL 8.4 engine-version pattern.

### Describe any new or updated permissions being added

N/A. This change adds an engine-version constant and does not modify IAM permissions.

### Description of how you validated changes

- `yarn eslint aws-rds/lib/instance-engine.ts`
- `yarn test aws-rds/test/instance.test.ts --runInBand`: all 161 tests passed; the targeted run exited nonzero only because repository-wide coverage thresholds are not met by a single test file
- Full `aws-cdk-lib` build reached JSII compilation but is currently blocked on `upstream/main` by duplicate `attrCertificateAuthorityData` identifiers in generated EKS and EKS v2 sources

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

[comment]: <> (by cdk-contribution-skill)