### PR TITLE
fix(apigateway): log group destination ARN causes permanent Stage drift

### DIFF
--- a/packages/aws-cdk-lib/aws-apigateway/lib/access-log.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/lib/access-log.ts
@@ -1,7 +1,9 @@
 import type { IStageRef } from './apigateway.generated';
 import type * as firehose from '../../aws-kinesisfirehose';
+import { ArnFormat, FeatureFlags, Stack } from '../../core';
 import { ValidationError } from '../../core/lib/errors';
 import { lit } from '../../core/lib/private/literal-string';
+import { APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD } from '../../cx-api';
 import type { ILogGroupRef } from '../../interfaces/generated/aws-logs-interfaces.generated';
 
 /**
@@ -35,6 +37,16 @@ export class LogGroupLogDestination implements IAccessLogDestination {
    * Binds this destination to the CloudWatch Logs.
    */
   public bind(_stage: IStageRef): AccessLogDestinationConfig {
+    if (FeatureFlags.of(this.logGroup).isEnabled(APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD)) {
+      return {
+        destinationArn: Stack.of(this.logGroup).formatArn({
+          service: 'logs',
+          resource: 'log-group',
+          resourceName: this.logGroup.logGroupRef.logGroupName,
+          arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+        }),
+      };
+    }
     return {
       destinationArn: this.logGroup.logGroupRef.logGroupArn,
     };

--- a/packages/aws-cdk-lib/aws-apigateway/test/stage.test.ts
+++ b/packages/aws-cdk-lib/aws-apigateway/test/stage.test.ts
@@ -2,6 +2,7 @@ import { Template } from '../../assertions';
 import * as firehose from '../../aws-kinesisfirehose';
 import * as logs from '../../aws-logs';
 import * as cdk from '../../core';
+import * as cxapi from '../../cx-api';
 import * as apigateway from '../lib';
 import { ApiDefinition } from '../lib';
 
@@ -331,6 +332,68 @@ describe('stage', () => {
         Format: '$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId',
       },
       StageName: 'prod',
+    });
+  });
+
+  test('the log group destination ARN omits the trailing wildcard when the feature flag is enabled', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    stack.node.setContext(cxapi.APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD, true);
+    const api = new apigateway.RestApi(stack, 'test-api', { cloudWatchRole: false, deploy: false });
+    const deployment = new apigateway.Deployment(stack, 'my-deployment', { api });
+    api.root.addMethod('GET');
+
+    // WHEN
+    const testLogGroup = new logs.LogGroup(stack, 'LogGroup');
+    new apigateway.Stage(stack, 'my-stage', {
+      deployment,
+      accessLogDestination: new apigateway.LogGroupLogDestination(testLogGroup),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      AccessLogSetting: {
+        DestinationArn: {
+          'Fn::Join': ['', [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':logs:',
+            { Ref: 'AWS::Region' },
+            ':',
+            { Ref: 'AWS::AccountId' },
+            ':log-group:',
+            { Ref: 'LogGroupF5B46931' },
+          ]],
+        },
+      },
+    });
+  });
+
+  test('the log group destination ARN keeps the trailing wildcard when the feature flag is disabled', () => {
+    // GIVEN
+    const stack = new cdk.Stack();
+    stack.node.setContext(cxapi.APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD, false);
+    const api = new apigateway.RestApi(stack, 'test-api', { cloudWatchRole: false, deploy: false });
+    const deployment = new apigateway.Deployment(stack, 'my-deployment', { api });
+    api.root.addMethod('GET');
+
+    // WHEN
+    const testLogGroup = new logs.LogGroup(stack, 'LogGroup');
+    new apigateway.Stage(stack, 'my-stage', {
+      deployment,
+      accessLogDestination: new apigateway.LogGroupLogDestination(testLogGroup),
+    });
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      AccessLogSetting: {
+        DestinationArn: {
+          'Fn::GetAtt': [
+            'LogGroupF5B46931',
+            'Arn',
+          ],
+        },
+      },
     });
   });
 

--- a/packages/aws-cdk-lib/cx-api/lib/features.ts
+++ b/packages/aws-cdk-lib/cx-api/lib/features.ts
@@ -93,6 +93,7 @@ export const REDSHIFT_COLUMN_ID = '@aws-cdk/aws-redshift:columnId';
 export const ENABLE_EMR_SERVICE_POLICY_V2 = '@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2';
 export const EC2_RESTRICT_DEFAULT_SECURITY_GROUP = '@aws-cdk/aws-ec2:restrictDefaultSecurityGroup';
 export const APIGATEWAY_REQUEST_VALIDATOR_UNIQUE_ID = '@aws-cdk/aws-apigateway:requestValidatorUniqueId';
