### PR TITLE
refactor(core): refactor asset bundling code to make it more readable and fix bugs that were exposed

### DIFF
--- a/packages/aws-cdk-lib/core/lib/asset-staging.ts
+++ b/packages/aws-cdk-lib/core/lib/asset-staging.ts
@@ -18,7 +18,7 @@ import { lit } from './private/literal-string';
 import { profileSpan } from './private/perf';
 import type { Stack } from './stack';
 import * as cxapi from '../../cx-api';
-import { isInternalPath, resolveLinkTarget } from './fs/utils';
+import { walkDirectory } from './fs/utils';
 
 const ARCHIVE_EXTENSIONS = ['.tar.gz', '.zip', '.jar', '.tar', '.tgz'];
 
@@ -158,9 +158,9 @@ export class AssetStaging extends Construct {
   /**
    * A custom source fingerprint given by the user
    *
-   * Will not be used literally, always hashed later on.
+   * Will not be changed, hashed later on.
    */
-  private customSourceFingerprint?: string;
+  private readonly customSourceFingerprint?: string;
 
   private readonly cacheKey: string;
 
@@ -285,15 +285,15 @@ export class AssetStaging extends Construct {
    * Optionally skip if staging is disabled, in which case we pretend we did something but we don't really.
    */
   private stageByCopying(sourceStats: fs.Stats): StagedAsset {
-    const assetHash = this.calculateHash(this.hashType);
+    if (!sourceStats.isDirectory() && !sourceStats.isFile()) {
+      throw new ValidationError(lit`AssetExpectedDirectoryOrFile`, `Asset ${this.sourcePath} is expected to be either a directory or a regular file`, this);
+    }
+
+    const assetHash = this.calculateHash(this.hashType, this.customSourceFingerprint);
     const targetPath = this.stagingDisabled
       ? this.sourcePath
       : path.resolve(this.assetOutdir, renderAssetFilename(assetHash, getExtension(this.sourcePath)));
     const stagedPath = this.renderStagedPath(this.sourcePath, targetPath);
-
-    if (!sourceStats.isDirectory() && !sourceStats.isFile()) {
-      throw new ValidationError(lit`AssetExpectedDirectoryOrFile`, `Asset ${this.sourcePath} is expected to be either a directory or a regular file`, this);
-    }
 
     this.copySourceIntoStaging(stagedPath, sourceStats);
 
@@ -319,7 +319,9 @@ export class AssetStaging extends Construct {
 
     // Bundle straight into the final asset directory if we know the hash, otherwise
     // into a temporary one we hash and rename afterwards.
-    const knownDirHash = this.hashIsKnownBeforeBundling ? this.calculateHash(this.hashType, bundling) : undefined;
+    const knownDirHash = this.hashIsKnownBeforeBundling
+      ? this.calculateHash(this.hashType, this.customSourceFingerprint, bundling)
+      : undefined;
     const bundleDir = this.determineBundleDir(knownDirHash);
     this.bundle(bundling, bundleDir);
 
@@ -327,7 +329,8 @@ export class AssetStaging extends Construct {
     const ignore = IgnoreStrategy.fromCopyOptions(this.fingerprintOptions, bundleDir);
     const bundledAsset = determineBundledAsset(this, bundleDir, outputType, ignore, props.follow);
 
-    const assetHash = knownDirHash ?? this.calculateHash(this.hashType, bundling, bundledAsset.path);
+    const assetHash = knownDirHash
+      ?? this.calculateHash(this.hashType, this.customSourceFingerprint, bundling, bundledAsset.path);
     const stagedPath = this.renderStagedPath(
       bundledAsset.path,
       path.resolve(this.assetOutdir, renderAssetFilename(assetHash, bundledAsset.extension)),
@@ -352,14 +355,13 @@ export class AssetStaging extends Construct {
   private stageBySkippingBundling(bundling: BundlingOptions): StagedAsset {
     // OUTPUT and BUNDLE hash the bundling result, which we don't have. Use a CUSTOM hash
     // instead of fingerprinting a potentially very large source directory.
-    let hashType = this.hashType;
-    if (!this.hashIsKnownBeforeBundling) {
-      this.customSourceFingerprint = Names.uniqueId(this);
-      hashType = AssetHashType.CUSTOM;
-    }
+    const hashType = this.hashIsKnownBeforeBundling ? this.hashType : AssetHashType.CUSTOM;
+    const customFingerprint = this.hashIsKnownBeforeBundling
+      ? this.customSourceFingerprint
+      : Names.uniqueId(this);
 
     return {
-      assetHash: this.calculateHash(hashType, bundling),
+      assetHash: this.calculateHash(hashType, customFingerprint, bundling),
       stagedPath: this.sourcePath,
       packaging: FileAssetPackaging.ZIP_DIRECTORY,
       isArchive: true,
@@ -431,6 +433,9 @@ export class AssetStaging extends Construct {
    * The source belongs to the user, so it is only ever read, never moved or deleted.
    *
    * Does nothing if source and staged path are the same, i.e. when staging is disabled.
+   *
+   * `sourceStats` is a file or a directory; `stageByCopying` has already rejected
+   * anything else.
    */
   private copySourceIntoStaging(stagedPath: string, sourceStats: fs.Stats) {
     // Is the work already done?
@@ -440,11 +445,9 @@ export class AssetStaging extends Construct {
 
     if (sourceStats.isFile()) {
       fs.copyFileSync(this.sourcePath, stagedPath);
-    } else if (sourceStats.isDirectory()) {
+    } else {
       fs.mkdirSync(stagedPath);
       FileSystem.copyDirectory(this.sourcePath, stagedPath, this.fingerprintOptions);
-    } else {
-      throw new ValidationError(lit`UnknownFileType`, `Unknown file type: ${this.sourcePath}`, this);
     }
   }
 
@@ -462,18 +465,36 @@ export class AssetStaging extends Construct {
   }
 
   /**
-   * Bundles an asset into the given directory
+   * Make sure `bundleDir` holds the bundled asset
    *
-   * If the given directory already exists, assume that everything's already
-   * in order and don't do anything.
+   * If the directory already exists, a previous run bundled identical content there and
+   * we don't bundle again. Either way the result is checked for output, so an empty
+   * directory left behind by an interrupted run is not staged as an empty asset.
    *
    * @param options Bundling options
    * @param bundleDir Where to create the bundle directory
    */
   private bundle(options: BundlingOptions, bundleDir: string) {
-    // An existing bundle directory is a complete bundle of identical content.
-    if (fs.existsSync(bundleDir)) { return; }
+    const existing = fs.statSync(bundleDir, { throwIfNoEntry: false });
+    const bundledLocally = existing ? undefined : this.runBundling(options, bundleDir);
 
+    // A `bundleDir` that isn't a directory is reported by `determineBundledAsset`, which
+    // has a clearer message for it than a failed read would.
+    if (existing && !existing.isDirectory()) {
+      return;
+    }
+
+    if (FileSystem.isEmpty(bundleDir)) {
+      // Name the directory the user writes to theirs locally, the container's mount otherwise.
+      const outputDir = bundledLocally ? bundleDir : AssetStaging.BUNDLING_OUTPUT_DIR;
+      throw new ValidationError(lit`BundlingProducedNoOutput`, `Bundling did not produce any output. Check that content is written to ${outputDir}.`, this);
+    }
+  }
+
+  /**
+   * Bundle into `bundleDir`, returning whether the bundling ran locally
+   */
+  private runBundling(options: BundlingOptions, bundleDir: string): boolean | undefined {
     // Bundle into a sibling and rename on success, so an interrupted run can't leave a
     // partial bundle at `bundleDir` for a later run to mistake for a complete one.
     const tempDir = `${bundleDir}-building`;
@@ -491,17 +512,15 @@ export class AssetStaging extends Construct {
       if (!bundledLocally) {
         this.bundleWithDocker(options, tempDir);
       }
-
-      fs.renameSync(tempDir, bundleDir);
     } catch (err) {
       throw new ValidationError(lit`FailedToBundleAsset`, `Failed to bundle asset ${this.node.path}, bundle output is located at ${tempDir}: ${err}`, this);
     }
 
-    if (FileSystem.isEmpty(bundleDir)) {
-      // Name the directory the user writes to: theirs locally, the container's mount otherwise.
-      const outputDir = bundledLocally ? bundleDir : AssetStaging.BUNDLING_OUTPUT_DIR;
-      throw new ValidationError(lit`BundlingProducedNoOutput`, `Bundling did not produce any output. Check that content is written to ${outputDir}.`, this);
-    }
+    // Outside the `catch`: bundling has succeeded, so a failure to move the output into
+    // place is not a bundling failure and must not be reported as one.
+    fs.renameSync(tempDir, bundleDir);
+
+    return bundledLocally;
   }
 
   /**
@@ -525,7 +544,13 @@ export class AssetStaging extends Construct {
     }
   }
 
-  private calculateHash(hashType: AssetHashType, bundling?: BundlingOptions, outputDir?: string): string {
+  /**
+   * Compute the asset hash.
+   *
+   * `customFingerprint` is passed in rather than read from the field, because the
+   * skipped-bundling path substitutes one of its own.
+   */
+  private calculateHash(hashType: AssetHashType, customFingerprint: string | undefined, bundling?: BundlingOptions, outputDir?: string): string {
     // When bundling a CUSTOM or SOURCE asset hash type, we want the hash to include
     // the bundling configuration. We handle CUSTOM and bundled SOURCE hash types
     // as a special case to preserve existing user asset hashes in all other cases.
@@ -533,7 +558,7 @@ export class AssetStaging extends Construct {
       const hash = crypto.createHash('sha256');
 
       // if asset hash is provided by user, use it, otherwise fingerprint the source.
-      hash.update(this.customSourceFingerprint ?? FileSystem.fingerprint(this.sourcePath, this.fingerprintOptions));
+      hash.update(customFingerprint ?? FileSystem.fingerprint(this.sourcePath, this.fingerprintOptions));
 
       // If we're bundling an asset, include the bundling configuration in the hash
       if (bundling) {
@@ -606,69 +631,20 @@ function validateInternalSymlinks(
   followMode: SymlinkFollowMode,
   ignoreStrategy: IgnoreStrategy,
 ) {
-  const canonicalRoot = realDirectoryPath(root);
-
-  // We descend into symlinks that stay inside the tree, so without this a link pointing
-  // at one of its own ancestors would recurse forever.
-  const descendedInto = new Set<string>([canonicalRoot]);
-
-  validateDirectory(root);
-
-  function validateDirectory(directory: string) {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      const childPath = path.join(directory, entry.name);
-
-      if (entry.isDirectory()) {
-        if (!ignoreStrategy.completelyIgnores(childPath)) {
-          validateDirectory(childPath);
-        }
-        continue;
-      }
-
-      if (!entry.isSymbolicLink() || ignoreStrategy.ignores(childPath)) {
-        continue;
-      }
-
-      const target = canonicalLinkTarget(resolveLinkTarget(childPath, fs.readlinkSync(childPath)));
-      if (!isInternalPath(canonicalRoot, target)) {
+  // Under BLOCK_EXTERNAL the walk follows internal links and reports external ones, which
+  // is exactly the set we have to reject. Links the ignore strategy excludes never reach
+  // us, so nothing outside the asset is validated.
+  walkDirectory(root, { follow: followMode, ignoreStrategy }, {
+    onSymlink: (entry) => {
+      if (!entry.internal) {
         throw new ValidationError(
           lit`BundlingFileSymlinkForbidden`,
-          `The file ${target} is an external symbolic link which is forbidden due to follow mode ${followMode}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
+          `The file ${entry.resolvedLinkTarget} is an external symbolic link which is forbidden due to follow mode ${followMode}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
           scope,
         );
       }
-
-      // The link is internal, but a directory it points at can hold links that escape.
-      if (!descendedInto.has(target) && fs.statSync(target, { throwIfNoEntry: false })?.isDirectory()) {
-        descendedInto.add(target);
-        validateDirectory(childPath);
-      }
-    }
-  }
-}
-
-/**
- * Resolve any symlinked directories in a path, so inside/outside comparisons agree.
- *
- * `path.resolve` normalizes `..` lexically but does not resolve links, so without this a
- * symlinked *ancestor* of the asset root makes paths inside the tree look external.
- *
- * Returns the path unchanged if it cannot be resolved, e.g. a link into a missing directory.
- */
-function realDirectoryPath(directory: string): string {
-  try {
-    return fs.realpathSync(directory);
-  } catch {
-    return directory;
-  }
-}
-
-/**
- * Resolves the directories leading to the target, but never the target itself: a link is
- * judged by where it points, not by where that points in turn.
- */
-function canonicalLinkTarget(target: string): string {
-  return path.join(realDirectoryPath(path.dirname(target)), path.basename(target));
+    },
+  });
 }
 
 /**

--- a/packages/aws-cdk-lib/core/lib/asset-staging.ts
+++ b/packages/aws-cdk-lib/core/lib/asset-staging.ts
@@ -176,7 +176,7 @@ export class AssetStaging extends Construct {
       extraHash: props.extraHash || salt ? `${props.extraHash ?? ''}${salt ?? ''}` : undefined,
     };
 
-    // Stat the source once; the decisions below depend on whether it's a file or a directory.
+    // Stat the source once. The decisions below depend on whether it's a file or a directory.
     const sourceStats = fs.statSync(this.sourcePath, { throwIfNoEntry: false });
     if (!sourceStats) {
       throw new ValidationError(lit`CannotFindAsset`, `Cannot find asset at ${this.sourcePath}`, this);
@@ -227,7 +227,7 @@ export class AssetStaging extends Construct {
       skip,
     });
 
-    // Actually stage the asset: on a cache miss, `obtain` runs `stageThisAsset`.
+    // Actually stage the asset: on a cache miss, we stage the asset.
     const staged = AssetStaging.assetCache.obtain(this.cacheKey, stageThisAsset);
     this.stagedPath = staged.stagedPath;
     this.absoluteStagedPath = staged.stagedPath;

--- a/packages/aws-cdk-lib/core/lib/asset-staging.ts
+++ b/packages/aws-cdk-lib/core/lib/asset-staging.ts
@@ -164,8 +164,6 @@ export class AssetStaging extends Construct {
 
   private readonly cacheKey: string;
 
-  private readonly _sourceStats?: fs.Stats;
-
   constructor(scope: Construct, id: string, props: AssetStagingProps) {
     super(scope, id);
 
@@ -178,17 +176,17 @@ export class AssetStaging extends Construct {
       extraHash: props.extraHash || salt ? `${props.extraHash ?? ''}${salt ?? ''}` : undefined,
     };
 
-    if (!fs.existsSync(this.sourcePath)) {
+    // Stat the source once; the decisions below depend on whether it's a file or a directory.
+    const sourceStats = fs.statSync(this.sourcePath, { throwIfNoEntry: false });
+    if (!sourceStats) {
       throw new ValidationError(lit`CannotFindAsset`, `Cannot find asset at ${this.sourcePath}`, this);
     }
 
-    const ignoreStrategy = IgnoreStrategy.fromCopyOptions(props, this.sourcePath);
-    // look for invalid (external) symlinks
-    if (props.follow == SymlinkFollowMode.BLOCK_EXTERNAL && fs.statSync(this.sourcePath).isDirectory()) {
-      validateInternalSymlinks(this.sourcePath, scope, props.follow, ignoreStrategy);
+    // Look for invalid (external) symlinks. Uses `fingerprintOptions`, so we check
+    // exactly the files that get packaged.
+    if (props.follow == SymlinkFollowMode.BLOCK_EXTERNAL && sourceStats.isDirectory()) {
+      validateInternalSymlinks(this.sourcePath, this, props.follow, IgnoreStrategy.fromCopyOptions(this.fingerprintOptions, this.sourcePath));
     }
-
-    this._sourceStats = fs.statSync(this.sourcePath);
 
     const outdir = stageOf(this)?.assetOutdir;
     if (!outdir) {
@@ -201,17 +199,13 @@ export class AssetStaging extends Construct {
     this.customSourceFingerprint = props.assetHash;
     this.hashType = determineHashType(this, props.assetHashType, this.customSourceFingerprint);
 
-    // Decide what we're going to do, without actually doing it yet
-    let stageThisAsset: () => StagedAsset;
-    let skip = false;
-    if (props.bundling) {
-      // Check if we actually have to bundle for this stack
-      skip = !stackOf(this).bundlingRequired;
-      const bundling = props.bundling;
-      stageThisAsset = () => this.stageByBundling(bundling, skip, props);
-    } else {
-      stageThisAsset = () => this.stageByCopying();
-    }
+    // Decide what to do, without doing it yet. Bundling is skipped when no stack needs
+    // it; we still produce a hash, so `skip` is part of the cache key below.
+    const bundling = props.bundling;
+    const skip = bundling !== undefined && !stackOf(this).bundlingRequired;
+    const stageThisAsset = bundling
+      ? () => this.stageByBundling(bundling, skip, props, sourceStats)
+      : () => this.stageByCopying(sourceStats);
 
     // Calculate a cache key from the props. This way we can check if we already
     // staged this asset and reuse the result (e.g. the same asset with the same
@@ -233,27 +227,13 @@ export class AssetStaging extends Construct {
       skip,
     });
 
+    // Actually stage the asset: on a cache miss, `obtain` runs `stageThisAsset`.
     const staged = AssetStaging.assetCache.obtain(this.cacheKey, stageThisAsset);
     this.stagedPath = staged.stagedPath;
     this.absoluteStagedPath = staged.stagedPath;
     this.assetHash = staged.assetHash;
     this.packaging = staged.packaging;
     this.isArchive = staged.isArchive;
-
-    // Memory optimization: this._sourceStats is used as a field to covertly pass
-    // arguments between functions in the constructor, but the size of that object is 1.8kB
-    //
-    // That's holding on to a lot of unnecessary memory if there are a lot of assets (think 100k+).
-    //
-    // Release the object here, we don't need it again.
-    this._sourceStats = undefined;
-  }
-
-  private get sourceStats(): fs.Stats {
-    if (!this._sourceStats) {
-      throw new AssumptionError(lit`SourceStatusUnset`, '_sourceStats has been unset');
-    }
-    return this._sourceStats;
   }
 
   /**
@@ -304,96 +284,118 @@ export class AssetStaging extends Construct {
    *
    * Optionally skip if staging is disabled, in which case we pretend we did something but we don't really.
    */
-  private stageByCopying(): StagedAsset {
+  private stageByCopying(sourceStats: fs.Stats): StagedAsset {
     const assetHash = this.calculateHash(this.hashType);
     const targetPath = this.stagingDisabled
       ? this.sourcePath
       : path.resolve(this.assetOutdir, renderAssetFilename(assetHash, getExtension(this.sourcePath)));
     const stagedPath = this.renderStagedPath(this.sourcePath, targetPath);
 
-    if (!this.sourceStats.isDirectory() && !this.sourceStats.isFile()) {
+    if (!sourceStats.isDirectory() && !sourceStats.isFile()) {
       throw new ValidationError(lit`AssetExpectedDirectoryOrFile`, `Asset ${this.sourcePath} is expected to be either a directory or a regular file`, this);
     }
 
-    this.stageAsset(this.sourcePath, stagedPath, 'copy');
+    this.copySourceIntoStaging(stagedPath, sourceStats);
 
     return {
       assetHash,
       stagedPath,
-      packaging: this.sourceStats.isDirectory() ? FileAssetPackaging.ZIP_DIRECTORY : FileAssetPackaging.FILE,
-      isArchive: this.sourceStats.isDirectory() || ARCHIVE_EXTENSIONS.includes(getExtension(this.sourcePath).toLowerCase()),
+      packaging: sourceStats.isDirectory() ? FileAssetPackaging.ZIP_DIRECTORY : FileAssetPackaging.FILE,
+      isArchive: sourceStats.isDirectory() || ARCHIVE_EXTENSIONS.includes(getExtension(this.sourcePath).toLowerCase()),
     };
   }
 
   /**
    * Stage the source to the target by bundling
-   *
-   * Optionally skip, in which case we pretend we did something but we don't really.
    */
-  private stageByBundling(bundling: BundlingOptions, skip: boolean, props: AssetStagingProps): StagedAsset {
-    if (!this.sourceStats.isDirectory()) {
+  private stageByBundling(bundling: BundlingOptions, skip: boolean, props: AssetStagingProps, sourceStats: fs.Stats): StagedAsset {
+    if (!sourceStats.isDirectory()) {
       throw new ValidationError(lit`AssetExpectedDirectoryForBundling`, `Asset ${this.sourcePath} is expected to be a directory when bundling`, this);
     }
 
     if (skip) {
-      // We should have bundled, but didn't to save time. Still pretend to have a hash.
-      // If the asset uses OUTPUT or BUNDLE, we use a CUSTOM hash to avoid fingerprinting
-      // a potentially very large source directory. Other hash types are kept the same.
-      let hashType = this.hashType;
-      if (hashType === AssetHashType.OUTPUT || hashType === AssetHashType.BUNDLE) {
-        this.customSourceFingerprint = Names.uniqueId(this);
-        hashType = AssetHashType.CUSTOM;
-      }
-      return {
-        assetHash: this.calculateHash(hashType, bundling),
-        stagedPath: this.sourcePath,
-        packaging: FileAssetPackaging.ZIP_DIRECTORY,
-        isArchive: true,
-      };
+      return this.stageBySkippingBundling(bundling);
     }
 
-    // Try to calculate assetHash beforehand (if we can)
-    let assetHash = this.hashType === AssetHashType.SOURCE || this.hashType === AssetHashType.CUSTOM
-      ? this.calculateHash(this.hashType, bundling)
-      : undefined;
-
-    const bundleDir = this.determineBundleDir(this.assetOutdir, assetHash);
+    // Bundle straight into the final asset directory if we know the hash, otherwise
+    // into a temporary one we hash and rename afterwards.
+    const knownDirHash = this.hashIsKnownBeforeBundling ? this.calculateHash(this.hashType, bundling) : undefined;
+    const bundleDir = this.determineBundleDir(knownDirHash);
     this.bundle(bundling, bundleDir);
 
-    // Check bundling output content and determine if we will need to archive
-    const bundlingOutputType = bundling.outputType ?? BundlingOutput.AUTO_DISCOVER;
-    const ignore = IgnoreStrategy.fromCopyOptions(props, bundleDir);
-    const bundledAsset = determineBundledAsset(this, bundleDir, bundlingOutputType, ignore, props.follow);
+    const outputType = bundling.outputType ?? BundlingOutput.AUTO_DISCOVER;
+    const ignore = IgnoreStrategy.fromCopyOptions(this.fingerprintOptions, bundleDir);
+    const bundledAsset = determineBundledAsset(this, bundleDir, outputType, ignore, props.follow);
 
-    // Calculate assetHash afterwards if we still must
-    assetHash = assetHash ?? this.calculateHash(this.hashType, bundling, bundledAsset.path);
-
+    const assetHash = knownDirHash ?? this.calculateHash(this.hashType, bundling, bundledAsset.path);
     const stagedPath = this.renderStagedPath(
       bundledAsset.path,
       path.resolve(this.assetOutdir, renderAssetFilename(assetHash, bundledAsset.extension)),
     );
 
-    this.stageAsset(bundledAsset.path, stagedPath, 'move');
-
-    // If bundling produced a single archive file we "touch" this file in the bundling
-    // directory after it has been moved to the staging directory if the hash is known before bundling. This way if bundling
-    // is skipped because the bundling directory already exists we can still determine
-    // the correct packaging type.
-    // If the hash is calculated after bundling we remove the temporary directory now.
-    if (bundledAsset.packaging === FileAssetPackaging.FILE) {
-      if (this.hashType === AssetHashType.OUTPUT || this.hashType === AssetHashType.BUNDLE) {
-        fs.removeSync(path.dirname(bundledAsset.path));
-      } else {
-        fs.closeSync(fs.openSync(bundledAsset.path, 'w'));
-      }
-    }
+    this.moveBundleIntoStaging(bundledAsset.path, stagedPath);
+    this.cleanUpBundleDir(bundledAsset);
 
     return {
       assetHash,
       stagedPath,
       packaging: bundledAsset.packaging,
-      isArchive: bundlingOutputType !== BundlingOutput.SINGLE_FILE,
+      isArchive: outputType !== BundlingOutput.SINGLE_FILE,
     };
+  }
+
+  /**
+   * Produce a `StagedAsset` for an asset we deliberately did not bundle.
+   *
+   * No stack needs the output, so we skip the bundling and return the source directory.
+   */
+  private stageBySkippingBundling(bundling: BundlingOptions): StagedAsset {
+    // OUTPUT and BUNDLE hash the bundling result, which we don't have. Use a CUSTOM hash
+    // instead of fingerprinting a potentially very large source directory.
+    let hashType = this.hashType;
+    if (!this.hashIsKnownBeforeBundling) {
+      this.customSourceFingerprint = Names.uniqueId(this);
+      hashType = AssetHashType.CUSTOM;
+    }
+
+    return {
+      assetHash: this.calculateHash(hashType, bundling),
+      stagedPath: this.sourcePath,
+      packaging: FileAssetPackaging.ZIP_DIRECTORY,
+      isArchive: true,
+    };
+  }
+
+  /**
+   * Whether the asset hash can be computed before bundling runs.
+   *
+   * SOURCE and CUSTOM come from the input; OUTPUT and BUNDLE come from the result.
+   */
+  private get hashIsKnownBeforeBundling(): boolean {
+    return this.hashType === AssetHashType.SOURCE || this.hashType === AssetHashType.CUSTOM;
+  }
+
+  /**
+   * Tidy up the bundling directory after its output has been staged.
+   *
+   * Only single-file output leaves a directory behind, since a bundled directory was
+   * renamed into staging. Moving that one file out left the directory empty,
+   * and what we do with it depends on whether a later run looks for it:
+   *
+   * - Hash known up front: it is `asset.<hash>`, which a later run reuses to skip
+   *   bundling. Recreate the file empty so that run still sees single-file output.
+   * - Hash known afterwards: it is `bundling-temp-<cacheKey>`, so delete it.
+   */
+  private cleanUpBundleDir(bundledAsset: BundledAsset) {
+    if (bundledAsset.packaging !== FileAssetPackaging.FILE) {
+      return;
+    }
+
+    if (this.hashIsKnownBeforeBundling) {
+      fs.closeSync(fs.openSync(bundledAsset.path, 'w'));
+    } else {
+      fs.removeSync(path.dirname(bundledAsset.path));
+    }
   }
 
   /**
@@ -404,111 +406,122 @@ export class AssetStaging extends Construct {
   }
 
   /**
-   * Copies or moves the files from sourcePath to targetPath.
+   * Move a freshly created bundle into the staging directory.
    *
-   * Moving implies the source directory is temporary and can be trashed.
+   * We own the bundle directory, since `bundle()` just produced it: renaming it into
+   * place is cheap, and if the staged asset already exists we can throw the bundle away.
    *
-   * Will not do anything if source and target are the same.
+   * Does nothing if bundle and staged path are the same.
    */
-  private stageAsset(sourcePath: string, targetPath: string, style: 'move' | 'copy') {
-    // Is the work already done?
-    const isAlreadyStaged = fs.existsSync(targetPath);
-    if (isAlreadyStaged) {
-      if (style === 'move' && sourcePath !== targetPath) {
-        fs.removeSync(sourcePath);
+  private moveBundleIntoStaging(bundlePath: string, stagedPath: string) {
+    // Already staged, so our bundle output is redundant.
+    if (fs.existsSync(stagedPath)) {
+      if (bundlePath !== stagedPath) {
+        fs.removeSync(bundlePath);
       }
       return;
     }
 
-    // Moving can be done quickly
-    if (style === 'move') {
-      fs.renameSync(sourcePath, targetPath);
+    fs.renameSync(bundlePath, stagedPath);
+  }
+
+  /**
+   * Copy the user's source into the staging directory.
+   *
+   * The source belongs to the user, so it is only ever read, never moved or deleted.
+   *
+   * Does nothing if source and staged path are the same, i.e. when staging is disabled.
+   */
+  private copySourceIntoStaging(stagedPath: string, sourceStats: fs.Stats) {
+    // Is the work already done?
+    if (fs.existsSync(stagedPath)) {
       return;
     }
 
-    // Copy file/directory to staging directory
-    if (this.sourceStats.isFile()) {
-      fs.copyFileSync(sourcePath, targetPath);
-    } else if (this.sourceStats.isDirectory()) {
-      fs.mkdirSync(targetPath);
-      FileSystem.copyDirectory(sourcePath, targetPath, this.fingerprintOptions);
+    if (sourceStats.isFile()) {
+      fs.copyFileSync(this.sourcePath, stagedPath);
+    } else if (sourceStats.isDirectory()) {
+      fs.mkdirSync(stagedPath);
+      FileSystem.copyDirectory(this.sourcePath, stagedPath, this.fingerprintOptions);
     } else {
-      throw new ValidationError(lit`UnknownFileType`, `Unknown file type: ${sourcePath}`, this);
+      throw new ValidationError(lit`UnknownFileType`, `Unknown file type: ${this.sourcePath}`, this);
     }
   }
 
   /**
    * Determine the directory where we're going to write the bundling output
    *
-   * This is the target directory where we're going to write the staged output
-   * files if we can (if the hash is fully known), or a temporary directory
-   * otherwise.
+   * The final staged asset directory if the hash is already known, otherwise an
+   * intermediate one named after the asset's cache key.
    */
-  private determineBundleDir(outdir: string, sourceHash?: string) {
-    if (sourceHash) {
-      return path.resolve(outdir, renderAssetFilename(sourceHash));
-    }
-
-    // When the asset hash isn't known in advance, bundler outputs to an
-    // intermediate directory named after the asset's cache key
-    return path.resolve(outdir, `bundling-temp-${this.cacheKey}`);
+  private determineBundleDir(assetHash?: string) {
+    return path.resolve(
+      this.assetOutdir,
+      assetHash ? renderAssetFilename(assetHash) : `bundling-temp-${this.cacheKey}`,
+    );
   }
 
   /**
-   * Bundles an asset to the given directory
+   * Bundles an asset into the given directory
    *
    * If the given directory already exists, assume that everything's already
    * in order and don't do anything.
    *
    * @param options Bundling options
    * @param bundleDir Where to create the bundle directory
-   * @returns The fully resolved bundle output directory.
    */
   private bundle(options: BundlingOptions, bundleDir: string) {
+    // An existing bundle directory is a complete bundle of identical content.
     if (fs.existsSync(bundleDir)) { return; }
 
+    // Bundle into a sibling and rename on success, so an interrupted run can't leave a
+    // partial bundle at `bundleDir` for a later run to mistake for a complete one.
     const tempDir = `${bundleDir}-building`;
-    // Remove the tempDir if it exists, then recreate it
     fs.rmSync(tempDir, { recursive: true, force: true });
-
     fs.ensureDirSync(tempDir);
-    // Chmod the bundleDir to full access.
-    fs.chmodSync(tempDir, 0o777);
+    fs.chmodSync(tempDir, 0o777); // the bundling container may run as another user
 
-    let localBundling: boolean | undefined;
+    let bundledLocally: boolean | undefined;
     try {
       process.stderr.write(`Bundling asset ${this.node.path}...\n`);
 
       using _span = timerSpanFromOptions(options);
 
-      localBundling = options.local?.tryBundle(tempDir, options);
-      if (!localBundling) {
-        const assetStagingOptions = {
-          sourcePath: this.sourcePath,
-          bundleDir: tempDir,
-          ...options,
-        };
-
-        switch (options.bundlingFileAccess) {
-          case BundlingFileAccess.VOLUME_COPY:
-            new AssetBundlingVolumeCopy(assetStagingOptions).run();
-            break;
-          case BundlingFileAccess.BIND_MOUNT:
-          default:
-            new AssetBundlingBindMount(assetStagingOptions).run();
-            break;
-        }
+      bundledLocally = options.local?.tryBundle(tempDir, options);
+      if (!bundledLocally) {
+        this.bundleWithDocker(options, tempDir);
       }
 
-      // Success, rename the tempDir into place
       fs.renameSync(tempDir, bundleDir);
     } catch (err) {
       throw new ValidationError(lit`FailedToBundleAsset`, `Failed to bundle asset ${this.node.path}, bundle output is located at ${tempDir}: ${err}`, this);
     }
 
     if (FileSystem.isEmpty(bundleDir)) {
-      const outputDir = localBundling ? bundleDir : AssetStaging.BUNDLING_OUTPUT_DIR;
+      // Name the directory the user writes to: theirs locally, the container's mount otherwise.
+      const outputDir = bundledLocally ? bundleDir : AssetStaging.BUNDLING_OUTPUT_DIR;
       throw new ValidationError(lit`BundlingProducedNoOutput`, `Bundling did not produce any output. Check that content is written to ${outputDir}.`, this);
+    }
+  }
+
+  /**
+   * Run the bundling command in a Docker container.
+   */
+  private bundleWithDocker(options: BundlingOptions, bundleDir: string) {
+    const bundlingOptions = {
+      sourcePath: this.sourcePath,
+      bundleDir,
+      ...options,
+    };
+
+    switch (options.bundlingFileAccess) {
+      case BundlingFileAccess.VOLUME_COPY:
+        new AssetBundlingVolumeCopy(bundlingOptions).run();
+        break;
+      case BundlingFileAccess.BIND_MOUNT:
+      default:
+        new AssetBundlingBindMount(bundlingOptions).run();
+        break;
     }
   }
 
@@ -583,42 +596,79 @@ function determineHashType(scope: Construct, assetHashType?: AssetHashType, cust
 
 /**
  * Walk the directory tree, throw if we find external symlinks
- * @param root true root of the directory
- * @param subRoot used for walking subdirectories
+ *
+ * Only checks entries that end up in the asset: ignored files, and the contents of
+ * ignored directories, are skipped.
  */
 function validateInternalSymlinks(
   root: string,
   scope: Construct,
   followMode: SymlinkFollowMode,
-  ignoreStrat: IgnoreStrategy,
-  subRoot: string = root,
+  ignoreStrategy: IgnoreStrategy,
 ) {
-  const entries = fs.readdirSync(subRoot, { withFileTypes: true });
-  for (const entry of entries) {
-    const childPath = path.join(subRoot, entry.name);
-    if (entry.isDirectory()) {
-      if (ignoreStrat.completelyIgnores(childPath)) {
+  const canonicalRoot = realDirectoryPath(root);
+
+  // We descend into symlinks that stay inside the tree, so without this a link pointing
+  // at one of its own ancestors would recurse forever.
+  const descendedInto = new Set<string>([canonicalRoot]);
+
+  validateDirectory(root);
+
+  function validateDirectory(directory: string) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const childPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!ignoreStrategy.completelyIgnores(childPath)) {
+          validateDirectory(childPath);
+        }
         continue;
       }
-      validateInternalSymlinks(root, scope, followMode, ignoreStrat, childPath);
-    } else if (!entry.isSymbolicLink()) {
-      continue;
-    } else { // we have a symlink
-      if (ignoreStrat.completelyIgnores(childPath)) {
+
+      if (!entry.isSymbolicLink() || ignoreStrategy.ignores(childPath)) {
         continue;
       }
-      // check whether this is internal or external
-      const linkPath = fs.readlinkSync(childPath);
-      const resolvedPath = resolveLinkTarget(childPath, linkPath);
-      if (!isInternalPath(root, resolvedPath)) {
+
+      const target = canonicalLinkTarget(resolveLinkTarget(childPath, fs.readlinkSync(childPath)));
+      if (!isInternalPath(canonicalRoot, target)) {
         throw new ValidationError(
           lit`BundlingFileSymlinkForbidden`,
-          `The file ${resolvedPath} is an external symbolic link which is forbidden due to follow mode ${followMode}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
+          `The file ${target} is an external symbolic link which is forbidden due to follow mode ${followMode}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
           scope,
         );
       }
+
+      // The link is internal, but a directory it points at can hold links that escape.
+      if (!descendedInto.has(target) && fs.statSync(target, { throwIfNoEntry: false })?.isDirectory()) {
+        descendedInto.add(target);
+        validateDirectory(childPath);
+      }
     }
   }
+}
+
+/**
+ * Resolve any symlinked directories in a path, so inside/outside comparisons agree.
+ *
+ * `path.resolve` normalizes `..` lexically but does not resolve links, so without this a
+ * symlinked *ancestor* of the asset root makes paths inside the tree look external.
+ *
+ * Returns the path unchanged if it cannot be resolved, e.g. a link into a missing directory.
+ */
+function realDirectoryPath(directory: string): string {
+  try {
+    return fs.realpathSync(directory);
+  } catch {
+    return directory;
+  }
+}
+
+/**
+ * Resolves the directories leading to the target, but never the target itself: a link is
+ * judged by where it points, not by where that points in turn.
+ */
+function canonicalLinkTarget(target: string): string {
+  return path.join(realDirectoryPath(path.dirname(target)), path.basename(target));
 }
 
 /**
@@ -668,31 +718,6 @@ function sanitizeHashValue(key: string, value: any): any {
   return value;
 }
 
-/**
- * Returns the single archive file of a directory or undefined
- */
-function findSingleFile(scope: Construct, directory: string, archiveOnly: boolean): string | undefined {
-  if (!fs.existsSync(directory)) {
-    throw new ValidationError(lit`DirectoryDoesNotExist`, `Directory ${directory} does not exist.`, scope);
-  }
-
-  if (!fs.statSync(directory).isDirectory()) {
-    throw new ValidationError(lit`PathIsNotDirectory`, `${directory} is not a directory.`, scope);
-  }
-
-  const content = fs.readdirSync(directory);
-  if (content.length === 1) {
-    const file = path.join(directory, content[0]);
-    const extension = getExtension(content[0]).toLowerCase();
-
-    if (fs.statSync(file).isFile() && (!archiveOnly || ARCHIVE_EXTENSIONS.includes(extension))) {
-      return file;
-    }
-  }
-
-  return undefined;
-}
-
 interface BundledAsset {
   path: string;
   packaging: FileAssetPackaging;
@@ -702,6 +727,8 @@ interface BundledAsset {
 /**
  * Returns the bundled asset to use based on the content of the bundle directory
  * and the type of output.
+ *
+ * Reads the bundle directory once; everything below is derived from those entries.
  */
 function determineBundledAsset(
   scope: Construct,
@@ -710,15 +737,24 @@ function determineBundledAsset(
   ignore: IgnoreStrategy,
   followMode?: SymlinkFollowMode,
 ): BundledAsset {
-  const archiveFile = findSingleFile(scope, bundleDir, outputType !== BundlingOutput.SINGLE_FILE);
+  const stats = fs.statSync(bundleDir, { throwIfNoEntry: false });
+  if (!stats) {
+    throw new ValidationError(lit`DirectoryDoesNotExist`, `Directory ${bundleDir} does not exist.`, scope);
+  }
+  if (!stats.isDirectory()) {
+    throw new ValidationError(lit`PathIsNotDirectory`, `${bundleDir} is not a directory.`, scope);
+  }
+
+  const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
+  const singleFile = findSingleOutputFile(entries, outputType);
 
   // auto-discover means that if there is an archive file, we take it as the
   // bundle, otherwise, we will archive here.
-  if (outputType === BundlingOutput.AUTO_DISCOVER) {
-    outputType = archiveFile ? BundlingOutput.ARCHIVED : BundlingOutput.NOT_ARCHIVED;
-  }
+  const discoveredOutputType = outputType === BundlingOutput.AUTO_DISCOVER
+    ? (singleFile ? BundlingOutput.ARCHIVED : BundlingOutput.NOT_ARCHIVED)
+    : outputType;
 
-  switch (outputType) {
+  switch (discoveredOutputType) {
     case BundlingOutput.NOT_ARCHIVED:
       if (followMode == SymlinkFollowMode.BLOCK_EXTERNAL) {
         validateInternalSymlinks(bundleDir, scope, followMode, ignore);
@@ -726,13 +762,35 @@ function determineBundledAsset(
       return { path: bundleDir, packaging: FileAssetPackaging.ZIP_DIRECTORY };
     case BundlingOutput.ARCHIVED:
     case BundlingOutput.SINGLE_FILE:
-      if (!archiveFile) {
+      if (!singleFile) {
         throw new ValidationError(lit`BundlingOutputDirectoryExpectedSingleFile`, 'Bundling output directory is expected to include only a single file when `output` is set to `ARCHIVED` or `SINGLE_FILE`', scope);
-      } else if (fs.lstatSync(archiveFile).isSymbolicLink()) {
+      } else if (singleFile.isSymbolicLink()) {
         throw new ValidationError(lit`SymlinkInBundlingOutput`, 'The output from bundling is not allowed to be a symlink.', scope);
       }
-      return { path: archiveFile, packaging: FileAssetPackaging.FILE, extension: getExtension(archiveFile) };
+      return {
+        path: path.join(bundleDir, singleFile.name),
+        packaging: FileAssetPackaging.FILE,
+        extension: getExtension(singleFile.name),
+      };
   }
+}
+
+/**
+ * Returns the lone file bundling produced, or undefined if the output isn't a single file.
+ *
+ * `SINGLE_FILE` accepts any lone file. Other output types only accept one that looks like
+ * an archive, so a single loose file still gets zipped.
+ */
+function findSingleOutputFile(entries: fs.Dirent[], outputType: BundlingOutput): fs.Dirent | undefined {
+  if (entries.length !== 1) {
+    return undefined;
+  }
+
+  const entry = entries[0];
+  const isFile = entry.isFile() || entry.isSymbolicLink();
+  const isArchive = ARCHIVE_EXTENSIONS.includes(getExtension(entry.name).toLowerCase());
+
+  return isFile && (isArchive || outputType === BundlingOutput.SINGLE_FILE) ? entry : undefined;
 }
 
 /**

--- a/packages/aws-cdk-lib/core/lib/fs/copy.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/copy.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { IgnoreStrategy } from './ignore';
 import type { CopyOptions } from './options';
 import { SymlinkFollowMode } from './options';
-import { resolveLinkTarget, shouldFollow } from './utils';
+import { walkDirectory } from './utils';
 import { UnscopedValidationError } from '../errors';
 import { lit } from '../private/literal-string';
 
@@ -16,61 +16,39 @@ export function copyDirectory(srcDir: string, destDir: string, options: CopyOpti
     throw new UnscopedValidationError(lit`Directory`, `${srcDir} is not a directory`);
   }
 
-  copyInto(srcDir, destDir);
+  walkDirectory(srcDir, { follow, ignoreStrategy, root }, {
+    onDirectory: (entry) => {
+      // An ignored directory is not created. If something below it is re-included, copying
+      // that file creates the directory on the way.
+      if (!entry.ignored) {
+        fs.mkdirSync(destinationOf(entry.path), { recursive: true });
+      }
+    },
 
-  function copyInto(sourceDir: string, targetDir: string) {
-    for (const file of fs.readdirSync(sourceDir)) {
-      const sourceFilePath = path.join(sourceDir, file);
+    onFile: (entry) => {
+      const destination = destinationOf(entry.path);
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.copyFileSync(entry.realPath, destination);
+    },
 
-      if (ignoreStrategy.completelyIgnores(sourceFilePath)) {
-        continue;
+    onSymlink: (entry) => {
+      if (follow === SymlinkFollowMode.BLOCK_EXTERNAL && !entry.internal) {
+        throw new UnscopedValidationError(
+          lit`BundlingFileSymlinkForbidden`,
+          `The file ${entry.resolvedLinkTarget} is an external symbolic link which is forbidden due to follow mode ${follow}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
+        );
       }
 
-      const destFilePath = path.join(targetDir, file);
-
-      // ALWAYS resolves every entry up front, so symlinks never show up as links below.
-      let stat: fs.Stats | undefined = follow === SymlinkFollowMode.ALWAYS
-        ? fs.statSync(sourceFilePath)
-        : fs.lstatSync(sourceFilePath);
-
-      if (stat.isSymbolicLink()) {
-        // Target's stats if we follow the link, undefined if we copied the link itself.
-        stat = copyOrFollowSymlink(sourceFilePath, destFilePath);
-      }
-
-      if (!stat) {
-        continue;
-      }
-
-      if (stat.isDirectory()) {
-        if (!ignoreStrategy.ignores(sourceFilePath)) {
-          fs.mkdirSync(destFilePath, { recursive: true });
-        }
-        copyInto(sourceFilePath, destFilePath);
-      } else if (stat.isFile()) {
-        if (!ignoreStrategy.ignores(sourceFilePath)) {
-          fs.mkdirSync(targetDir, { recursive: true });
-          fs.copyFileSync(sourceFilePath, destFilePath);
-        }
-      }
-    }
-  }
+      const destination = destinationOf(entry.path);
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.symlinkSync(entry.linkTarget, destination);
+    },
+  });
 
   /**
-   * Returns the target's stats if the link should be followed, otherwise copies the link
-   * itself and returns undefined.
+   * The place under `destDir` an entry is copied to, mirroring where it sits under `srcDir`
    */
-  function copyOrFollowSymlink(sourceFilePath: string, destFilePath: string): fs.Stats | undefined {
-    const target = fs.readlinkSync(sourceFilePath);
-
-    if (shouldFollow(follow, root, resolveLinkTarget(sourceFilePath, target))) {
-      return fs.statSync(sourceFilePath);
-    }
-
-    if (!ignoreStrategy.ignores(sourceFilePath)) {
-      fs.mkdirSync(path.dirname(destFilePath), { recursive: true });
-      fs.symlinkSync(target, destFilePath);
-    }
-    return undefined;
+  function destinationOf(sourcePath: string): string {
+    return path.join(destDir, path.relative(srcDir, sourcePath));
   }
 }

--- a/packages/aws-cdk-lib/core/lib/fs/copy.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/copy.ts
@@ -3,65 +3,74 @@ import * as path from 'path';
 import { IgnoreStrategy } from './ignore';
 import type { CopyOptions } from './options';
 import { SymlinkFollowMode } from './options';
-import { shouldFollow } from './utils';
+import { resolveLinkTarget, shouldFollow } from './utils';
 import { UnscopedValidationError } from '../errors';
 import { lit } from '../private/literal-string';
 
 export function copyDirectory(srcDir: string, destDir: string, options: CopyOptions = { }, rootDir?: string) {
   const follow = options.follow ?? SymlinkFollowMode.EXTERNAL;
-
-  rootDir = rootDir || srcDir;
-
-  const ignoreStrategy = IgnoreStrategy.fromCopyOptions(options, rootDir);
+  const root = rootDir || srcDir;
+  const ignoreStrategy = IgnoreStrategy.fromCopyOptions(options, root);
 
   if (!fs.statSync(srcDir).isDirectory()) {
     throw new UnscopedValidationError(lit`Directory`, `${srcDir} is not a directory`);
   }
 
-  const files = fs.readdirSync(srcDir);
-  for (const file of files) {
-    const sourceFilePath = path.join(srcDir, file);
+  copyInto(srcDir, destDir);
 
-    if (ignoreStrategy.completelyIgnores(sourceFilePath)) {
-      continue;
-    }
+  function copyInto(sourceDir: string, targetDir: string) {
+    for (const file of fs.readdirSync(sourceDir)) {
+      const sourceFilePath = path.join(sourceDir, file);
 
-    const destFilePath = path.join(destDir, file);
+      if (ignoreStrategy.completelyIgnores(sourceFilePath)) {
+        continue;
+      }
 
-    let stat: fs.Stats | undefined = follow === SymlinkFollowMode.ALWAYS
-      ? fs.statSync(sourceFilePath)
-      : fs.lstatSync(sourceFilePath);
+      const destFilePath = path.join(targetDir, file);
 
-    if (stat && stat.isSymbolicLink()) {
-      const target = fs.readlinkSync(sourceFilePath);
+      // ALWAYS resolves every entry up front, so symlinks never show up as links below.
+      let stat: fs.Stats | undefined = follow === SymlinkFollowMode.ALWAYS
+        ? fs.statSync(sourceFilePath)
+        : fs.lstatSync(sourceFilePath);
 
-      // determine if this is an external link (i.e. the target's absolute path
-      // is outside of the root directory).
-      const targetPath = path.normalize(path.resolve(srcDir, target));
+      if (stat.isSymbolicLink()) {
+        // Target's stats if we follow the link, undefined if we copied the link itself.
+        stat = copyOrFollowSymlink(sourceFilePath, destFilePath);
+      }
 
-      if (shouldFollow(follow, rootDir, targetPath)) {
-        stat = fs.statSync(sourceFilePath);
-      } else {
+      if (!stat) {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
         if (!ignoreStrategy.ignores(sourceFilePath)) {
-          fs.mkdirSync(destDir, { recursive: true });
-          fs.symlinkSync(target, destFilePath);
+          fs.mkdirSync(destFilePath, { recursive: true });
         }
-        stat = undefined;
+        copyInto(sourceFilePath, destFilePath);
+      } else if (stat.isFile()) {
+        if (!ignoreStrategy.ignores(sourceFilePath)) {
+          fs.mkdirSync(targetDir, { recursive: true });
+          fs.copyFileSync(sourceFilePath, destFilePath);
+        }
       }
     }
+  }
 
-    if (stat && stat.isDirectory()) {
-      if (!ignoreStrategy.ignores(sourceFilePath)) fs.mkdirSync(destFilePath, { recursive: true });
-      copyDirectory(sourceFilePath, destFilePath, options, rootDir);
-      stat = undefined;
+  /**
+   * Returns the target's stats if the link should be followed, otherwise copies the link
+   * itself and returns undefined.
+   */
+  function copyOrFollowSymlink(sourceFilePath: string, destFilePath: string): fs.Stats | undefined {
+    const target = fs.readlinkSync(sourceFilePath);
+
+    if (shouldFollow(follow, root, resolveLinkTarget(sourceFilePath, target))) {
+      return fs.statSync(sourceFilePath);
     }
 
-    if (stat && stat.isFile()) {
-      if (!ignoreStrategy.ignores(sourceFilePath)) {
-        fs.mkdirSync(destDir, { recursive: true });
-        fs.copyFileSync(sourceFilePath, destFilePath);
-      }
-      stat = undefined;
+    if (!ignoreStrategy.ignores(sourceFilePath)) {
+      fs.mkdirSync(path.dirname(destFilePath), { recursive: true });
+      fs.symlinkSync(target, destFilePath);
     }
+    return undefined;
   }
 }

--- a/packages/aws-cdk-lib/core/lib/fs/fingerprint.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/fingerprint.ts
@@ -5,7 +5,7 @@ import { FingerprintDiskCache } from './fingerprint-disk-cache';
 import { IgnoreStrategy } from './ignore';
 import type { FingerprintOptions } from './options';
 import { IgnoreMode, SymlinkFollowMode } from './options';
-import { isInternalPath, resolveLinkTarget } from './utils';
+import { walkDirectory } from './utils';
 import { UnscopedValidationError } from '../errors';
 import { lit } from '../private/literal-string';
 
@@ -48,7 +48,7 @@ export function fingerprint(fileOrDirectory: string, options: FingerprintOptions
   const root = fs.realpathSync(fileOrDirectory);
   const isDir = fs.statSync(root).isDirectory();
 
-  // Hash keys are relative to `root`; inside/outside checks use the directory holding it.
+  // Hash keys are relative to `root`. The disk cache is scoped to the directory holding it.
   const rootDirectory = isDir ? root : path.dirname(root);
 
   const ignoreMode = options.ignoreMode || IgnoreMode.GLOB;
@@ -63,7 +63,22 @@ export function fingerprint(fileOrDirectory: string, options: FingerprintOptions
 
   // Dispatch based on whether the root is a file or directory
   if (isDir) {
-    processDirectory(root, root);
+    walkDirectory(root, { follow, ignoreStrategy }, {
+      // Stats are only present for a followed symlink, whose target the walk had to stat to
+      // know it was a file. Reuse those; plain files were never stat'ed, so stat them here.
+      onFile: (entry) => hashFileContent(entry.path, entry.stats
+        ? contentFingerprintWithStats(entry.realPath, entry.stats, cache)
+        : contentFingerprintOf(entry.realPath)),
+
+      onSymlink: (entry) => hashLinkTarget(entry.path, entry.linkTarget),
+
+      onUnsupported: (entry) => {
+        throw new UnscopedValidationError(
+          lit`UnableToUnableHashNeither`,
+          `Unable to hash ${entry.path}: it is neither a file nor a directory`,
+        );
+      },
+    });
   } else {
     hashFileContent(root, contentFingerprintOf(root));
   }
@@ -94,86 +109,6 @@ export function fingerprint(fileOrDirectory: string, options: FingerprintOptions
   function contentFingerprintOf(file: string): string {
     return contentFingerprintWithStats(file, fs.statSync(file, { bigint: true }), cache);
   }
-
-  // --- Inlined shouldFollow logic (avoids per-call path.resolve + fs.existsSync overhead) ---
-
-  function shouldFollowLink(resolvedLinkTarget: string): boolean {
-    switch (follow) {
-      case SymlinkFollowMode.ALWAYS:
-        return true;
-      case SymlinkFollowMode.EXTERNAL:
-        return !isInternalPath(rootDirectory, resolvedLinkTarget);
-      case SymlinkFollowMode.BLOCK_EXTERNAL:
-        return isInternalPath(rootDirectory, resolvedLinkTarget);
-      case SymlinkFollowMode.NEVER:
-        return false;
-      default:
-        return false;
-    }
-  }
-
-  // --- Core traversal ---
-
-  function processDirectory(symbolicPath: string, realPath: string) {
-    const entries = fs.readdirSync(realPath, { withFileTypes: true });
-    const sorted = entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
-    for (const entry of sorted) {
-      const childSymbolicPath = path.join(symbolicPath, entry.name);
-      const childRealPath = path.join(realPath, entry.name);
-      if (entry.isSymbolicLink()) {
-        processSymlink(childSymbolicPath, childRealPath);
-      } else if (entry.isFile()) {
-        if (!ignoreStrategy.ignores(childSymbolicPath)) {
-          hashFileContent(childSymbolicPath, contentFingerprintOf(childRealPath));
-        }
-      } else if (entry.isDirectory()) {
-        if (!ignoreStrategy.completelyIgnores(childSymbolicPath)) {
-          processDirectory(childSymbolicPath, childRealPath);
-        }
-      }
-    }
-  }
-
-  function processSymlink(symbolicPath: string, realPath: string) {
-    const linkTarget = fs.readlinkSync(realPath);
-    const resolvedLinkTarget = resolveLinkTarget(realPath, linkTarget);
-
-    // Follow the link only if the mode allows it and the target exists.
-    const targetStat = shouldFollowLink(resolvedLinkTarget) ? tryStat(resolvedLinkTarget) : undefined;
-
-    if (!targetStat) {
-      if (!ignoreStrategy.ignores(symbolicPath)) {
-        hashLinkTarget(symbolicPath, linkTarget);
-      }
-      return;
-    }
-
-    if (targetStat.isDirectory()) {
-      if (!ignoreStrategy.completelyIgnores(symbolicPath)) {
-        processDirectory(symbolicPath, resolvedLinkTarget);
-      }
-    } else if (targetStat.isFile()) {
-      if (!ignoreStrategy.ignores(symbolicPath)) {
-        hashFileContent(symbolicPath, contentFingerprintWithStats(resolvedLinkTarget, targetStat, cache));
-      }
-    } else {
-      throw new UnscopedValidationError(
-        lit`UnableToUnableHashNeither`,
-        `Unable to hash ${symbolicPath}: it is neither a file nor a directory`,
-      );
-    }
-  }
-}
-
-/**
- * Stats a path, or returns undefined if it cannot be reached.
- */
-function tryStat(target: string): fs.BigIntStats | undefined {
-  try {
-    return fs.statSync(target, { bigint: true });
-  } catch {
-    return undefined;
-  }
 }
 
 export function contentFingerprint(file: string): string {
@@ -182,7 +117,9 @@ export function contentFingerprint(file: string): string {
 }
 
 function contentFingerprintWithStats(file: string, stats: fs.BigIntStats, cache: FingerprintDiskCache | undefined): string {
-  const cacheKey = `${stats.ino}|${stats.mtimeMs}|${stats.size}`;
+  // Nanosecond mtime: millisecond resolution would give same-size writes within
+  // the same millisecond an identical key, and a stale cache hit.
+  const cacheKey = `${stats.ino}|${stats.mtimeNs}|${stats.size}`;
   return cache?.obtain(cacheKey, () => contentFingerprintMiss(file)) ?? contentFingerprintMiss(file);
 }
 

--- a/packages/aws-cdk-lib/core/lib/fs/fingerprint.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/fingerprint.ts
@@ -37,60 +37,74 @@ export function clearLargeFileFingerprintCache() {
  */
 export function fingerprint(fileOrDirectory: string, options: FingerprintOptions = { }) {
   const hash = crypto.createHash('sha256');
-  _hashField(hash, 'options.extra', options.extraHash || '');
+  hashField(hash, 'options.extra', options.extraHash || '');
   const follow = options.follow || SymlinkFollowMode.EXTERNAL;
-  _hashField(hash, 'options.follow', follow);
+  hashField(hash, 'options.follow', follow);
 
   // Resolve symlinks in the initial path (for example, the root directory
   // might be symlinked). It's important that we know the absolute path, so we
   // can judge if further symlinks inside the target directory are within the
   // target or not (if we don't resolve, we would test w.r.t. the wrong path).
-  fileOrDirectory = fs.realpathSync(fileOrDirectory);
+  const root = fs.realpathSync(fileOrDirectory);
+  const isDir = fs.statSync(root).isDirectory();
 
-  const isDir = fs.statSync(fileOrDirectory).isDirectory();
-  const rootDirectory = isDir
-    ? fileOrDirectory
-    : path.dirname(fileOrDirectory);
+  // Hash keys are relative to `root`; inside/outside checks use the directory holding it.
+  const rootDirectory = isDir ? root : path.dirname(root);
 
   const ignoreMode = options.ignoreMode || IgnoreMode.GLOB;
   if (ignoreMode != IgnoreMode.GLOB) {
-    _hashField(hash, 'options.ignoreMode', ignoreMode);
+    hashField(hash, 'options.ignoreMode', ignoreMode);
   }
 
-  // Pre-resolve rootDirectory once — avoids repeated path.resolve in the hot loop
-  const resolvedRoot = path.resolve(rootDirectory);
-
-  const ignoreStrategy = IgnoreStrategy.fromCopyOptions(options, fileOrDirectory);
+  const ignoreStrategy = IgnoreStrategy.fromCopyOptions(options, root);
 
   // Per-operation disk cache scoped to this directory
-  const cache = new FingerprintDiskCache(resolvedRoot);
-
-  function _contentFingerprint(file: string): string {
-    const stats = fs.statSync(file, { bigint: true });
-    return contentFingerprintWithStats(file, stats, cache);
-  }
+  const cache = new FingerprintDiskCache(rootDirectory);
 
   // Dispatch based on whether the root is a file or directory
   if (isDir) {
-    _processDirectory(fileOrDirectory, fileOrDirectory);
+    processDirectory(root, root);
   } else {
-    const hashComponent = path.relative(fileOrDirectory, fileOrDirectory).replace(/\\/g, '/');
-    _hashField(hash, `file:${hashComponent}`, _contentFingerprint(fileOrDirectory));
+    hashFileContent(root, contentFingerprintOf(root));
   }
 
   cache.save();
   return hash.digest('hex');
 
+  // --- Hashing ---
+
+  /**
+   * Root-relative and forward-slashed, so fingerprints match across platforms.
+   */
+  function hashKey(symbolicPath: string): string {
+    return path.relative(root, symbolicPath).replace(/\\/g, '/');
+  }
+
+  function hashFileContent(symbolicPath: string, contentHash: string) {
+    hashField(hash, `file:${hashKey(symbolicPath)}`, contentHash);
+  }
+
+  /**
+   * Hashes where a symlink points, not what it points at.
+   */
+  function hashLinkTarget(symbolicPath: string, linkTarget: string) {
+    hashField(hash, `link:${hashKey(symbolicPath)}`, linkTarget);
+  }
+
+  function contentFingerprintOf(file: string): string {
+    return contentFingerprintWithStats(file, fs.statSync(file, { bigint: true }), cache);
+  }
+
   // --- Inlined shouldFollow logic (avoids per-call path.resolve + fs.existsSync overhead) ---
 
-  function _shouldFollowLink(resolvedLinkTarget: string): boolean {
+  function shouldFollowLink(resolvedLinkTarget: string): boolean {
     switch (follow) {
       case SymlinkFollowMode.ALWAYS:
         return true;
       case SymlinkFollowMode.EXTERNAL:
-        return !isInternalPath(resolvedRoot, resolvedLinkTarget);
+        return !isInternalPath(rootDirectory, resolvedLinkTarget);
       case SymlinkFollowMode.BLOCK_EXTERNAL:
-        return isInternalPath(resolvedRoot, resolvedLinkTarget);
+        return isInternalPath(rootDirectory, resolvedLinkTarget);
       case SymlinkFollowMode.NEVER:
         return false;
       default:
@@ -100,74 +114,65 @@ export function fingerprint(fileOrDirectory: string, options: FingerprintOptions
 
   // --- Core traversal ---
 
-  function _processDirectory(symbolicPath: string, realPath: string) {
+  function processDirectory(symbolicPath: string, realPath: string) {
     const entries = fs.readdirSync(realPath, { withFileTypes: true });
     const sorted = entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
     for (const entry of sorted) {
       const childSymbolicPath = path.join(symbolicPath, entry.name);
       const childRealPath = path.join(realPath, entry.name);
       if (entry.isSymbolicLink()) {
-        _processSymlink(childSymbolicPath, childRealPath);
+        processSymlink(childSymbolicPath, childRealPath);
       } else if (entry.isFile()) {
-        if (ignoreStrategy.ignores(childSymbolicPath)) {
-          continue;
+        if (!ignoreStrategy.ignores(childSymbolicPath)) {
+          hashFileContent(childSymbolicPath, contentFingerprintOf(childRealPath));
         }
-        const hashComponent = path.relative(fileOrDirectory, childSymbolicPath).replace(/\\/g, '/');
-        _hashField(hash, `file:${hashComponent}`, _contentFingerprint(childRealPath));
       } else if (entry.isDirectory()) {
-        if (ignoreStrategy.completelyIgnores(childSymbolicPath)) {
-          continue;
+        if (!ignoreStrategy.completelyIgnores(childSymbolicPath)) {
+          processDirectory(childSymbolicPath, childRealPath);
         }
-        _processDirectory(childSymbolicPath, childRealPath);
       }
     }
   }
 
-  function _processSymlink(symbolicPath: string, realPath: string) {
+  function processSymlink(symbolicPath: string, realPath: string) {
     const linkTarget = fs.readlinkSync(realPath);
     const resolvedLinkTarget = resolveLinkTarget(realPath, linkTarget);
 
-    if (!_shouldFollowLink(resolvedLinkTarget)) {
-      // Not following — hash the link target string itself
-      if (ignoreStrategy.ignores(symbolicPath)) {
-        return;
-      }
-      const hashComponent = path.relative(fileOrDirectory, symbolicPath).replace(/\\/g, '/');
-      _hashField(hash, `link:${hashComponent}`, linkTarget);
-      return;
-    }
+    // Follow the link only if the mode allows it and the target exists.
+    const targetStat = shouldFollowLink(resolvedLinkTarget) ? tryStat(resolvedLinkTarget) : undefined;
 
-    // Following the symlink — stat the target to determine type
-    let targetStat: fs.BigIntStats;
-    try {
-      targetStat = fs.statSync(resolvedLinkTarget, { bigint: true });
-    } catch {
-      // Target doesn't exist — treat as non-followed link
-      if (ignoreStrategy.ignores(symbolicPath)) {
-        return;
+    if (!targetStat) {
+      if (!ignoreStrategy.ignores(symbolicPath)) {
+        hashLinkTarget(symbolicPath, linkTarget);
       }
-      const hashComponent = path.relative(fileOrDirectory, symbolicPath).replace(/\\/g, '/');
-      _hashField(hash, `link:${hashComponent}`, linkTarget);
       return;
     }
 
     if (targetStat.isDirectory()) {
-      if (ignoreStrategy.completelyIgnores(symbolicPath)) {
-        return;
+      if (!ignoreStrategy.completelyIgnores(symbolicPath)) {
+        processDirectory(symbolicPath, resolvedLinkTarget);
       }
-      _processDirectory(symbolicPath, resolvedLinkTarget);
     } else if (targetStat.isFile()) {
-      if (ignoreStrategy.ignores(symbolicPath)) {
-        return;
+      if (!ignoreStrategy.ignores(symbolicPath)) {
+        hashFileContent(symbolicPath, contentFingerprintWithStats(resolvedLinkTarget, targetStat, cache));
       }
-      const hashComponent = path.relative(fileOrDirectory, symbolicPath).replace(/\\/g, '/');
-      _hashField(hash, `file:${hashComponent}`, contentFingerprintWithStats(resolvedLinkTarget, targetStat, cache));
     } else {
       throw new UnscopedValidationError(
         lit`UnableToUnableHashNeither`,
         `Unable to hash ${symbolicPath}: it is neither a file nor a directory`,
       );
     }
+  }
+}
+
+/**
+ * Stats a path, or returns undefined if it cannot be reached.
+ */
+function tryStat(target: string): fs.BigIntStats | undefined {
+  try {
+    return fs.statSync(target, { bigint: true });
+  } catch {
+    return undefined;
   }
 }
 
@@ -233,6 +238,6 @@ function contentFingerprintMiss(file: string): string {
   return `${size}:${hash.digest('hex')}`;
 }
 
-function _hashField(hash: crypto.Hash, header: string, value: string | Buffer | DataView) {
+function hashField(hash: crypto.Hash, header: string, value: string | Buffer | DataView) {
   hash.update(CTRL_SOH).update(header).update(CTRL_SOT).update(value).update(CTRL_ETX);
 }

--- a/packages/aws-cdk-lib/core/lib/fs/ignore.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/ignore.ts
@@ -12,6 +12,10 @@ import { lit } from '../private/literal-string';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { minimatch } = require('minimatch');
 
+// Negation rules as described in @balena/dockerignore.
+// See https://www.npmjs.com/package/@balena/dockerignore#exclusion-patterns
+const DOCKER_NEGATIVE_PATTERN = /^\s*(\!|\/\!)(.*)/;
+
 /**
  * Represents file path ignoring behavior.
  */
@@ -112,38 +116,22 @@ export class GlobIgnoreStrategy extends IgnoreStrategy {
     this.patterns = patterns;
   }
 
-  /**
-   * Adds another pattern.
-   * @params pattern the pattern to add
-   */
   public add(pattern: string): void {
     this.patterns.push(pattern);
   }
 
-  /**
-   * Determines whether a given file path should be ignored or not.
-   *
-   * @param absoluteFilePath absolute file path to be assessed against the pattern
-   * @returns `true` if the file should be ignored
-   */
   public ignores(absoluteFilePath: string): boolean {
     if (!path.isAbsolute(absoluteFilePath)) {
       throw new UnscopedValidationError(lit`GlobIgnoreStrategyIgnoresExpects`, 'GlobIgnoreStrategy.ignores() expects an absolute path');
     }
 
-    let relativePath = path.relative(this.absoluteRootPath, absoluteFilePath);
+    const relativePath = path.relative(this.absoluteRootPath, absoluteFilePath);
     let excludeOutput = false;
 
+    // Last matching pattern wins, and a `!` pattern re-includes.
     for (const pattern of this.patterns) {
-      const negate = pattern.startsWith('!');
-      const match = minimatch(relativePath, pattern, { matchBase: true, flipNegate: true });
-
-      if (!negate && match) {
-        excludeOutput = true;
-      }
-
-      if (negate && match) {
-        excludeOutput = false;
+      if (minimatch(relativePath, pattern, { matchBase: true, flipNegate: true })) {
+        excludeOutput = !pattern.startsWith('!');
       }
     }
 
@@ -169,45 +157,28 @@ export class GitIgnoreStrategy extends IgnoreStrategy {
     this.ignore = gitIgnore().add(patterns);
   }
 
-  /**
-   * Adds another pattern.
-   * @params pattern the pattern to add
-   */
   public add(pattern: string): void {
     this.ignore.add(pattern);
   }
 
-  /**
-   * Determines whether a given file path should be ignored or not.
-   *
-   * @param absoluteFilePath absolute file path to be assessed against the pattern
-   * @returns `true` if the file should be ignored
-   */
   public ignores(absoluteFilePath: string): boolean {
     if (!path.isAbsolute(absoluteFilePath)) {
       throw new UnscopedValidationError(lit`GitIgnoreStrategyIgnoresExpects`, 'GitIgnoreStrategy.ignores() expects an absolute path');
     }
 
-    let relativePath = path.relative(this.absoluteRootPath, absoluteFilePath);
-
-    return this.ignore.ignores(relativePath);
+    return this.ignore.ignores(path.relative(this.absoluteRootPath, absoluteFilePath));
   }
 
-  /**
-   * Determines whether a given directory path should be ignored and have all of its children ignored.
-   *
-   * @param absoluteDirectoryPath absolute directory path to be assessed against the pattern
-   * @returns `true` if the directory and all of its children should be ignored
-   */
   public completelyIgnores(absoluteDirectoryPath: string): boolean {
     if (!path.isAbsolute(absoluteDirectoryPath)) {
       throw new UnscopedValidationError(lit`GitIgnoreStrategyCompletelyIgnores`, 'GitIgnoreStrategy.completelyIgnores() expects an absolute path');
     }
 
+    // A trailing separator tells gitignore this is a directory.
     const relativePath = path.relative(this.absoluteRootPath, absoluteDirectoryPath);
-    const relativePathWithSep = relativePath.endsWith(path.sep) ? relativePath : relativePath + path.sep;
+    const asDirectory = relativePath.endsWith(path.sep) ? relativePath : relativePath + path.sep;
 
-    return this.ignore.ignores(relativePathWithSep);
+    return this.ignore.ignores(asDirectory);
   }
 }
 
@@ -218,9 +189,6 @@ export class DockerIgnoreStrategy extends IgnoreStrategy {
   private readonly absoluteRootPath: string;
   private readonly ignore: DockerIgnore.Ignore;
   private readonly completeIgnore: DockerIgnore.Ignore;
-  // Follows negation rules as describe in @balena/dockerignore
-  // See https://www.npmjs.com/package/@balena/dockerignore#exclusion-patterns
-  private readonly negativeIgnoreRegex = /^\s*(\!|\/\!)(.*)/;
 
   constructor(absoluteRootPath: string, patterns: string[]) {
     super();
@@ -246,24 +214,17 @@ export class DockerIgnoreStrategy extends IgnoreStrategy {
   private completelyAdd(pattern: string) {
     this.completeIgnore.add(pattern);
 
-    const negativeMatch = pattern.match(this.negativeIgnoreRegex);
-    if (negativeMatch !== null) {
-      let dirname: string | undefined = negativeMatch[2]!;
-      while (true) {
-        dirname = path.dirname(dirname);
-        if (dirname === '/' || dirname === '.') {
-          break;
-        }
+    const negativeMatch = pattern.match(DOCKER_NEGATIVE_PATTERN);
+    if (negativeMatch === null) {
+      return;
+    }
 
-        this.completeIgnore.add(negativeMatch[1]+dirname);
-      }
+    const [, negation, negatedPath] = negativeMatch;
+    for (let dir = path.dirname(negatedPath); dir !== '/' && dir !== '.'; dir = path.dirname(dir)) {
+      this.completeIgnore.add(negation + dir);
     }
   }
 
-  /**
-   * Adds another pattern.
-   * @params pattern the pattern to add
-   */
   public add(pattern: string): void {
     this.ignore.add(pattern);
     this.completelyAdd(pattern);
@@ -277,22 +238,10 @@ export class DockerIgnoreStrategy extends IgnoreStrategy {
     return path.relative(this.absoluteRootPath, absoluteFilePath);
   }
 
-  /**
-   * Determines whether a given file path should be ignored or not.
-   *
-   * @param absoluteFilePath absolute file path to be assessed against the pattern
-   * @returns `true` if the file should be ignored
-   */
   public ignores(absoluteFilePath: string): boolean {
     return this.ignore.ignores(this.getRelativePath(absoluteFilePath));
   }
 
-  /**
-   * Determines whether a given directory path should be ignored and have all of its children ignored.
-   *
-   * @param absoluteDirectoryPath absolute directory path to be assessed against the pattern
-   * @returns `true` if the directory and all of its children should be ignored
-   */
   public completelyIgnores(absoluteDirectoryPath: string): boolean {
     const relativePath = this.getRelativePath(absoluteDirectoryPath);
     return this.ignore.ignores(relativePath) && this.completeIgnore.ignores(relativePath);

--- a/packages/aws-cdk-lib/core/lib/fs/ignore.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/ignore.ts
@@ -220,7 +220,10 @@ export class DockerIgnoreStrategy extends IgnoreStrategy {
     }
 
     const [, negation, negatedPath] = negativeMatch;
-    for (let dir = path.dirname(negatedPath); dir !== '/' && dir !== '.'; dir = path.dirname(dir)) {
+    // Stop at a root without adding it. `dirname` of a root returns that same root, which
+    // covers `/` on posix and a drive root like `C:\` on win32 — the latter would otherwise
+    // never match a hardcoded `/` and loop forever.
+    for (let dir = path.dirname(negatedPath); dir !== '.' && path.dirname(dir) !== dir; dir = path.dirname(dir)) {
       this.completeIgnore.add(negation + dir);
     }
   }
@@ -230,20 +233,23 @@ export class DockerIgnoreStrategy extends IgnoreStrategy {
     this.completelyAdd(pattern);
   }
 
-  private getRelativePath(absoluteFilePath: string): string {
+  /**
+   * @param caller the public method to name in the error, since either can be the caller
+   */
+  private getRelativePath(absoluteFilePath: string, caller: string): string {
     if (!path.isAbsolute(absoluteFilePath)) {
-      throw new UnscopedValidationError(lit`DockerIgnoreStrategyIgnoresExpects`, 'DockerIgnoreStrategy.ignores() expects an absolute path');
+      throw new UnscopedValidationError(lit`DockerIgnoreStrategyIgnoresExpects`, `DockerIgnoreStrategy.${caller}() expects an absolute path`);
     }
 
     return path.relative(this.absoluteRootPath, absoluteFilePath);
   }
 
   public ignores(absoluteFilePath: string): boolean {
-    return this.ignore.ignores(this.getRelativePath(absoluteFilePath));
+    return this.ignore.ignores(this.getRelativePath(absoluteFilePath, 'ignores'));
   }
 
   public completelyIgnores(absoluteDirectoryPath: string): boolean {
-    const relativePath = this.getRelativePath(absoluteDirectoryPath);
+    const relativePath = this.getRelativePath(absoluteDirectoryPath, 'completelyIgnores');
     return this.ignore.ignores(relativePath) && this.completeIgnore.ignores(relativePath);
   }
 }

--- a/packages/aws-cdk-lib/core/lib/fs/options.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/options.ts
@@ -35,8 +35,9 @@ export enum SymlinkFollowMode {
    * tree.
    *
    * This is the safest mode of operation as it ensures that copy operations
-   * won't materialize files from the user's file system. Internal symlinks are
-   * not followed.
+   * won't materialize files from outside the source tree. Symlinks pointing
+   * inside the source tree are followed, so their targets are copied as regular
+   * files.
    *
    * If the copy operation runs into an external symlink, it will fail.
    */

--- a/packages/aws-cdk-lib/core/lib/fs/utils.ts
+++ b/packages/aws-cdk-lib/core/lib/fs/utils.ts
@@ -1,42 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { IgnoreStrategy } from './ignore';
 import { SymlinkFollowMode } from './options';
-import { UnscopedValidationError } from '../errors';
-import { lit } from '../private/literal-string';
-
-/**
- * Determines whether a symlink should be followed or not, based on a FollowMode.
- *
- * @param mode       the FollowMode.
- * @param sourceRoot the root of the source tree.
- * @param realPath   the real path of the target of the symlink.
- *
- * @returns true if the link should be followed.
- */
-export function shouldFollow(mode: SymlinkFollowMode, sourceRoot: string, realPath: string): boolean {
-  switch (mode) {
-    case SymlinkFollowMode.ALWAYS:
-      return fs.existsSync(realPath);
-    case SymlinkFollowMode.EXTERNAL:
-      return !_isInternal() && fs.existsSync(realPath);
-    case SymlinkFollowMode.BLOCK_EXTERNAL:
-      if (_isInternal()) {
-        return fs.existsSync(realPath);
-      } else {
-        throw new UnscopedValidationError(lit`BundlingFileSymlinkForbidden`,
-          `The file ${realPath} is an external symbolic link which is forbidden due to follow mode ${mode}. Set \`follow\` to a mode that will follow symlinks (ALWAYS or EXTERNAL) or emit a regular file`,
-        );
-      }
-    case SymlinkFollowMode.NEVER:
-      return false;
-    default:
-      throw new UnscopedValidationError(lit`UnsupportedFollowMode`, `Unsupported FollowMode: ${mode}`);
-  }
-
-  function _isInternal(): boolean {
-    return isInternalPath(path.resolve(sourceRoot), path.resolve(realPath));
-  }
-}
 
 export function isInternalPath(rootPath: string, targetPath: string): boolean {
   return rootPath === targetPath || targetPath.startsWith(rootPath + path.sep);
@@ -46,4 +11,280 @@ export function resolveLinkTarget(realPath: string, linkTarget: string): string 
   return path.isAbsolute(linkTarget)
     ? path.resolve(linkTarget)
     : path.resolve(path.dirname(realPath), linkTarget);
+}
+
+/**
+ * An entry encountered while walking a directory tree
+ */
+export interface WalkEntry {
+  /**
+   * Where the entry sits in the tree
+   *
+   * If a symlink was followed to get here, this path goes through the symlink rather
+   * than through the target it points at.
+   */
+  readonly path: string;
+
+  /**
+   * The path to read this entry's content from
+   *
+   * Same as `path`, unless a symlink was followed, in which case it is the link's target.
+   */
+  readonly realPath: string;
+}
+
+/**
+ * A directory whose contents are about to be walked
+ */
+export interface WalkDirectoryEntry extends WalkEntry {
+  /**
+   * Whether the directory itself is excluded by the ignore strategy
+   *
+   * The walk still descends into it, because a pattern that excludes a directory can
+   * re-include files underneath it. A directory that is excluded along with everything
+   * inside it is skipped and never reported at all.
+   */
+  readonly ignored: boolean;
+}
+
+/**
+ * A file, or a symlink that was followed to one
+ */
+export interface WalkFileEntry extends WalkEntry {
+  /**
+   * Stats of a followed symlink's target
+   *
+   * Only set when the walk already had to stat the target, so callers that need stats can
+   * use these instead of calling `stat` again.
+   */
+  readonly stats?: fs.BigIntStats;
+}
+
+/**
+ * A symlink that is being kept as a link rather than followed
+ */
+export interface WalkSymlinkEntry extends WalkEntry {
+  /**
+   * The link target exactly as written, which is what gets copied or hashed
+   */
+  readonly linkTarget: string;
+
+  /**
+   * `linkTarget` resolved against the link's own directory
+   */
+  readonly resolvedLinkTarget: string;
+
+  /**
+   * Whether the target is inside the walk root
+   */
+  readonly internal: boolean;
+}
+
+/**
+ * Receives the entries that a walk includes in its result
+ *
+ * Every callback is optional, so a visitor only implements the entry kinds it cares
+ * about. Entries excluded by the ignore strategy are never reported.
+ */
+export interface WalkVisitor {
+  /**
+   * A file, or a symlink that was followed to a file
+   */
+  onFile?(entry: WalkFileEntry): void;
+
+  /**
+   * A directory, or a symlink that was followed to a directory
+   */
+  onDirectory?(entry: WalkDirectoryEntry): void;
+
+  /**
+   * A symlink that is not being followed
+   */
+  onSymlink?(entry: WalkSymlinkEntry): void;
+
+  /**
+   * A followed symlink whose target is neither a file nor a directory
+   *
+   * For example a socket, a named pipe or a device node.
+   */
+  onUnsupported?(entry: WalkEntry): void;
+}
+
+/**
+ * Options for `walkDirectory`
+ */
+export interface WalkOptions {
+  /**
+   * What to do with the symlinks encountered along the way
+   */
+  readonly follow: SymlinkFollowMode;
+
+  /**
+   * Which entries to leave out of the walk
+   */
+  readonly ignoreStrategy: IgnoreStrategy;
+
+  /**
+   * The tree a symlink has to point inside of to count as internal
+   *
+   * @default - the directory being walked
+   */
+  readonly root?: string;
+}
+
+/**
+ * Walk a directory tree, reporting the entries that belong in its result
+ *
+ * Fingerprinting, copying and symlink validation all share this traversal, so all three
+ * agree on what an asset contains: how the ignore strategy is applied, which symlinks are
+ * followed, and how a link target is resolved. Those decisions are made here; callers only
+ * decide what to do with an entry.
+ *
+ * Entries are visited in sorted order, so a caller that hashes the entries it is given
+ * gets the same hash every time.
+ */
+export function walkDirectory(directory: string, options: WalkOptions, visitor: WalkVisitor) {
+  const { follow, ignoreStrategy } = options;
+
+  // Resolve symlinks in the root itself so that inside/outside comparisons are made against
+  // the real location. `path.resolve` cleans up `..` but does not resolve symlinks, so
+  // without this a symlinked directory *above* the root makes paths inside the tree look
+  // like they are outside it.
+  const canonicalRoot = realPathOrSelf(options.root ?? directory);
+
+  // Real paths of the directories we are currently inside. Used to stop a symlink that
+  // points back at one of its own parent directories from recursing forever.
+  const ancestors = new Set<string>();
+
+  walk(directory, directory, realPathOrSelf(directory));
+
+  /**
+   * @param symbolicPath where this directory sits in the tree
+   * @param realPath the path to read it from
+   * @param canonicalPath `realPath` with symlinks resolved, used to detect cycles
+   */
+  function walk(symbolicPath: string, realPath: string, canonicalPath: string) {
+    // We are already inside this directory, so going in again would never finish. Two
+    // separate links to the same directory are not inside each other, so both of those are
+    // still walked in full.
+    if (ancestors.has(canonicalPath)) {
+      return;
+    }
+    ancestors.add(canonicalPath);
+
+    const entries = fs.readdirSync(realPath, { withFileTypes: true });
+    entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+
+    for (const entry of entries) {
+      const childPath = path.join(symbolicPath, entry.name);
+      const childRealPath = path.join(realPath, entry.name);
+
+      if (entry.isSymbolicLink()) {
+        visitSymlink(childPath, childRealPath);
+      } else if (entry.isDirectory()) {
+        visitDirectory(childPath, childRealPath, path.join(canonicalPath, entry.name));
+      } else if (entry.isFile()) {
+        visitFile({ path: childPath, realPath: childRealPath });
+      }
+    }
+
+    ancestors.delete(canonicalPath);
+  }
+
+  function visitDirectory(symbolicPath: string, realPath: string, canonicalPath: string) {
+    if (ignoreStrategy.completelyIgnores(symbolicPath)) {
+      return;
+    }
+
+    // Ignored directories are still reported, so the visitor can decide what to do with
+    // them, and are still walked into because files below them may be re-included.
+    if (visitor.onDirectory) {
+      visitor.onDirectory({ path: symbolicPath, realPath, ignored: ignoreStrategy.ignores(symbolicPath) });
+    }
+
+    walk(symbolicPath, realPath, canonicalPath);
+  }
+
+  function visitFile(entry: WalkFileEntry) {
+    if (!ignoreStrategy.ignores(entry.path)) {
+      visitor.onFile?.(entry);
+    }
+  }
+
+  function visitSymlink(symbolicPath: string, realPath: string) {
+    const linkTarget = fs.readlinkSync(realPath);
+    const resolvedLinkTarget = canonicalLinkTarget(resolveLinkTarget(realPath, linkTarget));
+    const internal = isInternalPath(canonicalRoot, resolvedLinkTarget);
+
+    // If the target cannot be reached we treat the link as one we are not following, so a
+    // broken link is reported as a link instead of failing the walk.
+    const targetStats = shouldFollow(internal) ? tryStat(resolvedLinkTarget) : undefined;
+
+    if (!targetStats) {
+      if (!ignoreStrategy.ignores(symbolicPath)) {
+        visitor.onSymlink?.({ path: symbolicPath, realPath, linkTarget, resolvedLinkTarget, internal });
+      }
+      return;
+    }
+
+    // We are following the link, so the entry is reported at the link's own path but read
+    // from the target.
+    if (targetStats.isDirectory()) {
+      visitDirectory(symbolicPath, resolvedLinkTarget, realPathOrSelf(resolvedLinkTarget));
+    } else if (targetStats.isFile()) {
+      visitFile({ path: symbolicPath, realPath: resolvedLinkTarget, stats: targetStats });
+    } else if (!ignoreStrategy.ignores(symbolicPath)) {
+      visitor.onUnsupported?.({ path: symbolicPath, realPath: resolvedLinkTarget });
+    }
+  }
+
+  /**
+   * Whether to follow a link, which every mode decides based only on where the target is
+   */
+  function shouldFollow(internal: boolean): boolean {
+    switch (follow) {
+      case SymlinkFollowMode.ALWAYS:
+        return true;
+      case SymlinkFollowMode.EXTERNAL:
+        return !internal;
+      case SymlinkFollowMode.BLOCK_EXTERNAL:
+        return internal;
+      case SymlinkFollowMode.NEVER:
+      default:
+        return false;
+    }
+  }
+}
+
+/**
+ * Resolves symlinks in the directories that lead up to a link target, but not in the target
+ * itself
+ *
+ * If the target is itself a symlink we want to know where it is, not where it points, since
+ * that is the location we compare against the walk root.
+ */
+function canonicalLinkTarget(target: string): string {
+  return path.join(realPathOrSelf(path.dirname(target)), path.basename(target));
+}
+
+/**
+ * Resolves the symlinks in a path, returning it unchanged if that is not possible
+ */
+function realPathOrSelf(target: string): string {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return target;
+  }
+}
+
+/**
+ * Stats a path, or returns undefined if it cannot be reached
+ */
+function tryStat(target: string): fs.BigIntStats | undefined {
+  try {
+    return fs.statSync(target, { bigint: true });
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/aws-cdk-lib/core/test/fs/utils.test.ts
+++ b/packages/aws-cdk-lib/core/test/fs/utils.test.ts
@@ -1,193 +1,10 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
-import { ImportMock } from 'ts-mock-imports';
-import { SymlinkFollowMode } from '../../lib/fs';
+import { IgnoreStrategy, SymlinkFollowMode } from '../../lib/fs';
 import * as util from '../../lib/fs/utils';
 
 describe('utils', () => {
-  describe('shouldFollow', () => {
-    describe('always', () => {
-      test('follows internal', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', true);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.ALWAYS, sourceRoot, linkTarget)).toEqual(true);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('follows external', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', true);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.ALWAYS, sourceRoot, linkTarget)).toEqual(true);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('does not follow internal when the referent does not exist', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', false);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.ALWAYS, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('does not follow external when the referent does not exist', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', false);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.ALWAYS, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-    });
-
-    describe('external', () => {
-      test('does not follow internal', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync');
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.EXTERNAL, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.notCalled).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('follows external', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', true);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.EXTERNAL, sourceRoot, linkTarget)).toEqual(true);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('follows a sibling that shares a name prefix with the root', () => {
-        // 'source/root-sibling' is NOT inside 'source/root', even though its path
-        // string starts with the root string. It must be treated as external.
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('source', 'root-sibling', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', true);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.EXTERNAL, sourceRoot, linkTarget)).toEqual(true);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('does not follow external when referent does not exist', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', false);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.EXTERNAL, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-    });
-
-    describe('blockExternal', () => {
-      test('follows internal', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', true);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.BLOCK_EXTERNAL, sourceRoot, linkTarget)).toEqual(true);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('does not follow internal when referent does not exist', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync', false);
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.BLOCK_EXTERNAL, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.calledOnceWith(linkTarget)).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('throws on external', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync');
-        try {
-          expect(() => util.shouldFollow(SymlinkFollowMode.BLOCK_EXTERNAL, sourceRoot, linkTarget))
-            .toThrow(/external symbolic link which is forbidden/);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('throws on a sibling that shares a name prefix with the root', () => {
-        // 'source/root-sibling' is external to 'source/root' despite the shared
-        // string prefix, so BLOCK_EXTERNAL must reject it.
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('source', 'root-sibling', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync');
-        try {
-          expect(() => util.shouldFollow(SymlinkFollowMode.BLOCK_EXTERNAL, sourceRoot, linkTarget))
-            .toThrow(/external symbolic link which is forbidden/);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-    });
-
-    describe('never', () => {
-      test('does not follow internal', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join(sourceRoot, 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync');
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.NEVER, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.notCalled).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-
-      test('does not follow external', () => {
-        const sourceRoot = path.join('source', 'root');
-        const linkTarget = path.join('alternate', 'referent');
-        const mockFsExists = ImportMock.mockFunction(fs, 'existsSync');
-        try {
-          expect(util.shouldFollow(SymlinkFollowMode.NEVER, sourceRoot, linkTarget)).toEqual(false);
-          expect(mockFsExists.notCalled).toEqual(true);
-        } finally {
-          mockFsExists.restore();
-        }
-      });
-    });
-  });
-
   describe('isInternalPath', () => {
     const root = path.resolve(path.join('source', 'root'));
 
@@ -231,6 +48,291 @@ describe('utils', () => {
       expect(util.resolveLinkTarget(realPath, linkTarget)).toEqual(
         path.resolve(path.join('source', 'root', 'sibling', 'referent')),
       );
+    });
+  });
+
+  describe('walkDirectory', () => {
+    let tmp: string;
+    let root: string;
+    let outside: string;
+
+    beforeEach(() => {
+      // Realpath'd because `os.tmpdir()` is itself a symlink on macOS, which would
+      // otherwise make every path under it compare as external.
+      tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'walk-tests')));
+      root = path.join(tmp, 'root');
+      outside = path.join(tmp, 'outside');
+      fs.mkdirSync(root);
+      fs.mkdirSync(outside);
+      fs.writeFileSync(path.join(outside, 'referent.txt'), 'outside');
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmp, { force: true, recursive: true });
+    });
+
+    /**
+     * Walks a directory and records what each callback was handed, root-relative so the
+     * assertions don't contain temp directory names.
+     */
+    function record(options: Partial<util.WalkOptions> = {}, directory = root) {
+      const files = new Array<string>();
+      const directories = new Array<string>();
+      const symlinks = new Array<string>();
+      const unsupported = new Array<string>();
+
+      util.walkDirectory(directory, {
+        follow: SymlinkFollowMode.EXTERNAL,
+        ignoreStrategy: IgnoreStrategy.glob(directory, []),
+        ...options,
+      }, {
+        onFile: (entry) => files.push(rel(directory, entry.path)),
+        onDirectory: (entry) => directories.push(rel(directory, entry.path) + (entry.ignored ? ' (ignored)' : '')),
+        onSymlink: (entry) => symlinks.push(`${rel(directory, entry.path)} => ${entry.linkTarget}${entry.internal ? '' : ' (external)'}`),
+        onUnsupported: (entry) => unsupported.push(rel(directory, entry.path)),
+      });
+
+      return { files, directories, symlinks, unsupported };
+    }
+
+    function rel(from: string, to: string): string {
+      return path.relative(from, to).replace(/\\/g, '/');
+    }
+
+    /**
+     * `internal-link` points at a file in the tree, `external-link` at one outside it.
+     * Link targets are written with forward slashes so they can be asserted verbatim.
+     */
+    function writeLinks() {
+      fs.writeFileSync(path.join(root, 'file.txt'), 'inside');
+      fs.symlinkSync('file.txt', path.join(root, 'internal-link'));
+      fs.symlinkSync('../outside/referent.txt', path.join(root, 'external-link'));
+    }
+
+    describe('follow modes', () => {
+      test('ALWAYS follows both internal and external links', () => {
+        writeLinks();
+
+        const walked = record({ follow: SymlinkFollowMode.ALWAYS });
+
+        expect(walked.files).toEqual(['external-link', 'file.txt', 'internal-link']);
+        expect(walked.symlinks).toEqual([]);
+      });
+
+      test('EXTERNAL follows only the external link, keeping the internal one as a link', () => {
+        writeLinks();
+
+        const walked = record({ follow: SymlinkFollowMode.EXTERNAL });
+
+        expect(walked.files).toEqual(['external-link', 'file.txt']);
+        expect(walked.symlinks).toEqual(['internal-link => file.txt']);
+      });
+
+      test('BLOCK_EXTERNAL follows the internal link and reports the external one as external', () => {
+        writeLinks();
+
+        const walked = record({ follow: SymlinkFollowMode.BLOCK_EXTERNAL });
+
+        expect(walked.files).toEqual(['file.txt', 'internal-link']);
+        // Reported rather than rejected: refusing an external link is the caller's policy.
+        expect(walked.symlinks).toEqual(['external-link => ../outside/referent.txt (external)']);
+      });
+
+      test('NEVER keeps both links', () => {
+        writeLinks();
+
+        const walked = record({ follow: SymlinkFollowMode.NEVER });
+
+        expect(walked.files).toEqual(['file.txt']);
+        expect(walked.symlinks).toEqual([
+          'external-link => ../outside/referent.txt (external)',
+          'internal-link => file.txt',
+        ]);
+      });
+
+      // A target that cannot be reached is not followed, whatever the mode says, because
+      // there is nothing to descend into or read.
+      test.each([
+        SymlinkFollowMode.ALWAYS,
+        SymlinkFollowMode.EXTERNAL,
+        SymlinkFollowMode.BLOCK_EXTERNAL,
+        SymlinkFollowMode.NEVER,
+      ])('a dangling link is kept as a link under mode %s', (follow) => {
+        fs.symlinkSync('missing.txt', path.join(root, 'dangling'));
+
+        const walked = record({ follow });
+
+        expect(walked.files).toEqual([]);
+        expect(walked.symlinks).toEqual(['dangling => missing.txt']);
+      });
+    });
+
+    describe('a sibling directory that shares a name prefix with the root', () => {
+      // '<tmp>/root-sibling' string-prefixes '<tmp>/root' but is not inside it, so it has
+      // to count as external.
+      beforeEach(() => {
+        fs.mkdirSync(path.join(tmp, 'root-sibling'));
+        fs.writeFileSync(path.join(tmp, 'root-sibling', 'referent.txt'), 'sibling');
+        fs.symlinkSync('../root-sibling/referent.txt', path.join(root, 'sibling-link'));
+      });
+
+      test('is followed under mode EXTERNAL', () => {
+        const walked = record({ follow: SymlinkFollowMode.EXTERNAL });
+
+        expect(walked.files).toEqual(['sibling-link']);
+        expect(walked.symlinks).toEqual([]);
+      });
+
+      test('is reported as external under mode BLOCK_EXTERNAL', () => {
+        const walked = record({ follow: SymlinkFollowMode.BLOCK_EXTERNAL });
+
+        expect(walked.files).toEqual([]);
+        expect(walked.symlinks).toEqual(['sibling-link => ../root-sibling/referent.txt (external)']);
+      });
+    });
+
+    describe('directories', () => {
+      test('a followed link to a directory has its contents reported under the link', () => {
+        fs.mkdirSync(path.join(outside, 'dir'));
+        fs.writeFileSync(path.join(outside, 'dir', 'inner.txt'), 'inner');
+        fs.symlinkSync('../outside/dir', path.join(root, 'dir-link'));
+
+        const walked = record({ follow: SymlinkFollowMode.EXTERNAL });
+
+        expect(walked.directories).toEqual(['dir-link']);
+        expect(walked.files).toEqual(['dir-link/inner.txt']);
+      });
+
+      test('an unfollowed link to a directory is kept as a link', () => {
+        fs.mkdirSync(path.join(root, 'dir'));
+        fs.writeFileSync(path.join(root, 'dir', 'inner.txt'), 'inner');
+        fs.symlinkSync('dir', path.join(root, 'dir-link'));
+
+        const walked = record({ follow: SymlinkFollowMode.NEVER });
+
+        expect(walked.directories).toEqual(['dir']);
+        expect(walked.files).toEqual(['dir/inner.txt']);
+        expect(walked.symlinks).toEqual(['dir-link => dir']);
+      });
+
+      test('the walked directory itself is not reported', () => {
+        fs.writeFileSync(path.join(root, 'file.txt'), 'inside');
+
+        expect(record().directories).toEqual([]);
+      });
+    });
+
+    describe('symlink cycles', () => {
+      test('a link pointing at one of its own ancestors terminates without descending', () => {
+        fs.mkdirSync(path.join(root, 'sub'));
+        fs.writeFileSync(path.join(root, 'sub', 'file.txt'), 'inside');
+        fs.symlinkSync('..', path.join(root, 'sub', 'loop'));
+
+        const walked = record({ follow: SymlinkFollowMode.ALWAYS });
+
+        expect(walked.directories).toEqual(['sub', 'sub/loop']);
+        expect(walked.files).toEqual(['sub/file.txt']);
+      });
+
+      test('two links to one directory are both walked in full', () => {
+        // The cycle guard tracks ancestors, not every directory seen, so links that are not
+        // ancestors of each other still both contribute. Deduplicating them would silently
+        // change the fingerprint of an existing asset.
+        fs.mkdirSync(path.join(outside, 'dir'));
+        fs.writeFileSync(path.join(outside, 'dir', 'inner.txt'), 'inner');
+        fs.symlinkSync('../outside/dir', path.join(root, 'a-link'));
+        fs.symlinkSync('../outside/dir', path.join(root, 'b-link'));
+
+        const walked = record({ follow: SymlinkFollowMode.EXTERNAL });
+
+        expect(walked.files).toEqual(['a-link/inner.txt', 'b-link/inner.txt']);
+      });
+    });
+
+    describe('ignored entries', () => {
+      test('an ignored file is not reported', () => {
+        fs.writeFileSync(path.join(root, 'keep.txt'), 'keep');
+        fs.writeFileSync(path.join(root, 'drop.txt'), 'drop');
+
+        const walked = record({ ignoreStrategy: IgnoreStrategy.glob(root, ['drop.txt']) });
+
+        expect(walked.files).toEqual(['keep.txt']);
+      });
+
+      test('an ignored symlink is not reported, so a caller never rejects an excluded link', () => {
+        fs.symlinkSync('../outside/referent.txt', path.join(root, 'external-link'));
+
+        const walked = record({
+          follow: SymlinkFollowMode.BLOCK_EXTERNAL,
+          ignoreStrategy: IgnoreStrategy.glob(root, ['external-link']),
+        });
+
+        expect(walked.symlinks).toEqual([]);
+      });
+
+      test('a completely ignored directory is not descended into', () => {
+        fs.mkdirSync(path.join(root, 'sub'));
+        fs.writeFileSync(path.join(root, 'sub', 'inner.txt'), 'inner');
+
+        const walked = record({ ignoreStrategy: IgnoreStrategy.glob(root, ['sub']) });
+
+        expect(walked.directories).toEqual([]);
+        expect(walked.files).toEqual([]);
+      });
+
+      test('a directory excluded with a re-included child is descended into and flagged ignored', () => {
+        fs.mkdirSync(path.join(root, 'sub'));
+        fs.writeFileSync(path.join(root, 'sub', 'keep.txt'), 'keep');
+        fs.writeFileSync(path.join(root, 'sub', 'drop.txt'), 'drop');
+
+        const walked = record({ ignoreStrategy: IgnoreStrategy.docker(root, ['**', '!sub/keep.txt']) });
+
+        expect(walked.directories).toEqual(['sub (ignored)']);
+        expect(walked.files).toEqual(['sub/keep.txt']);
+      });
+    });
+
+    test('entries are reported in sorted order, so a derived hash is stable', () => {
+      for (const name of ['c.txt', 'a.txt', 'b.txt']) {
+        fs.writeFileSync(path.join(root, name), name);
+      }
+
+      expect(record().files).toEqual(['a.txt', 'b.txt', 'c.txt']);
+    });
+
+    describe('the root option', () => {
+      beforeEach(() => {
+        fs.writeFileSync(path.join(root, 'file.txt'), 'inside');
+        fs.mkdirSync(path.join(root, 'sub'));
+        fs.symlinkSync('../file.txt', path.join(root, 'sub', 'up-link'));
+      });
+
+      test('defaults to the directory being walked, making a link out of it external', () => {
+        const walked = record({ follow: SymlinkFollowMode.EXTERNAL }, path.join(root, 'sub'));
+
+        expect(walked.files).toEqual(['up-link']);
+      });
+
+      test('makes a link internal when it points inside the wider root', () => {
+        const walked = record({
+          follow: SymlinkFollowMode.EXTERNAL,
+          root,
+          ignoreStrategy: IgnoreStrategy.glob(root, []),
+        }, path.join(root, 'sub'));
+
+        expect(walked.files).toEqual([]);
+        expect(walked.symlinks).toEqual(['up-link => ../file.txt']);
+      });
+    });
+
+    // Needs a path that is neither a file nor a directory; `/dev/null` is the portable one.
+    (process.platform === 'win32' ? test.skip : test)('a followed link to neither a file nor a directory is reported as unsupported', () => {
+      fs.symlinkSync('/dev/null', path.join(root, 'device-link'));
+
+      const walked = record({ follow: SymlinkFollowMode.ALWAYS });
+
+      expect(walked.unsupported).toEqual(['device-link']);
+      expect(walked.files).toEqual([]);
     });
   });
 });

--- a/packages/aws-cdk-lib/core/test/staging.test.ts
+++ b/packages/aws-cdk-lib/core/test/staging.test.ts
@@ -826,6 +826,34 @@ describe('staging', () => {
     );
   });
 
+  test('bundling throws when an empty bundle directory is left over from an earlier run', () => {
+    // GIVEN - the asset directory an interrupted run would have left behind, empty. The hash
+    // is known before bundling, so the bundle directory is `asset.<hash>` and a later run
+    // reuses it instead of bundling again.
+    const props = {
+      sourcePath: FIXTURE_TEST1_DIR,
+      assetHashType: AssetHashType.SOURCE,
+      bundling: {
+        image: DockerImage.fromRegistry('alpine'),
+        command: [DockerStubCommand.SUCCESS],
+      },
+    };
+
+    const firstOutdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-b3-first'));
+    const bundleDirName = path.basename(
+      new AssetStaging(new Stack(new App({ outdir: firstOutdir }), 'stack'), 'Asset', props).absoluteStagedPath,
+    );
+    AssetStaging.clearAssetHashCache();
+
+    const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-b3'));
+    const app = new App({ outdir });
+    const stack = new Stack(app, 'stack');
+    fs.mkdirpSync(path.join(app.synth().directory, bundleDirName));
+
+    // THEN - staged as an empty asset before, rejected now
+    expect(() => new AssetStaging(stack, 'Asset', props)).toThrow(/Bundling did not produce any output/);
+  });
+
   testDeprecated('bundling with BUNDLE asset hash type', () => {
     // GIVEN
     const app = new App();


### PR DESCRIPTION
### Reason for this change

<!--What is the bug or use case behind this change?-->
Asset bundling code is difficult to parse and has repetitive sections of code that could be consolidated. There are also some minor bugs in the way we bundle assets that should be fixed. 

### Description of changes

<!--
What code changes did you make? 
Why do these changes address the issue?
What alternatives did you consider and reject?
What design decisions have you made?
-->
Refactored the asset bundling and staging code. 
The biggest change is that the 3 functions that involved directory walks, copy directory, fingerprinting, and checking for external links are now consolidated into one utility function, each of these directory walks are still slightly different so the utility function accepts callbacks for each of the different walk locations to provide their own twists on the implementation.

**Improvements to BLOCK_EXTERNAL**
- If a directory is an internal symlink, previously we would see that it is an internal symlink and not verify that its contents are also internal symlinks. Now we check the contents of directories that are internal symlinks to ensure they do not contain any external symlinks
- When an external symlink was detected, error in `asset-staging.ts` would point to the parent construct's path instead of the asset's
- Symlinks were unconditionally using `completelyIgnores()`, symlinks now properly use `completelyIgnores()` for directories and `ignores()` for files 

**Bug fixes**
- if a directory contained a link that pointed back to its parent, then CDK would trap itself in a loop until it ran out of memory, CDK now remembers which folder it started from and does not follow the link
- If bundling output produced a broken symlink would previously get the message 'no such file or directory', now get an error they bundling output cannot be a symlink 
- CDK caches file fingerprints between runs, it identified files using timestamps measured in milliseconds, if a files was written twice within the same millisecond and stayed the same size, the second version of the file would reuse the first version since the fingerprint would be the same. Switched to nanoseconds to prevent this from happening (this was probably not happening often to begin with but we now have more safety to prevent it from happening)
- when staging by copying, we would previously attempt to read the asset before we determined whether it was a file or a directory, if it wasn't the process would hang. Moved the file or directory check earlier in the function so we throw an error and abort if the asset we were given is not a file or directory
- If a previous bundle attempt was interrupted, an empty `asset.<hash>/` could be left behind. The next bundling attempt would look at this dir and assume the work was already done and could ship an empty asset. We now check to ensure no empty directories are left behind
- Clarified error messaging for Docker ignore strategy, now correctly reports whether an error was in `.ignores()` or `.completelyIgnores()` - previously all errors were attributed to `.ignores()`.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced? -->
N/A

### Description of how you validated changes

<!-- Have you added any unit tests and/or integration tests? Did you test by hand? -->
Validated that all existing tests still pass, added some new ones to cover additional cases and some of the new functions the refactor introduced. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
