### PR TITLE
docs(core): drop stale `sep` reference from `ArnComponents.arnFormat` default docs

### DIFF
--- a/packages/aws-cdk-lib/core/lib/arn.ts
+++ b/packages/aws-cdk-lib/core/lib/arn.ts
@@ -112,8 +112,7 @@ export interface ArnComponents {
   /**
    * The specific ARN format to use for this ARN value.
    *
-   * @default - uses value of `sep` as the separator for formatting,
-   *   `ArnFormat.SLASH_RESOURCE_NAME` if that property was also not provided
+   * @default - ArnFormat.SLASH_RESOURCE_NAME
    */
   readonly arnFormat?: ArnFormat;
 }


### PR DESCRIPTION
Body:

Fixes #38763

## Summary

The `arnFormat` property documentation on `ArnComponents` (which surfaces as
the `arn_format` parameter docs of `Stack.format_arn` in the generated
Python/API docs) stated:

> Default: - uses value of sep as the separator for formatting,
> ArnFormat.SLASH_RESOURCE_NAME if that property was also not provided

`sep` is a deprecated property and does not appear on the generated Python
surface, so the reference is dangling there. This changes the default text
to state the effective modern default directly:

> Default: - ArnFormat.SLASH_RESOURCE_NAME

No code change — `Arn.format` behavior is untouched (`sep` still takes
precedence when explicitly provided, as documented on the property itself).
