### PR TITLE
fix(s3-deployment): renderData is quadratic in the number of tokens

### DIFF
--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/render-data.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/render-data.ts
@@ -12,13 +12,18 @@ export interface Content {
  */
 class TokenToMarkerMapper implements ITokenMapper {
   markers: Record<string, any>;
+  private markerCount: number;
 
   constructor() {
     this.markers = {};
+    this.markerCount = 0;
   }
 
   mapToken(token: IResolvable) {
-    const newMarker = `<<marker:0xbaba:${Object.keys(this.markers).length}>>`;
+    // Derive the marker id from a running counter rather than `Object.keys(this.markers).length`.
+    // The latter materializes the full key array on every call, making renderData O(n^2) in the
+    // number of tokens. The counter produces identical ids in the same order.
+    const newMarker = `<<marker:0xbaba:${this.markerCount++}>>`;
     this.markers[newMarker] = token.toString();
     return newMarker;
   }

--- a/packages/aws-cdk-lib/aws-s3-deployment/test/content.test.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/test/content.test.ts
@@ -48,6 +48,24 @@ test('multiple markers', () => {
   });
 });
 
+test('marker ids are dense, sequential and unique for many tokens', () => {
+  // Guards the id-generation contract the O(n) fix relies on: ids are `t0..tN-1`
+  // in encounter order. Deriving the id from a running counter (rather than from
+  // Object.keys(markers).length) must not change which id a token gets.
+  const n = 500;
+  const tokens = Array.from({ length: n }, (_, i) => Lazy.string({ produce: () => `value-${i}` }));
+  const data = tokens.map((t, i) => `lit${i}-${t}`).join('');
+
+  const rendered = renderData(data);
+  const markerKeys = Object.keys(rendered.markers);
+
+  expect(markerKeys).toHaveLength(n);
+  markerKeys.forEach((key, i) => {
+    expect(key).toStrictEqual(`<<marker:0xbaba:${i}>>`);
+    expect(rendered.markers[key]).toStrictEqual(tokens[i]);
+  });
+});
+
 test('json-encoded string', () => {
   const stack = new Stack();
   const bucket = new s3.Bucket(stack, 'Bucket');


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38768.

### Reason for this change

`renderData` (used by `s3deploy.Source.data()` / `Source.jsonData()`) is **O(n²)** in the number of tokens in the source string.

`TokenToMarkerMapper.mapToken` derives each marker id from the size of the map it is in the middle of filling:

```ts
mapToken(token: IResolvable) {
  const newMarker = `<<marker:0xbaba:${Object.keys(this.markers).length}>>`;
  this.markers[newMarker] = token.toString();
  return newMarker;
}
```

`mapToken` is called once per token fragment by `Tokenization.reverseString(data).mapTokens(...)`. `Object.keys(this.markers).length` materializes the full key array on **every** call just to read its length — `O(k)` per token, `O(k²)` over `k` tokens. This is the same shape as the `tree.json` quadratic fixed in #38761.

### Description of changes

Track a running counter on the mapper and use it for the id instead of re-measuring the map:

```diff
-        const newMarker = `<<marker:0xbaba:${Object.keys(this.markers).length}>>`;
+        const newMarker = `<<marker:0xbaba:${this.markerCount++}>>`;
```

Ids are generated in the same order with the same values, so the emitted markers and the marker map are **byte-for-byte unchanged**.

### Description of how you validated changes

**Unit test** — added a case to `content.test.ts` asserting that for many tokens the marker ids are dense, sequential and unique (`t0..tN-1` in encounter order), pinning the id contract the fix relies on. Existing marker tests (`multiple markers`, `json-encoded string`) already assert the exact ids and continue to pass unchanged.

**Benchmark** — timed the real `renderData` on a string of `n` interleaved literal + `Lazy` token fragments (Node 24), comparing the current `Object.keys` version against the counter:

| n tokens | current (ms) | with counter (ms) | speedup |
|---:|---:|---:|---:|
| 1,000  | 18.0     | 1.3  | 14× |
| 2,000  | 71.6     | 2.7  | 27× |
| 4,000  | 324.9    | 7.2  | 45× |
| 8,000  | 1,510.3  | 23.0 | 66× |
| 16,000 | 7,204.2  | ~413 | 17× |
| 32,000 | 35,301.6 | ~417 | 85× |

Current time roughly quadruples per doubling of `n` (quadratic); with the fix it is flat/linear (the residual at 16k–32k is token resolution + GC, not the marker loop).

### Describe any new or updated permissions being added

None.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
