### PR TITLE
fix(eks): reuse existing eks-pod-identity-agent addon for pod identity

### DIFF
--- a/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts
@@ -9,7 +9,7 @@ import type { IAddon } from './addon';
 import { Addon } from './addon';
 import type { AlbControllerOptions } from './alb-controller';
 import { AlbController } from './alb-controller';
-import { CfnCluster } from './eks.generated';
+import { CfnAddon, CfnCluster } from './eks.generated';
 import type { FargateProfileOptions } from './fargate-profile';
 import { FargateProfile } from './fargate-profile';
 import type { HelmChartOptions } from './helm-chart';
@@ -42,6 +42,8 @@ import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import { EKS_USE_NATIVE_OIDC_PROVIDER } from '../../cx-api';
 import type { ClusterReference, IClusterRef } from '../../interfaces/generated/aws-eks-interfaces.generated';
+
+const EKS_POD_IDENTITY_AGENT_ADDON_NAME = 'eks-pod-identity-agent';
 
 // defaults are based on https://eksctl.io
 const DEFAULT_CAPACITY_COUNT = 2;
@@ -1819,14 +1821,37 @@ export class Cluster extends ClusterBase {
    */
   public get eksPodIdentityAgent(): IAddon | undefined {
     if (!this._eksPodIdentityAgent) {
-      this._eksPodIdentityAgent = new Addon(this, 'EksPodIdentityAgentAddon', {
+      this._eksPodIdentityAgent = this.findEksPodIdentityAgent() ?? new Addon(this, 'EksPodIdentityAgentAddon', {
         cluster: this,
-        addonName: 'eks-pod-identity-agent',
+        addonName: EKS_POD_IDENTITY_AGENT_ADDON_NAME,
         removalPolicy: this._removalPolicy,
       });
     }
 
     return this._eksPodIdentityAgent;
+  }
+
+  /**
+   * Finds an `eks-pod-identity-agent` add-on that was already declared for this cluster,
+   * either through the `Addon` construct or directly as a `CfnAddon`, so that a second
+   * (conflicting) add-on is not created on the user's behalf.
+   */
+  private findEksPodIdentityAgent(): IAddon | undefined {
+    for (const construct of this.node.root.node.findAll()) {
+      if (!(construct instanceof CfnAddon)
+        || construct.addonName !== EKS_POD_IDENTITY_AGENT_ADDON_NAME
+        || construct.clusterName !== this.clusterName) {
+        continue;
+      }
+      if (construct.node.scope instanceof Addon) {
+        return construct.node.scope;
+      }
+      return Addon.fromAddonAttributes(this, 'EksPodIdentityAgentAddon', {
+        addonName: EKS_POD_IDENTITY_AGENT_ADDON_NAME,
+        clusterName: this.clusterName,
+      });
+    }
+    return undefined;
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-eks-v2/test/service-account.test.ts
+++ b/packages/aws-cdk-lib/aws-eks-v2/test/service-account.test.ts
@@ -1,3 +1,4 @@
+import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
 import { testFixture, testFixtureCluster } from './util';
 import { Template } from '../../assertions';
 import * as iam from '../../aws-iam';
@@ -379,6 +380,83 @@ describe('service account', () => {
       });
       // should not create OpenIdConnectProvider
       t.resourceCountIs('Custom::AWSCDKOpenIdConnectProvider', 0);
+    });
+    test('reuses an eks-pod-identity-agent Addon already declared for the cluster', () => {
+      // GIVEN
+      const { stack, cluster } = testFixtureCluster();
+      const addon = new eks.Addon(stack, 'PodIdentityAgent', {
+        cluster,
+        addonName: 'eks-pod-identity-agent',
+        addonVersion: 'v1.3.4-eksbuild.1',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+      const t = Template.fromStack(stack);
+
+      // THEN
+      expect(cluster.eksPodIdentityAgent).toBe(addon);
+      t.resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
+      t.hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        AddonVersion: 'v1.3.4-eksbuild.1',
+        ClusterName: { Ref: 'ClusterEB0386A7' },
+      });
+      t.resourceCountIs('AWS::EKS::PodIdentityAssociation', 1);
+    });
+    test('reuses an eks-pod-identity-agent CfnAddon already declared for the cluster', () => {
+      // GIVEN
+      const { stack, cluster } = testFixtureCluster();
+      new eks.CfnAddon(stack, 'PodIdentityAgent', {
+        clusterName: cluster.clusterName,
+        addonName: 'eks-pod-identity-agent',
+        addonVersion: 'v1.3.4-eksbuild.1',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+      const t = Template.fromStack(stack);
+
+      // THEN
+      expect(cluster.eksPodIdentityAgent?.addonName).toBe('eks-pod-identity-agent');
+      t.resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
+      t.hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        AddonVersion: 'v1.3.4-eksbuild.1',
+        ClusterName: { Ref: 'ClusterEB0386A7' },
+      });
+    });
+    test('does not reuse an eks-pod-identity-agent Addon that belongs to another cluster', () => {
+      // GIVEN
+      const { stack, app, cluster } = testFixtureCluster();
+      const otherStack = new cdk.Stack(app, 'OtherStack');
+      const otherCluster = new eks.Cluster(otherStack, 'OtherCluster', {
+        version: eks.KubernetesVersion.V1_25,
+        kubectlProviderOptions: { kubectlLayer: new KubectlV31Layer(otherStack, 'kubectlLayer') },
+      });
+      new eks.Addon(otherStack, 'PodIdentityAgent', {
+        cluster: otherCluster,
+        addonName: 'eks-pod-identity-agent',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        ClusterName: { Ref: 'ClusterEB0386A7' },
+      });
+      Template.fromStack(otherStack).resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
     });
   });
   describe('Service Account with eks.IdentityType.IRSA', () => {

--- a/packages/aws-cdk-lib/aws-eks/README.md
+++ b/packages/aws-cdk-lib/aws-eks/README.md
@@ -1698,6 +1698,25 @@ This simplifies the process of configuring IAM permissions for your Kubernetes a
 the installation of the Pod Identity Agent add-on, and the association between the role and the service account, making it easier to manage AWS credentials
 for your applications.
 
+If you need control over the add-on, for example to pin its version, declare the `eks-pod-identity-agent` add-on yourself
+before creating the service account. `ServiceAccount` detects an `Addon` (or `CfnAddon`) with that name that targets the
+same cluster and reuses it instead of installing a second one:
+
+```ts
+declare const cluster: eks.Cluster;
+
+new eks.Addon(this, 'PodIdentityAgent', {
+  cluster,
+  addonName: 'eks-pod-identity-agent',
+  addonVersion: 'v1.3.4-eksbuild.1',
+});
+
+new eks.ServiceAccount(this, 'ServiceAccount', {
+  cluster,
+  identityType: eks.IdentityType.POD_IDENTITY,
+});
+```
+
 ## Applying Kubernetes Resources
 
 The library supports several popular resource deployment mechanisms, among which are:

--- a/packages/aws-cdk-lib/aws-eks/lib/cluster.ts
+++ b/packages/aws-cdk-lib/aws-eks/lib/cluster.ts
@@ -12,6 +12,7 @@ import { AlbController } from './alb-controller';
 import { AwsAuth } from './aws-auth';
 import { ClusterResource, clusterArnComponents } from './cluster-resource';
 import type { ClusterReference, IClusterRef } from './eks.generated';
+import { CfnAddon } from './eks.generated';
 import type { FargateProfileOptions } from './fargate-profile';
 import { FargateProfile } from './fargate-profile';
 import type { HelmChartOptions } from './helm-chart';
@@ -43,6 +44,8 @@ import { addConstructMetadata, MethodMetadata } from '../../core/lib/metadata-re
 import { lit } from '../../core/lib/private/literal-string';
 import { propertyInjectable } from '../../core/lib/prop-injectable';
 import { EKS_USE_NATIVE_OIDC_PROVIDER } from '../../cx-api';
+
+const EKS_POD_IDENTITY_AGENT_ADDON_NAME = 'eks-pod-identity-agent';
 
 // defaults are based on https://eksctl.io
 const DEFAULT_CAPACITY_COUNT = 2;
@@ -2284,14 +2287,37 @@ export class Cluster extends ClusterBase {
    */
   public get eksPodIdentityAgent(): IAddon | undefined {
     if (!this._eksPodIdentityAgent) {
-      this._eksPodIdentityAgent = new Addon(this, 'EksPodIdentityAgentAddon', {
+      this._eksPodIdentityAgent = this.findEksPodIdentityAgent() ?? new Addon(this, 'EksPodIdentityAgentAddon', {
         cluster: this,
-        addonName: 'eks-pod-identity-agent',
+        addonName: EKS_POD_IDENTITY_AGENT_ADDON_NAME,
         removalPolicy: this._removalPolicy,
       });
     }
 
     return this._eksPodIdentityAgent;
+  }
+
+  /**
+   * Finds an `eks-pod-identity-agent` add-on that was already declared for this cluster,
+   * either through the `Addon` construct or directly as a `CfnAddon`, so that a second
+   * (conflicting) add-on is not created on the user's behalf.
+   */
+  private findEksPodIdentityAgent(): IAddon | undefined {
+    for (const construct of this.node.root.node.findAll()) {
+      if (!(construct instanceof CfnAddon)
+        || construct.addonName !== EKS_POD_IDENTITY_AGENT_ADDON_NAME
+        || construct.clusterName !== this.clusterName) {
+        continue;
+      }
+      if (construct.node.scope instanceof Addon) {
+        return construct.node.scope;
+      }
+      return Addon.fromAddonAttributes(this, 'EksPodIdentityAgentAddon', {
+        addonName: EKS_POD_IDENTITY_AGENT_ADDON_NAME,
+        clusterName: this.clusterName,
+      });
+    }
+    return undefined;
   }
 
   /**

--- a/packages/aws-cdk-lib/aws-eks/test/service-account.test.ts
+++ b/packages/aws-cdk-lib/aws-eks/test/service-account.test.ts
@@ -284,6 +284,98 @@ describe('service account', () => {
         'Pod Identity is not supported in Fargate. Use IRSA identity type instead.',
       );
     });
+    test('reuses an eks-pod-identity-agent Addon already declared for the cluster', () => {
+      // GIVEN
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const cluster = new Cluster(stack, 'Cluster', {
+        version: KubernetesVersion.V1_30,
+        kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+      });
+      const addon = new eks.Addon(stack, 'PodIdentityAgent', {
+        cluster,
+        addonName: 'eks-pod-identity-agent',
+        addonVersion: 'v1.3.4-eksbuild.1',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+      const t = Template.fromStack(stack);
+
+      // THEN
+      expect(cluster.eksPodIdentityAgent).toBe(addon);
+      t.resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
+      t.hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        AddonVersion: 'v1.3.4-eksbuild.1',
+        ClusterName: { Ref: 'Cluster9EE0221C' },
+      });
+      t.resourceCountIs('AWS::EKS::PodIdentityAssociation', 1);
+    });
+    test('reuses an eks-pod-identity-agent CfnAddon already declared for the cluster', () => {
+      // GIVEN
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const cluster = new Cluster(stack, 'Cluster', {
+        version: KubernetesVersion.V1_30,
+        kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+      });
+      new eks.CfnAddon(stack, 'PodIdentityAgent', {
+        clusterName: cluster.clusterName,
+        addonName: 'eks-pod-identity-agent',
+        addonVersion: 'v1.3.4-eksbuild.1',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+      const t = Template.fromStack(stack);
+
+      // THEN
+      expect(cluster.eksPodIdentityAgent?.addonName).toBe('eks-pod-identity-agent');
+      t.resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
+      t.hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        AddonVersion: 'v1.3.4-eksbuild.1',
+        ClusterName: { Ref: 'Cluster9EE0221C' },
+      });
+    });
+    test('does not reuse an eks-pod-identity-agent Addon that belongs to another cluster', () => {
+      // GIVEN
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const cluster = new Cluster(stack, 'Cluster', {
+        version: KubernetesVersion.V1_30,
+        kubectlLayer: new KubectlV31Layer(stack, 'KubectlLayer'),
+      });
+      const otherStack = new Stack(app, 'OtherStack');
+      const otherCluster = new Cluster(otherStack, 'OtherCluster', {
+        version: KubernetesVersion.V1_30,
+        kubectlLayer: new KubectlV31Layer(otherStack, 'KubectlLayer'),
+      });
+      new eks.Addon(otherStack, 'PodIdentityAgent', {
+        cluster: otherCluster,
+        addonName: 'eks-pod-identity-agent',
+      });
+
+      // WHEN
+      new eks.ServiceAccount(stack, 'MyServiceAccount', {
+        cluster,
+        identityType: eks.IdentityType.POD_IDENTITY,
+      });
+
+      // THEN
+      Template.fromStack(stack).hasResourceProperties('AWS::EKS::Addon', {
+        AddonName: 'eks-pod-identity-agent',
+        ClusterName: { Ref: 'Cluster9EE0221C' },
+      });
+      Template.fromStack(otherStack).resourcePropertiesCountIs('AWS::EKS::Addon', { AddonName: 'eks-pod-identity-agent' }, 1);
+    });
   });
   describe('Service Account with eks.IdentityType.IRSA', () => {
     test('default', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #32580.

### Reason for this change

#### Problem

Declaring the `eks-pod-identity-agent` add-on yourself (for example to pin `addonVersion`) and then creating a `ServiceAccount` with `identityType: IdentityType.POD_IDENTITY` on the same cluster produces two `AWS::EKS::Addon` resources with the same `ClusterName`/`AddonName`. The deployment then fails because the add-on already exists on the cluster. Users currently cannot both pin the agent version and use `POD_IDENTITY` service accounts.

#### Root cause

`Cluster.eksPodIdentityAgent` unconditionally instantiates its own `Addon`:

- `packages/aws-cdk-lib/aws-eks/lib/cluster.ts:2285-2296` (`get eksPodIdentityAgent()`), reached from `packages/aws-cdk-lib/aws-eks/lib/service-account.ts:201`
- `packages/aws-cdk-lib/aws-eks-v2/lib/cluster.ts:1820-1830`, reached from `packages/aws-cdk-lib/aws-eks-v2/lib/service-account.ts:200`

Nothing checks whether an add-on with that name already targets the cluster.

### Description of changes

#### Fix

Before creating `EksPodIdentityAgentAddon`, the getter now scans the construct tree for a `CfnAddon` whose `addonName` is `eks-pod-identity-agent` and whose `clusterName` is this cluster's `clusterName` (the getter is memoized, so the token compares equal for the same cluster and differs for any other cluster).

- If the `CfnAddon` is the `Resource` child of an `Addon`, that `Addon` is returned as `eksPodIdentityAgent`.
- If the user declared a raw `CfnAddon`, it is wrapped with `Addon.fromAddonAttributes` so the getter still returns an `IAddon`.
- Otherwise the behaviour is unchanged and the add-on is created as before.

The same change is applied to `aws-eks` and `aws-eks-v2`. The `aws-eks` README gains a short note showing how to pin the agent version by declaring the add-on before the service account.

This is the approach previously reviewed in #33891 (closed as stale before its snapshot build was fixed); this version reduces it to a single scan over `CfnAddon` and adds no new error paths.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

#### How tested

Unit tests added in `aws-eks/test/service-account.test.ts` and `aws-eks-v2/test/service-account.test.ts` (POD_IDENTITY describe block):

1. user-declared `Addon` + `POD_IDENTITY` `ServiceAccount` -> exactly one `AWS::EKS::Addon` named `eks-pod-identity-agent`, `cluster.eksPodIdentityAgent` is the user's `Addon`, `AddonVersion` preserved
2. same with a raw `CfnAddon`
3. an `eks-pod-identity-agent` add-on for a different cluster is not reused (cluster still gets its own add-on)

The existing `default` test keeps covering the case where nothing is pre-declared and the add-on is created.

Before the fix, tests 1 and 2 fail in both modules (the repo's strict CloudFormation validation flags the duplicate):

```
● service account › Service Account with eks.IdentityType.POD_IDENTITY › reuses an eks-pod-identity-agent Addon already declared for the cluster

  «ValidationFailed» [Warning] Template validation found issues in your templates. Construct library strict mode considers these errors.

  WARNING Properties: Primary identifiers {'ClusterName': 'Ref("Cluster9EE0221C")', 'AddonName': 'eks-pod-identity-agent'} should have unique values across the resources {'ClusterEksPodIdentityAgentAddonEF717E32', 'PodIdentityAgentD8D3AD08'} (CloudFormation Validate)
     Stack/Cluster/EksPodIdentityAgentAddon/Resource (ClusterEksPodIdentityAgentAddonEF717E32) constructs.Construct
     Acknowledge with 'CloudFormation-Validate::E3019'

Tests:       6 failed, 34 passed, 40 total
```

After the fix:

```
PASS aws-eks-v2/test/service-account.test.ts
PASS aws-eks/test/service-account.test.ts

Tests:       40 passed, 40 total
```

`aws-eks/test/cluster.test.ts`, `aws-eks-v2/test/cluster.test.ts` and both `addon.test.ts` suites also pass; `eslint` is clean on the changed files.

No integration test is added: the change is entirely synth-time (which construct is instantiated) and is fully observable in the synthesized template, so the unit tests above cover it. Happy to add one if maintainers prefer.

#### Links

- Issue: https://github.com/aws/aws-cdk/issues/32580
- Earlier attempt: https://github.com/aws/aws-cdk/pull/33891

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