+export const APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD = '@aws-cdk/aws-apigateway:logGroupDestinationArnWithoutWildcard';
 export const INCLUDE_PREFIX_IN_UNIQUE_NAME_GENERATION = '@aws-cdk/core:includePrefixInUniqueNameGeneration';
 export const KMS_ALIAS_NAME_REF = '@aws-cdk/aws-kms:aliasNameRef';
 export const KMS_APPLY_IMPORTED_ALIAS_PERMISSIONS_TO_PRINCIPAL = '@aws-cdk/aws-kms:applyImportedAliasPermissionsToPrincipal';
@@ -1954,6 +1955,28 @@ export const FLAGS: Record<string, FlagInfo> = {
     recommendedValue: true,
     unconfiguredBehavesLike: { v2: false },
     compatibilityWithOldBehaviorMd: 'Set this flag to `false` to keep omitting the property, and remove the registrations with `aws ecs update-service --load-balancers \'[]\'` instead.',
+  },
+
+  //////////////////////////////////////////////////////////////////////
+  [APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD]: {
+    type: FlagType.BugFix,
+    summary: 'Render the API Gateway access log destination ARN without the trailing `:*`',
+    detailsMd: `
+      API Gateway stores the access log destination ARN without the trailing \`:*\` that
+      \`LogGroup.logGroupArn\` carries. When the CDK renders the log group \`Arn\` attribute,
+      CloudFormation drift detection reports the stage as \`MODIFIED\` on every run, even
+      though the access logging configuration has not changed.
+
+      When this flag is enabled, \`LogGroupLogDestination\` rebuilds the ARN from the log
+      group name, so the synthesized template matches the value stored by the service and
+      drift detection reports the stage as \`IN_SYNC\`.
+
+      When disabled, the destination ARN keeps using the log group \`Arn\` attribute.
+    `,
+    introducedIn: { v2: 'V2NEXT' },
+    recommendedValue: true,
+    unconfiguredBehavesLike: { v2: false },
+    compatibilityWithOldBehaviorMd: 'Disable this flag to keep using the log group `Arn` attribute as the destination ARN.',
   },
 };
 

--- a/packages/aws-cdk-lib/cx-api/test/features.test.ts
+++ b/packages/aws-cdk-lib/cx-api/test/features.test.ts
@@ -53,6 +53,7 @@ test('feature flag defaults may not be changed anymore', () => {
     [feats.ANNOTATIONS_IN_VALIDATION_REPORT]: false,
     [feats.VALIDATE_AGAINST_DEFAULT_RULES]: false,
     [feats.ECS_REMOVE_EMPTY_LOAD_BALANCERS]: false,
+    [feats.APIGATEWAY_LOG_GROUP_DESTINATION_ARN_WITHOUT_WILDCARD]: false,
 
   });
 });


### PR DESCRIPTION
### Issue #

Closes #38796.

### Reason for this change

`LogGroupLogDestination` sets the REST API Stage `AccessLogSetting.DestinationArn`
to the log group `Arn` attribute, which resolves with a trailing `:*`:

    arn:aws:logs:eu-central-1:111122223333:log-group:/aws/apigateway/demo/accessLogs:*

API Gateway stores the ARN without the `:*`. CloudFormation drift detection then
reports the Stage as `MODIFIED` on every run, even when nothing changed. Teams
that gate deploys or audits on a clean drift status get a permanent false
positive.

### Description of changes

`LogGroupLogDestination` now rebuilds the destination ARN from the log group
name with `Stack.formatArn(..., ArnFormat.COLON_RESOURCE_NAME)`, which produces
the value API Gateway stores. `LogGroup.logGroupArn` keeps its trailing `:*`
because IAM policies rely on it.

The synthesized template changes for existing users, so the new behavior sits
behind the `@aws-cdk/aws-apigateway:logGroupDestinationArnWithoutWildcard`
feature flag (`BugFix`, recommended value `true`, unconfigured keeps the old
behavior). Unconfigured apps keep `Fn::GetAtt [LogGroup, Arn]`, so there is no
breaking change. I added the flag default to the frozen list in
`cx-api/test/features.test.ts` as required.

Alternative considered: a `propertyTransform` for
`AWS::ApiGateway::Stage.AccessLogSetting.DestinationArn`. It would fix existing
stacks without a template change, but it is an AWS owned resource schema change
and cannot land in this repository. The two approaches are complementary.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

New unit tests in `aws-apigateway/test/stage.test.ts` cover the flag enabled and
disabled cases. Both affected suites pass:

    cd packages/aws-cdk-lib
    npx jest aws-apigateway/test/stage.test.ts aws-apigateway/test/access-log.test.ts
    40 passed

    npx jest cx-api/test/features.test.ts
    123 passed

Integration tests were not run locally. The flag is off by default, so existing
integration snapshots do not change.

The same pattern exists in `aws-apigatewayv2` and can be handled in a separate
change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
