### PR TITLE
fix(lambda-nodejs): npm cache log directory is created as root in the bundling image

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/docker/Dockerfile
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/docker/Dockerfile
@@ -21,10 +21,13 @@ RUN npm install --global typescript
 ARG ESBUILD_VERSION=0.21
 RUN npm install --global --unsafe-perm=true esbuild@$ESBUILD_VERSION
 
+# Disable npm update notifications
+RUN npm config --global set update-notifier false
+
 # Ensure all users can write to npm cache
 RUN mkdir /tmp/npm-cache && \
-    chmod -R 777 /tmp/npm-cache && \
-    npm config --global set cache /tmp/npm-cache
+    npm config --global set cache /tmp/npm-cache && \
+    chmod -R 777 /tmp/npm-cache
 
 # Ensure all users can write to yarn cache
 RUN mkdir /tmp/yarn-cache && \
@@ -35,9 +38,6 @@ RUN mkdir /tmp/yarn-cache && \
 RUN mkdir /tmp/pnpm-cache && \
     chmod -R 777 /tmp/pnpm-cache && \
     pnpm config --global set store-dir /tmp/pnpm-cache
-
-# Disable npm update notifications
-RUN npm config --global set update-notifier false
 
 # create non root user and change allow execute command for non root user
 RUN /sbin/useradd -u 1000 user && chmod 711 /

--- a/packages/aws-cdk-lib/aws-lambda-nodejs/test/docker.test.ts
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/test/docker.test.ts
@@ -29,6 +29,22 @@ test('can npm install with non root user', () => {
   expect(proc.status).toEqual(0);
 });
 
+test('can npm ci with non root user', () => {
+  const proc = spawnSync(docker, [
+    'run', '-u', '500:500',
+    'esbuild',
+    'bash', '-c', [
+      'mkdir /tmp/test',
+      'cd /tmp/test',
+      'npm init --yes',
+      'npm i constructs --package-lock-only',
+      'npm ci',
+      'test -w /tmp/npm-cache/_logs',
+    ].join(' && '),
+  ]);
+  expect(proc.status).toEqual(0);
+});
+
 test('can yarn install with non root user', () => {
   const proc = spawnSync(docker, [
     'run', '-u', '500:500',


### PR DESCRIPTION
### Issue # (if applicable)

Closes #38764.

### Reason for this change

`npm config --global set update-notifier false` runs after the npm cache is chmodded to 777, and writes into that cache as root. The image ships with `/tmp/npm-cache/_logs` owned by `root:root` at mode 755, inside a directory #9167 made world-writable so bundling can run as an arbitrary UID. npm running as the bundling user cannot write its log file there, which breaks `npm ci` under `forceDockerBundling` on npm versions that treat the failed log write as fatal.

### Description of changes

Moved the update-notifier config ahead of the cache redirection so it no longer writes into `/tmp/npm-cache`, and made the `chmod` the last step of that block. The image now ships with an empty, 777 `/tmp/npm-cache`.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Added `can npm ci with non root user` to `docker.test.ts`, which runs `npm ci` as UID 500 and then checks the log directory is writable. It exits 1 against an image built from the current Dockerfile and 0 after the change. The other Docker tests (npm/yarn/pnpm/bun installs, esbuild, cache permissions) still pass against the rebuilt image.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
