### PR TITLE
docs(glue-alpha): update documentation for job timeout and worker type defaults

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/README.md
+++ b/packages/@aws-cdk/aws-glue-alpha/README.md
@@ -41,8 +41,9 @@ and deploy new resources.
 ## Create a Glue Job
 
 A Job encapsulates a script that connects to data sources, processes
-them, and then writes output to a data target. There are four types of Glue
-Jobs: Spark (ETL and Streaming), Python Shell, and Flex Jobs. Most
+them, and then writes output to a data target. There are three types of Glue
+Jobs: Spark jobs (with ETL, Streaming, and Flex execution variants), Python
+Shell jobs, and (deprecated) Ray jobs. Most
 of the required parameters for these jobs are common across all types,
 but there are a few differences depending on the languages supported
 and features provided by each type. For all job types, the L2 defaults
@@ -71,12 +72,13 @@ for more granular details.
 #### ETL Jobs
 
 ETL jobs support pySpark and Scala languages, for which there are separate but
-similar constructors. ETL jobs default to the G1 worker type, but you can
-override this default with other supported worker type values (G1, G2, G4
-and G8). ETL jobs defaults to Glue version 4.0, which you can override to 3.0.
+similar constructors. ETL jobs default to the `G_1X` worker type, but you can
+override this default with any other supported `WorkerType` (e.g. `G_2X`,
+`G_4X`, `G_8X`). ETL jobs default to Glue version 4.0, which you can override
+to any supported `GlueVersion` (e.g. 3.0, 5.0, 5.1).
 The following ETL features are enabled by default:
