### PR TITLE
fix(bedrock-alpha): guardrail version logical id derived from an unresolved token

### DIFF
--- a/packages/@aws-cdk/aws-bedrock-alpha/bedrock/guardrails/guardrail-version.ts
+++ b/packages/@aws-cdk/aws-bedrock-alpha/bedrock/guardrails/guardrail-version.ts
@@ -1,7 +1,6 @@
 import type { IResource } from 'aws-cdk-lib';
 import { Resource } from 'aws-cdk-lib';
 import { CfnGuardrailVersion } from 'aws-cdk-lib/aws-bedrock';
-import { md5hash } from 'aws-cdk-lib/core/lib/helpers-internal';
 import { addConstructMetadata } from 'aws-cdk-lib/core/lib/metadata-resource';
 import { propertyInjectable } from 'aws-cdk-lib/core/lib/prop-injectable';
 import type { Construct } from 'constructs';
@@ -132,10 +131,7 @@ export class GuardrailVersion extends GuardrailVersionBase {
     addConstructMetadata(this, props);
     this.guardrail = props.guardrail;
 
-    // Compute hash from guardrail, to recreate the resource when guardrail has changed
-    const hash = md5hash(props.guardrail.lastUpdated ?? 'Default');
-
-    this._resource = new CfnGuardrailVersion(this, `GuardrailVersion-${hash.slice(0, 16)}`, {
+    this._resource = new CfnGuardrailVersion(this, 'Resource', {
       guardrailIdentifier: this.guardrail.guardrailId,
       description: props.description,
     });

--- a/packages/@aws-cdk/aws-bedrock-alpha/test/bedrock/guardrails/guardrails.test.ts
+++ b/packages/@aws-cdk/aws-bedrock-alpha/test/bedrock/guardrails/guardrails.test.ts
@@ -1866,7 +1866,7 @@ describe('CDK-Created-Guardrail', () => {
     });
   });
 
-  test('Versioning is stable when unrelated constructs are added before the guardrail', () => {
+  test('Versioning - Stable Logical Id Regardless Of Construct Order', () => {
     const versionLogicalIds = (fillers: number) => {
       const testStack = new core.Stack(new App(), 'test-stack');
       for (let i = 0; i < fillers; i++) {
@@ -1880,6 +1880,7 @@ describe('CDK-Created-Guardrail', () => {
       return Object.keys(Template.fromStack(testStack).findResources('AWS::Bedrock::GuardrailVersion'));
     };
 
+    expect(versionLogicalIds(0)).toHaveLength(1);
     expect(versionLogicalIds(1)).toEqual(versionLogicalIds(0));
     expect(versionLogicalIds(2)).toEqual(versionLogicalIds(0));
   });

--- a/packages/@aws-cdk/aws-bedrock-alpha/test/bedrock/guardrails/guardrails.test.ts
+++ b/packages/@aws-cdk/aws-bedrock-alpha/test/bedrock/guardrails/guardrails.test.ts
@@ -1866,6 +1866,24 @@ describe('CDK-Created-Guardrail', () => {
     });
   });
 
+  test('Versioning is stable when unrelated constructs are added before the guardrail', () => {
+    const versionLogicalIds = (fillers: number) => {
+      const testStack = new core.Stack(new App(), 'test-stack');
+      for (let i = 0; i < fillers; i++) {
+        new bedrock.Guardrail(testStack, `Filler${i}`, { guardrailName: `filler-${i}` });
+      }
+      const guardrail = new bedrock.Guardrail(testStack, 'TestGuardrail', {
+        guardrailName: 'TestGuardrail',
+      });
+      guardrail.createVersion();
+
+      return Object.keys(Template.fromStack(testStack).findResources('AWS::Bedrock::GuardrailVersion'));
+    };
+
+    expect(versionLogicalIds(1)).toEqual(versionLogicalIds(0));
+    expect(versionLogicalIds(2)).toEqual(versionLogicalIds(0));
+  });
+
   test('Content Filter with Tier Configuration - CLASSIC', () => {
     new bedrock.Guardrail(stack, 'TestGuardrail', {
       guardrailName: 'TestGuardrail',


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38674.

### Reason for this change

`GuardrailVersion` names its `CfnGuardrailVersion` child `GuardrailVersion-${md5hash(guardrail.lastUpdated)}`. `lastUpdated` is the `AttrUpdatedAt` attribute, so at synth time it is an unresolved token like `${Token[TOKEN.21]}`. Token numbers are handed out in construction order, so any unrelated construct added earlier in the app shifts the number, changes the hash, and changes the logical id. CloudFormation then treats the version as a new resource and a no-op deploy replaces it, marking every consumer of the version ARN as changed.

### Description of changes

The child id is now the plain `Resource`, matching `PromptVersion` and the rest of the module. The hash carried no information about the guardrail in the first place, so nothing is lost by dropping it: `Guardrail.createVersion()` already scopes the version under `GuardrailVersion-${this.hash.slice(0, 16)}`, and whatever versioning signal exists lives there.

Two things I want to flag rather than silently decide:

Upgrading changes the version's logical id once, so the next deploy cuts a new guardrail version and deletes the old one. I did not add a feature flag for it. The module is alpha, the id was already changing on its own, and a guardrail version is an immutable snapshot that this construct was replacing on most deploys anyway. Happy to gate it if you would rather.

The outer `this.hash` has problems of its own that I left alone. It is `md5hash(JSON.stringify(cfnProps))` computed in the constructor, so a tokenized prop such as `kmsKey.keyArn` puts it back in the same unstable state, and the filter configs are `Lazy` at that point and serialize to `"<unresolved-lazy>"`, so changing a filter does not change the hash. Fixing that means resolving props during construction or deferring the id, which is a bigger change than this issue calls for. Let me know if you want it here or in a separate issue.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Added a unit test that synthesizes the same guardrail with a varying number of unrelated constructs before it and asserts the version logical id is unchanged. It fails on the current code and passes with the fix. The rest of the guardrail suite passes.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
