### PR TITLE
chore(rds): add Aurora MySQL version 3.13.0

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
+++ b/packages/aws-cdk-lib/aws-rds/lib/cluster-engine.ts
@@ -729,6 +729,8 @@ export class AuroraMysqlEngineVersion {
   public static readonly VER_3_11_1 = AuroraMysqlEngineVersion.builtIn_8_0('3.11.1');
   /** Version "8.0.mysql_aurora.3.12.0". */
   public static readonly VER_3_12_0 = AuroraMysqlEngineVersion.builtIn_8_0('3.12.0');
+  /** Version "8.0.mysql_aurora.3.13.0". */
+  public static readonly VER_3_13_0 = AuroraMysqlEngineVersion.builtIn_8_0('3.13.0');
 
   /**
    * Create a new AuroraMysqlEngineVersion with an arbitrary version.

--- a/packages/aws-cdk-lib/aws-rds/test/cluster-engine.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/cluster-engine.test.ts
@@ -246,6 +246,7 @@ describe('cluster engine', () => {
     AuroraMysqlEngineVersion.VER_3_11_0,
     AuroraMysqlEngineVersion.VER_3_11_1,
     AuroraMysqlEngineVersion.VER_3_12_0,
+    AuroraMysqlEngineVersion.VER_3_13_0,
   ])('cluster parameter group correctly determined for AURORA_MYSQL 3.x and given version $auroraMysqlFullVersion', (version: AuroraMysqlEngineVersion) => {
     // GIVEN
     const engine_ver = DatabaseClusterEngine.auroraMysql({ version });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38738.

### Reason for this change

Amazon Aurora MySQL 3.13.0, compatible with MySQL 8.0.45, is now generally available. The latest built-in CDK constant was version 3.12.0.

### Description of changes

- Adds `AuroraMysqlEngineVersion.VER_3_13_0` using the existing Aurora MySQL 8.0 engine-version pattern
- Includes the version in the parameter group family unit-test matrix to verify it resolves to `aurora-mysql8.0`

### Describe any new or updated permissions being added

N/A. This change adds an engine-version constant and does not modify IAM permissions.

### Description of how you validated changes

- `yarn eslint aws-rds/lib/cluster-engine.ts aws-rds/test/cluster-engine.test.ts`
- `yarn test aws-rds/test/cluster-engine.test.ts --runInBand --coverage=false` (107 tests passed)
- Full `aws-cdk-lib` build reached JSII compilation but is currently blocked on `upstream/main` by duplicate `attrCertificateAuthorityData` identifiers in generated EKS and EKS v2 sources

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

[comment]: <> (by cdk-contribution-skill)