### PR TITLE
docs(internal): improve DX

### DIFF
--- a/packages/aws-cdk-lib/pipelines/lib/private/asset-manifest.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/private/asset-manifest.ts
@@ -30,8 +30,8 @@ export class AssetManifestReader {
 
   /**
    * Load an asset manifest from the given file or directory
-   *
-   * If the argument given is a directoy, the default asset file name will be used.
+   * If the argument given is a directory, the default asset file name will be used.
+   * @param filePath Path to load an asset manifest from.
    */
   public static fromPath(filePath: string) {
     let st;
@@ -253,13 +253,14 @@ function filterDict<A>(xs: Record<string, A>, pred: (x: A, key: string) => boole
 }
 
 /**
- * A filter pattern for an destination identifier
+ * A filter pattern for a destination identifier
  */
 export class DestinationPattern {
   /**
    * Parse a ':'-separated string into an asset/destination identifier
+   * @param s The ':'-separated string that is to be parsed.
    */
-  public static parse(s: string) {
+  public static parse(s: string): DestinationPattern {
     if (!s) { throw new UnscopedValidationError(lit`EmptyStringValidDestination`, 'Empty string is not a valid destination identifier'); }
     const parts = s.split(':').map(x => x !== '*' ? x : undefined);
     if (parts.length === 1) { return new DestinationPattern(parts[0]); }
@@ -293,7 +294,7 @@ export class DestinationPattern {
   /**
    * Return a string representation for this asset identifier
    */
-  public toString() {
+  public toString(): string {
     return `${this.assetId ?? '*'}:${this.destinationId ?? '*'}`;
   }
 }

--- a/packages/aws-cdk-lib/pipelines/lib/private/cloud-assembly-internals.ts
+++ b/packages/aws-cdk-lib/pipelines/lib/private/cloud-assembly-internals.ts
@@ -1,5 +1,9 @@
 import type * as cxapi from '../../../cx-api';
 
+/**
+ * Checks whether the passed argument is an asset manifest.
+ * @param s Argument that is to be checked.
+ */
 export function isAssetManifest(s: cxapi.CloudArtifact): s is cxapi.AssetManifestArtifact {
   // instanceof is too risky, and we're at a too late stage to properly fix.
   // return s instanceof cxapi.AssetManifestArtifact;


### PR DESCRIPTION

### Reason for this change

The internal pipelines utilities contain several missing or unclear JSDoc blocks, typos, and functions without explicit return types. These issues reduce readability for contributors working in the pipelines/lib/private subsystem. This PR improves clarity without modifying any runtime behavior.

### Description of changes

This PR performs a small documentation cleanup in the internal pipelines asset‑manifest and cloud‑assembly utilities. Changes include:Fixing a typo (directoy → directory)Adding missing @param tags to internal functionsAdding explicit return type annotations (: DestinationPattern, : string)Adding a JSDoc block for isAssetManifestImproving clarity and consistency of internal commentsThese changes do not modify logic or public API surface.
They strictly improve readability and developer experience.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->
N/A - This PR only affects typing and comments, not runtime behaviour.

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
 No tests were needed - it's just comments and some explicit types.
### Checklist
- [x ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