-`—enable-metrics, —enable-continuous-cloudwatch-log.`
-The Spark UI (`—enable-spark-ui`) is off by default; enable it by setting the
+`--enable-metrics, --enable-continuous-cloudwatch-log.`
+The Spark UI (`--enable-spark-ui`) is off by default; enable it by setting the
 `sparkUI` prop.
 You can find more details about version, worker type and other features in
 [Glue's public documentation](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html).
@@ -140,10 +142,10 @@ Streaming jobs are similar to ETL jobs, except that they perform ETL on data
 streams using the Apache Spark Structured Streaming framework. Some Spark
 job features are not available to Streaming ETL jobs. They support Scala
 and pySpark languages. PySpark streaming jobs run on Python 3. It
-defaults to the G1 worker type and Glue 4.0, both of which you can override.
+defaults to the `G_1X` worker type and Glue 4.0, both of which you can override.
 The following best practice features are enabled by default:
-`—enable-metrics, —enable-continuous-cloudwatch-log`.
-The Spark UI (`—enable-spark-ui`) is off by default; enable it by setting the
+`--enable-metrics, --enable-continuous-cloudwatch-log`.
+The Spark UI (`--enable-spark-ui`) is off by default; enable it by setting the
 `sparkUI` prop.
 
 Reference the pyspark-streaming-jobs.test.ts and scalaspark-streaming-jobs.test.ts 
@@ -199,8 +201,8 @@ The flexible execution class is appropriate for non-urgent jobs such as
 pre-production jobs, testing, and one-time data loads. Flexible jobs default
 to Glue version 5.0 and worker type `G_1X`. The following best practice
 features are enabled by default:
-`—enable-metrics, —enable-continuous-cloudwatch-log`
-The Spark UI (`—enable-spark-ui`) is off by default; enable it by setting the
+`--enable-metrics, --enable-continuous-cloudwatch-log`
+The Spark UI (`--enable-spark-ui`) is off by default; enable it by setting the
 `sparkUI` prop.
 
 Reference the pyspark-flex-etl-jobs.test.ts and scalaspark-flex-etl-jobs.test.ts 
@@ -259,7 +261,7 @@ Python 3.9 and a MaxCapacity of `0.0625`. Python 3.9 supports pre-loaded
 analytics libraries using the `library-set=analytics` flag, which is
 enabled by default.
 
-Reference the pyspark-shell-job.test.ts unit tests for examples of 
+Reference the python-shell-job.test.ts unit tests for examples of 
 required-only and optional job parameters when creating these types of jobs.
 
 Example with only required parameters:

--- a/packages/@aws-cdk/aws-glue-alpha/lib/external-table.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/external-table.ts
@@ -13,17 +13,13 @@ import { TableBase } from './table-base';
 export interface ExternalTableProps extends TableBaseProps {
   /**
    * The connection the table will use when performing reads and writes.
-   *
-   * @default - No connection
    */
   readonly connection: IConnection;
 
   /**
    * The data source location of the glue table, (e.g. `default_db_public_example` for Redshift).
    *
-   * If this property is set, it will override both `bucket` and `s3Prefix`.
-   *
-   * @default - No outsourced data source location
+   * This overrides both `bucket` and `s3Prefix`.
    */
   readonly externalDataLocation: string;
 }

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
@@ -392,7 +392,7 @@ export interface JobProps {
    * The maximum time that a job run can consume resources before it is
    * terminated and enters TIMEOUT status. Specified in minutes.
    *
-   * @default 2880 (2 days for non-streaming)
+   * @default - no value set; Glue applies its service default (2880 minutes for non-streaming jobs)
    *
    */
   readonly timeout?: cdk.Duration;

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
@@ -71,10 +71,10 @@ export interface PySparkEtlJobProps extends SparkJobProps {
  * PySpark ETL Jobs class
  *
  * ETL jobs support pySpark and Scala languages, for which there are separate
- * but similar constructors. ETL jobs default to the G1 worker type, but you
- * can override this default with other supported worker type values
- * (G1, G2, G4 and G8). ETL jobs defaults to Glue version 4.0, which you can
- * override to 3.0. The following ETL features are enabled by default:
+ * but similar constructors. ETL jobs default to the `G_1X` worker type, but you
+ * can override this default with any other supported `WorkerType`
+ * (e.g. `G_2X`, `G_4X`, `G_8X`). ETL jobs default to Glue version 4.0, which you
+ * can override to any supported `GlueVersion` (e.g. 3.0, 5.0, 5.1). The following ETL features are enabled by default:
  * --enable-metrics, --enable-continuous-cloudwatch-log. The Spark UI
  * (--enable-spark-ui) is off by default; enable it by setting the `sparkUI` prop.
  * You can find more details about version, worker type and other features

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-streaming-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-streaming-job.ts
@@ -63,11 +63,11 @@ export interface PySparkStreamingJobProps extends SparkJobProps {
  *
  * A Streaming job is similar to an ETL job, except that it performs ETL on data streams
  * using the Apache Spark Structured Streaming framework.
- * These jobs will default to use Python 3.9.
+ * These jobs run on Python 3.
  *
- * Similar to ETL jobs, streaming job supports Scala and Python languages. Similar to ETL,
- * it supports G1 and G2 worker type and 2.0, 3.0 and 4.0 version. We’ll default to G1 worker
- * and 4.0 version for streaming jobs which developers can override.
+ * Similar to ETL jobs, streaming job supports Scala and Python languages. Streaming jobs
+ * default to the `G_1X` worker type and Glue version 4.0, both of which developers can
+ * override with any supported `WorkerType` or `GlueVersion`.
  * We will enable --enable-metrics, --enable-continuous-cloudwatch-log. The Spark UI
  * (--enable-spark-ui) is off by default; enable it by setting the `sparkUI` prop.
  */

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-etl-job.ts
@@ -69,10 +69,10 @@ export interface ScalaSparkEtlJobProps extends SparkJobProps {
  * Spark ETL Jobs class
  *
  * ETL jobs support pySpark and Scala languages, for which there are separate
- * but similar constructors. ETL jobs default to the G1 worker type, but you
- * can override this default with other supported worker type values
- * (G1, G2, G4 and G8). ETL jobs defaults to Glue version 4.0, which you can
- * override to 3.0. The following ETL features are enabled by default:
+ * but similar constructors. ETL jobs default to the `G_1X` worker type, but you
+ * can override this default with any other supported `WorkerType`
+ * (e.g. `G_2X`, `G_4X`, `G_8X`). ETL jobs default to Glue version 4.0, which you
+ * can override to any supported `GlueVersion` (e.g. 3.0, 5.0, 5.1). The following ETL features are enabled by default:
  * --enable-metrics, --enable-continuous-cloudwatch-log. The Spark UI
  * (--enable-spark-ui) is off by default; enable it by setting the `sparkUI` prop.
  * You can find more details about version, worker type and other features

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-streaming-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-streaming-job.ts
@@ -62,11 +62,11 @@ export interface ScalaSparkStreamingJobProps extends SparkJobProps {
  *
  * A Streaming job is similar to an ETL job, except that it performs ETL on data streams
  * using the Apache Spark Structured Streaming framework.
- * These jobs will default to use Python 3.9.
+ * This job runs on the Scala runtime.
  *
- * Similar to ETL jobs, streaming job supports Scala and Python languages. Similar to ETL,
- * it supports G1 and G2 worker type and 2.0, 3.0 and 4.0 version. We’ll default to G1 worker
- * and 4.0 version for streaming jobs which developers can override.
+ * Similar to ETL jobs, streaming job supports Scala and Python languages. Streaming jobs
+ * default to the `G_1X` worker type and Glue version 4.0, both of which developers can
+ * override with any supported `WorkerType` or `GlueVersion`.
  * We will enable --enable-metrics, --enable-continuous-cloudwatch-log. The Spark UI
  * (--enable-spark-ui) is off by default; enable it by setting the `sparkUI` prop.
  */

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/spark-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/spark-job.ts
@@ -102,7 +102,7 @@ export interface WorkerConfiguration {
   /**
    * The type of predefined worker that is allocated when a job runs.
    *
-   * Enum options: Standard, G_1X, G_2X, G_025X, G_4X, G_8X, Z_2X
+   * See the `WorkerType` enum for the full set of supported values.
    */
   readonly workerType: WorkerType;
 


### PR DESCRIPTION
Fixes several inconsistencies in the docs.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
