### PR TITLE
fix(core): cdk-nag warnings cannot be suppressed

### DIFF
--- a/packages/aws-cdk-lib/core/lib/private/annotation-plugin.ts
+++ b/packages/aws-cdk-lib/core/lib/private/annotation-plugin.ts
@@ -6,6 +6,7 @@ import { stackOf, stageOf } from './core-construct-finders';
 import * as cxschema from '../../../cloud-assembly-schema';
 import { CfnResource } from '../cfn-resource';
 import type { NamedValidationPluginReport } from '../validation/private/report';
+import { namespaceFromPluginName } from '../validation/private/validation-id';
 import type { PolicyValidationPluginReport, PolicyViolation, PolicyViolatingResource } from '../validation/report';
 
 /**
@@ -22,7 +23,6 @@ import type { PolicyValidationPluginReport, PolicyViolation, PolicyViolatingReso
  * has a prefix in which case the prefix is preserved.
  */
 export class AnnotationPlugin implements IPolicyValidationPlugin {
-  public static RULE_PREFIX = 'Annotation';
   public static NAME = 'Construct Annotations';
   public readonly name = AnnotationPlugin.NAME;
 
@@ -39,6 +39,8 @@ export class AnnotationPlugin implements IPolicyValidationPlugin {
  * into the same report pipeline as plugin violations.
  */
 export function collectAnnotationReport(root: IConstruct): IPolicyValidationPlugin | undefined {
+  const myNamespace = namespaceFromPluginName(AnnotationPlugin.NAME);
+
   const violationMap = new Map<string, PolicyViolation & { violatingResources: PolicyViolatingResource[] }>();
 
   for (const construct of iterateDfsPreorder(root)) {
@@ -51,7 +53,7 @@ export function collectAnnotationReport(root: IConstruct): IPolicyValidationPlug
       let { message, ruleName } = splitDescriptionAndId(String(entry.data));
 
       if (ruleName && !ruleName.includes('::')) {
-        ruleName = `${AnnotationPlugin.RULE_PREFIX}::${ruleName}`;
+        ruleName = `${myNamespace}::${ruleName}`;
       }
 
       let templatePath: string | undefined;
@@ -78,7 +80,7 @@ export function collectAnnotationReport(root: IConstruct): IPolicyValidationPlug
         existing.violatingResources.push(violatingResource);
       } else {
         violationMap.set(key, {
-          ruleName: ruleName ?? `${AnnotationPlugin.RULE_PREFIX}::${severity}-annotation`,
+          ruleName: ruleName ?? `${myNamespace}::${severity}-annotation`,
           description: message,
           severity,
           violatingResources: [violatingResource],

--- a/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
+++ b/packages/aws-cdk-lib/core/lib/private/synthesis-validation.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type * as private_cxapi from '@aws-cdk/cloud-assembly-api';
 import type { IConstruct } from 'constructs';
-import { AnnotationPlugin, collectAnnotationReport } from './annotation-plugin';
+import { collectAnnotationReport } from './annotation-plugin';
 import { collectAcknowledgedRuleIds } from './collect-acknowledged-rule-ids';
 import { lit } from './literal-string';
 import * as cxapi from '../../../cx-api';
@@ -21,6 +21,7 @@ import { ConstructTree } from '../validation/private/construct-tree';
 import { formatValidationReports, humanFriendlyFilename } from '../validation/private/modern-formatter';
 import type { NamedValidationPluginReport, SuppressedViolation } from '../validation/private/report';
 import { isSuppressibleViolation, mkPluginFailure, PolicyValidationReportFormatter } from '../validation/private/report';
+import { namespaceFromPluginName, normalizeValidationId } from '../validation/private/validation-id';
 
 const LEGACY_POLICY_VALIDATION_FILE_PATH = 'policy-validation-report.json';
 
@@ -280,19 +281,9 @@ function collectSuppressions(root: App, reports: NamedValidationPluginReport[]) 
         }
 
         const ackIds: string[] = [];
-        if (v.ruleName.includes('::')) {
-          ackIds.push(v.ruleName);
 
-          // Annotations are special; we renamed the suppression namespace at one point
-          // from "Construct-Annotations" to just "Annotation", and we also want
-          // to support the naked-rule-name form for backwards compatibility.
-          if (pluginName === AnnotationPlugin.NAME) {
-            const unnamespacedPart = v.ruleName.split('::').slice(1).join('::');
-            ackIds.push(`${pluginName}::${unnamespacedPart}`);
-          }
-        } else {
-          ackIds.push(`${pluginName}::${v.ruleName}`);
-        }
+        const ruleName = normalizeValidationId(v.ruleName, namespaceFromPluginName(pluginName));
+        ackIds.push(ruleName);
 
         const ack = firstThat(ackIds.map(hyphenify), id => acknowledgedRules.get(id));
 

--- a/packages/aws-cdk-lib/core/lib/validation/private/modern-formatter.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/modern-formatter.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import type { PluginReportJson, PolicyViolationJson, ViolatingConstructJson } from '@aws-cdk/cloud-assembly-schema';
 import { Colorize } from './color';
 import { isSuppressibleViolation } from './report';
-import { normalizeValidationIdForAnnotations, parseValidationId } from './validation-id';
+import { namespaceFromPluginName, normalizeValidationId, parseValidationId, pluginNameFromNamespace } from './validation-id';
 import { topUserFrame } from '../../private/stack-trace';
 
 export function formatValidationReports(fileRoot: string, reports: PluginReportJson[]): string[] {
@@ -64,10 +64,13 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
     lines.push(Colorize.underline(sanitize(location)));
   }
 
+  const pluginNs = namespaceFromPluginName(v.pluginName);
+  const parsed = parseValidationId(v.ruleName);
+
   lines.push([
     Colorize.bold(getSeverityColor(v.severity)(sanitize(v.severity))),
     Colorize.bold(stripAckTag(sanitize(v.description))),
-    Colorize.grey(`(${sanitize(namespace(v))})`),
+    Colorize.grey(`(${sanitize(parsed.namespace ? pluginNameFromNamespace(parsed.namespace) : v.pluginName)})`),
   ].join(' '));
 
   const constructInfo = formatConstructInfo(fileRoot, v.construct);
@@ -77,11 +80,12 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
     lines.push(`   Suggested fix: ${sanitize(v.suggestedFix).replace(/\n/g, '\n   ')}`);
   }
 
+  const ackId = normalizeValidationId(v.ruleName, pluginNs);
   if (isSuppressibleViolation(v)) {
-    lines.push(`   ${Colorize.grey(`Acknowledge with '${sanitize(ackId(v))}'`)}`);
+    lines.push(`   ${Colorize.grey(`Acknowledge with '${sanitize(ackId)}'`)}`);
   } else {
     // If not acknowledgeable, we should still show the rule name for reference.
-    lines.push(`   ${Colorize.grey(`Rule ${sanitize(ackId(v))}`)}`);
+    lines.push(`   ${Colorize.grey(`Rule ${sanitize(ackId)}`)}`);
   }
 
   return lines.join('\n');
@@ -173,12 +177,4 @@ function isPluginFailure(r: PluginReportJson): PluginError | undefined {
     return undefined;
   }
   return { error: r.metadata.error };
-}
-
-function namespace(v: FlattenedViolation): string {
-  return parseValidationId(v.ruleName).namespace ?? '';
-}
-
-function ackId(v: FlattenedViolation): string {
-  return normalizeValidationIdForAnnotations(v.ruleName);
 }

--- a/packages/aws-cdk-lib/core/lib/validation/private/modern-formatter.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/modern-formatter.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import type { PluginReportJson, PolicyViolationJson, ViolatingConstructJson } from '@aws-cdk/cloud-assembly-schema';
 import { Colorize } from './color';
 import { isSuppressibleViolation } from './report';
+import { normalizeValidationIdForAnnotations, parseValidationId } from './validation-id';
 import { topUserFrame } from '../../private/stack-trace';
 
 export function formatValidationReports(fileRoot: string, reports: PluginReportJson[]): string[] {
@@ -66,7 +67,7 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
   lines.push([
     Colorize.bold(getSeverityColor(v.severity)(sanitize(v.severity))),
     Colorize.bold(stripAckTag(sanitize(v.description))),
-    Colorize.grey(`(${namespace(v)})`),
+    Colorize.grey(`(${sanitize(namespace(v))})`),
   ].join(' '));
 
   const constructInfo = formatConstructInfo(fileRoot, v.construct);
@@ -77,7 +78,7 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
   }
 
   if (isSuppressibleViolation(v)) {
-    lines.push(`   ${Colorize.grey(`Acknowledge with '${ackId(v)}'`)}`);
+    lines.push(`   ${Colorize.grey(`Acknowledge with '${sanitize(ackId(v))}'`)}`);
   } else {
     // If not acknowledgeable, we should still show the rule name for reference.
     lines.push(`   ${Colorize.grey(`Rule ${sanitize(ackId(v))}`)}`);
@@ -175,9 +176,9 @@ function isPluginFailure(r: PluginReportJson): PluginError | undefined {
 }
 
 function namespace(v: FlattenedViolation): string {
-  return v.ruleName.includes('::') ? sanitize(v.ruleName.split('::')[0]) : sanitize(v.pluginName);
+  return parseValidationId(v.ruleName).namespace ?? '';
 }
 
 function ackId(v: FlattenedViolation): string {
-  return (v.ruleName.includes('::') ? sanitize(v.ruleName) : `${sanitize(v.pluginName)}::${sanitize(v.ruleName)}`).replace(/ /g, '-');
+  return normalizeValidationIdForAnnotations(v.ruleName);
 }

--- a/packages/aws-cdk-lib/core/lib/validation/private/validation-id.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/validation-id.ts
@@ -3,7 +3,7 @@ import { lit } from '../../private/literal-string';
 import { type Branded } from '../../private/type-brand';
 
 export interface ValidationId {
-  readonly namespace?: string;
+  readonly namespace?: ValidationNs;
   readonly ruleId: string;
 }
 
@@ -58,7 +58,7 @@ export function parseValidationId(id: string): ValidationId {
     throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. Missing plugin name before '::'.`);
   }
 
-  const namespace = id.substring(0, nsSeparator);
+  const namespace = id.substring(0, nsSeparator) as ValidationNs;
   const ruleId = id.substring(nsSeparator + 2);
 
   return { namespace, ruleId };
@@ -67,8 +67,8 @@ export function parseValidationId(id: string): ValidationId {
 /**
  * Normalize the given validation ID to a fully qualified ID, using the `annotation` namespace if no namespace is provided.
  */
-export function normalizeValidationId(id: string, defaultNamespace: ValidationNs): string {
-  const parsed = parseValidationId(id);
+export function normalizeValidationId(id: string | ValidationId, defaultNamespace: ValidationNs): string {
+  const parsed = typeof id === 'string' ? parseValidationId(id) : id;
 
   // Allow aliases for this namespace, but normalize it to the actual namespace we settled on.
   if (parsed.namespace && ['annotation', 'Construct-Annotations'].includes(parsed.namespace)) {
@@ -96,6 +96,14 @@ export function namespaceFromPluginName(pluginName: string): ValidationNs {
   }
 
   return pluginName.replace(/ /g, '-') as ValidationNs;
+}
+
+/**
+ * Convert a namespace to a displayable plugin name
+ */
+export function pluginNameFromNamespace(namespace: ValidationNs): string {
+  // We do not convert the annotation namespace back to its legacy plugin name.
+  return namespace.replace(/-/g, ' ');
 }
 
 export const ANNOTATION_PLUGIN_NAME = 'Construct Annotations';

--- a/packages/aws-cdk-lib/core/lib/validation/private/validation-id.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/private/validation-id.ts
@@ -1,0 +1,102 @@
+import { UnscopedValidationError } from '../../errors';
+import { lit } from '../../private/literal-string';
+import { type Branded } from '../../private/type-brand';
+
+export interface ValidationId {
+  readonly namespace?: string;
+  readonly ruleId: string;
+}
+
+/**
+ * Parse a validation ID into a namespace and rule name.
+ *
+ * `::` is used to separate the namespace from the rule name. If no namespace is provided, the `annotation` namespace is assumed.
+ *
+ * The rule name may not contain `::`, except between brackets.
+ *
+ * Right now, this parses and validates balanced brackets, because we assume the
+ * people who invent identifiers are not maniacs.  If it turns out this causes
+ * too many problems, we can remove matching bracket validation and just check
+ * for whether any brackets are open, not necessarily whether they match.
+ */
+export function parseValidationId(id: string): ValidationId {
+  let nsSeparator: undefined | number = undefined;
+
+  // Parser loop
+  const braceStack: string[] = [];
+  for (let i = 0; i < id.length; i++) {
+    const c = id[i];
+    if (c === ':' && id[i + 1] === ':' && braceStack.length === 0) {
+      // Found a namespace separator
+      if (nsSeparator !== undefined) {
+        throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. The '::' delimiter is reserved for separating the prefix from the rule name (e.g. 'prefix::RuleName').`);
+      }
+
+      nsSeparator = i;
+      i += 1;
+    } else if ([']', ')', '}'].includes(c)) {
+      // Found a closing brace, pop the stack
+      const lastBrace = braceStack.pop();
+      if (lastBrace === undefined) {
+        throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. Unmatched closing brace '${c}' at position ${i}.`);
+      }
+      if ((lastBrace === '(' && c !== ')') || (lastBrace === '[' && c !== ']') || (lastBrace === '{' && c !== '}')) {
+        throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. Mismatched closing brace '${c}' at position ${i}. Expected '${lastBrace === '(' ? ')' : lastBrace === '[' ? ']' : '}'}'.`);
+      }
+    } else if (['[', '(', '{'].includes(c)) {
+      // Found an opening brace, push it onto the stack
+      braceStack.push(c);
+    }
+  }
+
+  // Handle result
+  if (nsSeparator === undefined) {
+    return { ruleId: id };
+  }
+
+  if (nsSeparator === 0) {
+    throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. Missing plugin name before '::'.`);
+  }
+
+  const namespace = id.substring(0, nsSeparator);
+  const ruleId = id.substring(nsSeparator + 2);
+
+  return { namespace, ruleId };
+}
+
+/**
+ * Normalize the given validation ID to a fully qualified ID, using the `annotation` namespace if no namespace is provided.
+ */
+export function normalizeValidationId(id: string, defaultNamespace: ValidationNs): string {
+  const parsed = parseValidationId(id);
+
+  // Allow aliases for this namespace, but normalize it to the actual namespace we settled on.
+  if (parsed.namespace && ['annotation', 'Construct-Annotations'].includes(parsed.namespace)) {
+    return `${ANNOTATION_PLUGIN_NAMESPACE}::${parsed.ruleId}`;
+  }
+
+  return `${parsed.namespace ?? defaultNamespace}::${parsed.ruleId}`;
+}
+
+/**
+ * Normalize the given validation ID to a fully qualified ID, using the `Annotation` namespace if no namespace is provided.
+ */
+export function normalizeValidationIdForAnnotations(id: string): string {
+  return normalizeValidationId(id, ANNOTATION_PLUGIN_NAMESPACE);
+}
+
+export type ValidationNs = Branded<string, 'ValidationNs'>;
+
+/**
+ * Convert a plugin name to a namespace for validation IDs.
+ */
+export function namespaceFromPluginName(pluginName: string): ValidationNs {
+  if (pluginName === ANNOTATION_PLUGIN_NAME) {
+    return ANNOTATION_PLUGIN_NAMESPACE as ValidationNs;
+  }
+
+  return pluginName.replace(/ /g, '-') as ValidationNs;
+}
+
+export const ANNOTATION_PLUGIN_NAME = 'Construct Annotations';
+const ANNOTATION_PLUGIN_NAMESPACE = namespaceFromPluginName('Annotation');

--- a/packages/aws-cdk-lib/core/lib/validation/validations.ts
+++ b/packages/aws-cdk-lib/core/lib/validation/validations.ts
@@ -2,10 +2,10 @@ import type { IConstruct } from 'constructs';
 import type { IPolicyValidationPlugin } from './validation';
 import { Annotations } from '../annotations';
 import { UnscopedValidationError } from '../errors';
-import { AnnotationPlugin } from '../private/annotation-plugin';
 import { STAGE_TYPE, stageOf } from '../private/core-construct-finders';
 import { lit } from '../private/literal-string';
 import { enhancedStackTrace } from '../private/stack-trace';
+import { normalizeValidationIdForAnnotations } from './private/validation-id';
 
 /**
  * An acknowledgment of a validation rule, used to suppress it from output.
@@ -81,7 +81,8 @@ export class Validations {
    * @param message the warning message
    */
   public addWarning(id: string, message: string): void {
-    Annotations.of(this.scope).addWarningV2(this.qualifyId(id), message);
+    id = normalizeValidationIdForAnnotations(id);
+    Annotations.of(this.scope).addWarningV2(id, message);
   }
 
   /**
@@ -97,7 +98,8 @@ export class Validations {
    * @param message the error message
    */
   public addError(id: string, message: string): void {
-    Annotations.of(this.scope).addError(`${message} (${this.qualifyId(id)})`);
+    id = normalizeValidationIdForAnnotations(id);
+    Annotations.of(this.scope).addError(`${message} (${id})`);
   }
 
   /**
@@ -116,7 +118,7 @@ export class Validations {
    */
   public acknowledge(...rules: Acknowledgment[]): void {
     for (const rule of rules) {
-      const qualifiedId = this.qualifyId(rule.id);
+      const qualifiedId = normalizeValidationIdForAnnotations(rule.id);
       this.recordAcknowledgment(qualifiedId, rule.reason);
 
       // For now, all rules route to annotation acknowledgment.
@@ -132,23 +134,5 @@ export class Validations {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       { stackTraceOverride: enhancedStackTrace(this.recordAcknowledgment) },
     );
-  }
-
-  private qualifyId(id: string): string {
-    const parts = id.split('::');
-    if (parts.length > 2 || (parts.length === 2 && parts[0].length === 0)) {
-      throw new UnscopedValidationError(lit`InvalidValidationId`, `Invalid validation rule ID '${id}'. The '::' delimiter is reserved for separating the prefix from the rule name (e.g. 'prefix::RuleName').`);
-    }
-
-    if (parts.length === 1) {
-      return `${AnnotationPlugin.RULE_PREFIX}::${id}`;
-    }
-
-    if (parts[0] === 'annotation') {
-      // Uppercase this
-      return `${AnnotationPlugin.RULE_PREFIX}::${parts[1]}`;
-    }
-
-    return id;
   }
 }

--- a/packages/aws-cdk-lib/core/test/validation/validation-id.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation-id.test.ts
@@ -1,0 +1,21 @@
+import { parseValidationId } from '../../lib/validation/private/validation-id';
+
+test('missing namespace is fine', () => {
+  expect(parseValidationId('foo')).toEqual({ ruleId: 'foo' });
+});
+
+test('present namespace is fine', () => {
+  expect(parseValidationId('ns::foo')).toEqual({ namespace: 'ns', ruleId: 'foo' });
+});
+
+test('missing namespace and :: between brackets is fine', () => {
+  expect(parseValidationId('foo[bar::baz]')).toEqual({ ruleId: 'foo[bar::baz]' });
+});
+
+test('present namespace and :: between brackets is fine', () => {
+  expect(parseValidationId('ns::foo[bar::baz]')).toEqual({ namespace: 'ns', ruleId: 'foo[bar::baz]' });
+});
+
+test('multiple top-level namespaces throws', () => {
+  expect(() => parseValidationId('ns::foo[bar::baz]::oy')).toThrow(/Invalid validation rule ID/);
+});

--- a/packages/aws-cdk-lib/core/test/validation/validation.test.ts
+++ b/packages/aws-cdk-lib/core/test/validation/validation.test.ts
@@ -966,10 +966,11 @@ describe('validations', () => {
 
     // We make suppressible using both the old and new prefixes, to ensure that both are supported
     test.each([
+      '',
       'Construct-Annotations::',
       'Annotation::',
       'annotation::',
-    ])('Annotations.addWarningV2 can be acknowledged via Validations using: %p', (prefix) => {
+    ])('Annotations.addWarningV2 can be acknowledged via Validations with prefix: %p', (prefix) => {
       const app = new NonStrictApp({ context: annotationReportContext });
       const stack = new core.Stack(app, 'MyStack');
       const construct = new Construct(stack, 'MyConstruct');
@@ -1158,6 +1159,39 @@ describe('validations', () => {
 
       const output = mockErrorOutput();
       expect(output).not.toContain('S3_BUCKET_VERSIONING_ENABLED');
+    });
+
+    test('cdk-nag warning identifiers can be acknowledged via Validations.acknowledge', () => {
+      // cdk-nag's warnings contain `::`, which Validations uses as a namespace separator.
+      const warningId = 'AwsSolutions-IAM4[Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]';
+
+      const app = new NonStrictApp({ context: annotationReportContext });
+      const stack = new core.Stack(app);
+      new core.CfnResource(stack, 'MyBucket', {
+        type: 'AWS::S3::Bucket',
+        properties: {},
+      });
+
+      core.Validations.of(app).addPlugins(
+        new FakePlugin('AwsSolutions', [{
+          description: 'Something wrong with this resource',
+          ruleName: warningId,
+          severity: 'error',
+          violatingResources: [{
+            locations: [],
+            resourceLogicalId: 'MyBucket',
+            templatePath: 'Default.template.json',
+          }],
+        }]),
+      );
+
+      // Suppress the error-level violation using <pluginName>::<ruleId>
+      core.Validations.of(stack).acknowledge({ id: `AwsSolutions::${warningId}`, reason: 'Not needed for this bucket' });
+
+      redactAsmDir(app.synth());
+
+      const output = mockErrorOutput();
+      expect(output).not.toContain(warningId);
     });
 
     test('suppressed violations appear in validation-report.json', () => {


### PR DESCRIPTION
The warning identifiers of `cdk-nag` v3 oftentimes contain `::`, which the new validations API uses as a namespace separator.

Format of a `Validations.of().acknowledge()` identifier:

```
<namespace>::<id>

// e.g.

Annotations::some-identifier
CloudFormation-Validate::E5120
```

However the identifiers of `cdk-nag` contain ARNs, which themselves contain `::` like this:

```
AwsSolutions::AwsSolutions-IAM4[Policy::arn:AWS::Partition:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
```

Because of the occurrence of multiple instances of `::`, the above identifier is rejected by the `.acknowledge()` call.

This PR loosens the parser to take advantage of the particular format of `cdk-nag` identifiers to introduce identifier parsing and scoping rules: any bracket (`<`, `(`, `[`) introduces a new scope. Inside scopes, `::` is allowed and will not be considered a namespace separator. Outside scopes, the same rules still hold.

Normalize all the places where we make assumptions on the formats of validation identifiers to use the same code paths.

Closes https://github.com/cdklabs/cdk-nag/issues/2351, closes https://github.com/cdklabs/cdk-nag/issues/2359

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
